### PR TITLE
support to .net4.6

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Shims/Reflection.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Shims/Reflection.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 
+#if !(ENABLE_MONO_BLEEDING_EDGE_EDITOR || ENABLE_MONO_BLEEDING_EDGE_STANDALONE)
 namespace System.Reflection
 {
     public class TypeInfo
@@ -100,9 +101,12 @@ namespace System.Reflection
             }
         }
 
-        public bool IsConstructedGenericType()
+        public bool IsConstructedGenericType
         {
-            return type.IsGenericType && !type.IsGenericTypeDefinition;
+            get
+            {
+                return type.IsGenericType && !type.IsGenericTypeDefinition;
+            }
         }
 
         public Type[] ImplementedInterfaces
@@ -201,3 +205,4 @@ namespace System.Reflection
         }
     }
 }
+#endif

--- a/src/MessagePack/Resolvers/DynamicGenericResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicGenericResolver.cs
@@ -121,7 +121,7 @@ namespace MessagePack.Internal
                 {
                     return CreateInstance(typeof(KeyValuePairFormatter<,>), ti.GenericTypeArguments);
                 }
-                else if (isNullable && nullableElementType.GetTypeInfo().IsConstructedGenericType() && nullableElementType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+                else if (isNullable && nullableElementType.GetTypeInfo().IsConstructedGenericType && nullableElementType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 {
                     return CreateInstance(typeof(NullableFormatter<>), new[] { nullableElementType });
                 }
@@ -226,7 +226,7 @@ namespace MessagePack.Internal
                         return CreateInstance(typeof(ArraySegmentFormatter<>), ti.GenericTypeArguments);
                     }
                 }
-                else if (isNullable && nullableElementType.GetTypeInfo().IsConstructedGenericType() && nullableElementType.GetGenericTypeDefinition() == typeof(ArraySegment<>))
+                else if (isNullable && nullableElementType.GetTypeInfo().IsConstructedGenericType && nullableElementType.GetGenericTypeDefinition() == typeof(ArraySegment<>))
                 {
                     if (nullableElementType == typeof(ArraySegment<byte>))
                     {
@@ -249,7 +249,7 @@ namespace MessagePack.Internal
 
                     // generic collection
                     else if (ti.GenericTypeArguments.Length == 1
-                          && ti.ImplementedInterfaces.Any(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(ICollection<>))
+                          && ti.ImplementedInterfaces.Any(x => x.GetTypeInfo().IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(ICollection<>))
                           && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
                     {
                         var elemType = ti.GenericTypeArguments[0];
@@ -257,7 +257,7 @@ namespace MessagePack.Internal
                     }
                     // generic dictionary
                     else if (ti.GenericTypeArguments.Length == 2
-                          && ti.ImplementedInterfaces.Any(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                          && ti.ImplementedInterfaces.Any(x => x.GetTypeInfo().IsConstructedGenericType && x.GetGenericTypeDefinition() == typeof(IDictionary<,>))
                           && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
                     {
                         var keyType = ti.GenericTypeArguments[0];


### PR DESCRIPTION
I think that it prepares `ENABLE_MONO_BLEEDING_EDGE_EDITOR` and `ENABLE_MONO_BLEEDING_EDGE_STANDALONE` for .net4.6 the same as UniRx.
I checked by Unity2017.1.0f1.