### PR TITLE
Adding LZ4MessagePackSerializer.Deserialize<T>(ArraySegment) overloads

### DIFF
--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -132,7 +132,7 @@ namespace MessagePack
             int readSize;
             return formatter.Deserialize(bytes, 0, resolver, out readSize);
         }
-
+       
         public static T Deserialize<T>(Stream stream)
         {
             return Deserialize<T>(stream, defaultResolver);


### PR DESCRIPTION
In support of #81, this PR offers support for `ArraySegment<T>` parameters to the generic `LZ4MessagePackSerializer` `Deserialize` methods.

Somewhat selfishly, this will greatly help my project.
However to add matching support to the standard `MessagePackSerializer` is not a trivial exercise. 

If you are happy with this change, then this is a nice stop gap until `Span<T>` is available.
Assuming there is a implicit conversion* from `ArraySegment<T>` to `Span<T>` these overloads may be deprecated at that point.


*Support for implicit cast from `ArraySegment<T>` to `Span<T>` https://github.com/dotnet/coreclr/blob/bfc3141f97a9f9f0d095f3d2e99a7c02ce869ab0/src/mscorlib/shared/System/Span.cs#L356