### PR TITLE
Protect static instance fields by making them immutable

### DIFF
--- a/src/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack/Resolvers/BuiltinResolver.cs
@@ -11,7 +11,7 @@ namespace MessagePack.Resolvers
 {
     public class BuiltinResolver : IFormatterResolver
     {
-        public static IFormatterResolver Instance = new BuiltinResolver();
+        public static readonly IFormatterResolver Instance = new BuiltinResolver();
 
         BuiltinResolver()
         {

--- a/src/MessagePack/Resolvers/CompositeResolver.cs
+++ b/src/MessagePack/Resolvers/CompositeResolver.cs
@@ -7,7 +7,7 @@ namespace MessagePack.Resolvers
 {
     public class CompositeResolver : IFormatterResolver
     {
-        public static CompositeResolver Instance = new CompositeResolver();
+        public static readonly CompositeResolver Instance = new CompositeResolver();
 
         static bool isFreezed = false;
         static IFormatterResolver[] resolvers = new IFormatterResolver[0];

--- a/src/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -11,7 +11,7 @@ namespace MessagePack.Resolvers
     /// </summary>
     public class DynamicEnumResolver : IFormatterResolver
     {
-        public static DynamicEnumResolver Instance = new DynamicEnumResolver();
+        public static readonly DynamicEnumResolver Instance = new DynamicEnumResolver();
 
         const string ModuleName = "MessagePack.Resolvers.DynamicEnumResolver";
 

--- a/src/MessagePack/Resolvers/DynamicGenericResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicGenericResolver.cs
@@ -14,7 +14,7 @@ namespace MessagePack.Resolvers
 {
     public class DynamicGenericResolver : IFormatterResolver
     {
-        public static IFormatterResolver Instance = new DynamicGenericResolver();
+        public static readonly IFormatterResolver Instance = new DynamicGenericResolver();
 
         DynamicGenericResolver()
         {

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -13,7 +13,7 @@ namespace MessagePack.Resolvers
     /// </summary>
     public class DynamicObjectResolver : IFormatterResolver
     {
-        public static DynamicObjectResolver Instance = new DynamicObjectResolver();
+        public static readonly DynamicObjectResolver Instance = new DynamicObjectResolver();
 
         const string ModuleName = "MessagePack.Resolvers.DynamicObjectResolver";
 
@@ -74,7 +74,7 @@ namespace MessagePack.Resolvers
     /// </summary>
     public class DynamicContractlessObjectResolver : IFormatterResolver
     {
-        public static DynamicContractlessObjectResolver Instance = new DynamicContractlessObjectResolver();
+        public static readonly DynamicContractlessObjectResolver Instance = new DynamicContractlessObjectResolver();
 
         const string ModuleName = "MessagePack.Resolvers.DynamicContractlessObjectResolver";
 

--- a/src/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -13,7 +13,7 @@ namespace MessagePack.Resolvers
     /// </summary>
     public class DynamicUnionResolver : IFormatterResolver
     {
-        public static DynamicUnionResolver Instance = new DynamicUnionResolver();
+        public static readonly DynamicUnionResolver Instance = new DynamicUnionResolver();
 
         const string ModuleName = "MessagePack.Resolvers.DynamicUnionResolver";
 

--- a/src/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack/Resolvers/StandardResolver.cs
@@ -7,7 +7,7 @@ namespace MessagePack.Resolvers
     /// </summary>
     public class StandardResolver : IFormatterResolver
     {
-        public static IFormatterResolver Instance = new StandardResolver();
+        public static readonly IFormatterResolver Instance = new StandardResolver();
 
         static readonly IFormatterResolver[] resolvers = new[]
         {
@@ -57,7 +57,7 @@ namespace MessagePack.Resolvers
 
     public class ContractlessStandardResolver : IFormatterResolver
     {
-        public static IFormatterResolver Instance = new ContractlessStandardResolver();
+        public static readonly IFormatterResolver Instance = new ContractlessStandardResolver();
 
         static readonly IFormatterResolver[] resolvers = new[]
         {


### PR DESCRIPTION
Static instance fields should not be modified by library users.

Another option would be to use Auto-Property initializers from C# 6, e.g.
public static IFormatterResolver Instance { get; } = new BuiltinResolver();

But I chose to go with readonly since it matches the code conventions of the project.