### PR TITLE
Improve constructor choice by matching constructors one by one

### DIFF
--- a/sandbox/SharedData/Class1.cs
+++ b/sandbox/SharedData/Class1.cs
@@ -518,6 +518,24 @@ namespace SharedData
         }
     }
 
+    public class FindingConstructorCheck
+    {
+        public int MyProperty1 { get; set; }
+        public string MyProperty2 { get; set; }
+
+
+        public FindingConstructorCheck(KeyValuePair<int, string> ok)
+        {
+
+        }
+
+        public FindingConstructorCheck(int myProperty1, string myProperty2)
+        {
+            this.MyProperty1 = myProperty1;
+            this.MyProperty2 = myProperty2;
+        }
+    }
+
     [MessagePackObject]
     public class ArrayOptimizeClass
     {

--- a/src/MessagePack.CodeGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.CodeGenerator/CodeAnalysis/TypeCollector.cs
@@ -667,6 +667,7 @@ namespace MessagePack.CodeGenerator
                                 {
                                     if (ctorEnumerator != null)
                                     {
+                                        ctor = null;
                                         continue;
                                     }
                                     else
@@ -679,6 +680,7 @@ namespace MessagePack.CodeGenerator
                             {
                                 if (ctorEnumerator != null)
                                 {
+                                    ctor = null;
                                     continue;
                                 }
                                 else
@@ -697,6 +699,7 @@ namespace MessagePack.CodeGenerator
                                 {
                                     if (ctorEnumerator != null)
                                     {
+                                        ctor = null;
                                         continue;
                                     }
                                     else
@@ -714,6 +717,7 @@ namespace MessagePack.CodeGenerator
                                 {
                                     if (ctorEnumerator != null)
                                     {
+                                        ctor = null;
                                         continue;
                                     }
                                     else
@@ -726,6 +730,7 @@ namespace MessagePack.CodeGenerator
                             {
                                 if (ctorEnumerator != null)
                                 {
+                                    ctor = null;
                                     continue;
                                 }
                                 else
@@ -771,7 +776,7 @@ namespace MessagePack.CodeGenerator
 
         static bool TryGetNextConstructor(IEnumerator<IMethodSymbol> ctorEnumerator, ref IMethodSymbol ctor)
         {
-            if (ctorEnumerator == null)
+            if (ctorEnumerator == null || ctor != null)
             {
                 return false;
             }

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1321,6 +1321,7 @@ namespace MessagePack.Internal
                                 {
                                     if (ctorEnumerator != null)
                                     {
+                                        ctor = null;
                                         continue;
                                     }
                                     else
@@ -1333,6 +1334,7 @@ namespace MessagePack.Internal
                             {
                                 if (ctorEnumerator != null)
                                 {
+                                    ctor = null;
                                     continue;
                                 }
                                 else
@@ -1351,6 +1353,7 @@ namespace MessagePack.Internal
                                 {
                                     if (ctorEnumerator != null)
                                     {
+                                        ctor = null;
                                         continue;
                                     }
                                     else
@@ -1368,6 +1371,7 @@ namespace MessagePack.Internal
                                 {
                                     if (ctorEnumerator != null)
                                     {
+                                        ctor = null;
                                         continue;
                                     }
                                     else
@@ -1380,6 +1384,7 @@ namespace MessagePack.Internal
                             {
                                 if (ctorEnumerator != null)
                                 {
+                                    ctor = null;
                                     continue;
                                 }
                                 else
@@ -1410,7 +1415,7 @@ namespace MessagePack.Internal
 
         static bool TryGetNextConstructor(IEnumerator<ConstructorInfo> ctorEnumerator, ref ConstructorInfo ctor)
         {
-            if (ctorEnumerator == null)
+            if (ctorEnumerator == null || ctor != null)
             {
                 return false;
             }

--- a/tests/MessagePack.Tests/ObjectResolverTest.cs
+++ b/tests/MessagePack.Tests/ObjectResolverTest.cs
@@ -303,6 +303,17 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        public void FindingConstructor()
+        {
+            var data = new FindingConstructorCheck(10, "hogehoge");
+            var bin = MessagePackSerializer.Serialize(data, DynamicContractlessObjectResolver.Instance);
+            var re = MessagePackSerializer.Deserialize<FindingConstructorCheck>(bin, MessagePack.Resolvers.DynamicContractlessObjectResolver.Instance);
+
+            re.MyProperty1.Is(10);
+            re.MyProperty2.Is("hogehoge");
+        }
+
+        [Fact]
         public void NestedClass()
         {
             {

--- a/tests/MessagePack.Tests/ObjectResolverTest.cs
+++ b/tests/MessagePack.Tests/ObjectResolverTest.cs
@@ -306,8 +306,8 @@ namespace MessagePack.Tests
         public void FindingConstructor()
         {
             var data = new FindingConstructorCheck(10, "hogehoge");
-            var bin = MessagePackSerializer.Serialize(data, DynamicContractlessObjectResolver.Instance);
-            var re = MessagePackSerializer.Deserialize<FindingConstructorCheck>(bin, MessagePack.Resolvers.DynamicContractlessObjectResolver.Instance);
+            var bin = MessagePackSerializer.Serialize(data, ContractlessStandardResolver.Instance);
+            var re = MessagePackSerializer.Deserialize<FindingConstructorCheck>(bin, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
             re.MyProperty1.Is(10);
             re.MyProperty2.Is("hogehoge");


### PR DESCRIPTION
If parameters matching fails, try to match next constructor.
This does not change constructor finding order, but less errors can be caused.
More types can be serialized without adding `[SerializationConstructor]`.