### PR TITLE
Fixed invalid argument validation in LZ4Codec

### DIFF
--- a/src/MessagePack/LZ4/Codec/LZ4Codec.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.cs
@@ -143,12 +143,12 @@ namespace MessagePack.LZ4
             }
 
             if (input == null) throw new ArgumentNullException("input");
-            if (inputOffset < 0 || inputOffset + inputLength > input.Length)
-                throw new ArgumentException("inputOffset and inputLength are invalid for given input");
+            if ((uint)inputOffset > (uint)input.Length) throw new ArgumentOutOfRangeException("inputOffset");
+            if ((uint)inputLength > (uint)input.Length - (uint)inputOffset) throw new ArgumentOutOfRangeException("inputLength");
 
             if (output == null) throw new ArgumentNullException("output");
-            if (outputOffset < 0 || outputOffset + outputLength > output.Length)
-                throw new ArgumentException("outputOffset and outputLength are invalid for given output");
+            if ((uint)outputOffset > (uint)output.Length) throw new ArgumentOutOfRangeException("outputOffset");
+            if ((uint)outputLength > (uint)output.Length - (uint)outputOffset) throw new ArgumentOutOfRangeException("outputLength");
         }
 
         #endregion


### PR DESCRIPTION
Arguments from MessagePack.LZ4.CheckArguments(byte[], int, int, byte[], int, int) are validated incorrectly.

### Case 1:
MessagePack.LZ4.CheckArguments(new byte[0], int.MaxValue, 1, new byte[0], int.MaxValue, 1);

Expected:
throw ArgumentOutOfRangeException

Actual:
no Exception thrown, because of overflow at `inputOffset + inputLength`.

### Case 2:
MessagePack.LZ4.CheckArguments(new byte[0], 5, -5, new byte[0], 5, -5);

Expected:
throw ArgumentOutOfRangeException

Actual:
no Exception thrown, because`inputOffset + inputLength == 0`.