### PR TITLE
[WIP]Improve Read(Deserialize) Peformance

### DIFF
--- a/sandbox/PerfBenchmarkDotNet/Program.cs
+++ b/sandbox/PerfBenchmarkDotNet/Program.cs
@@ -32,7 +32,7 @@ namespace PerfBenchmarkDotNet
             Add(Job.ShortRun.With(BenchmarkDotNet.Environments.Platform.X64).WithWarmupCount(1).WithTargetCount(1));
 
             //Add(Job.ShortRun.With(BenchmarkDotNet.Environments.Platform.X64).WithWarmupCount(1).WithTargetCount(1),
-              //Job.ShortRun.With(BenchmarkDotNet.Environments.Platform.X86).WithWarmupCount(1).WithTargetCount(1));
+            //Job.ShortRun.With(BenchmarkDotNet.Environments.Platform.X86).WithWarmupCount(1).WithTargetCount(1));
         }
     }
 
@@ -49,7 +49,8 @@ namespace PerfBenchmarkDotNet
                 typeof(DictionaryLookupCompare),
                 typeof(StringKeyDeserializeCompare),
                 typeof(NewVsOld),
-                typeof(ImproveStringKeySerializeBenchmark)
+                typeof(ImproveStringKeySerializeBenchmark),
+                typeof(ImproveIntKeyDeserializeBenchmark),
             });
 
             // args = new[] { "0" };
@@ -122,44 +123,57 @@ namespace PerfBenchmarkDotNet
     }
 
     [newmsgpack::MessagePack.MessagePackObject]
+    [oldmsgpack::MessagePack.MessagePackObject]
     [ProtoContract]
     [ZeroFormattable]
     public class IntKeySerializerTarget
     {
         [newmsgpack::MessagePack.Key(0)]
+        [oldmsgpack::MessagePack.Key(0)]
         [Index(0)]
         [ProtoMember(1)]
         public virtual int MyProperty1 { get; set; }
         [newmsgpack::MessagePack.Key(1)]
+        [oldmsgpack::MessagePack.Key(1)]
         [Index(1)]
         [ProtoMember(2)]
         public virtual int MyProperty2 { get; set; }
         [newmsgpack::MessagePack.Key(2)]
+        [oldmsgpack::MessagePack.Key(2)]
         [Index(2)]
         [ProtoMember(3)]
         public virtual int MyProperty3 { get; set; }
         [newmsgpack::MessagePack.Key(3)]
+        [oldmsgpack::MessagePack.Key(3)]
         [Index(3)]
         [ProtoMember(4)]
         public virtual int MyProperty4 { get; set; }
         [newmsgpack::MessagePack.Key(4)]
+        [oldmsgpack::MessagePack.Key(4)]
         [Index(4)]
         [ProtoMember(5)]
         public virtual int MyProperty5 { get; set; }
         [newmsgpack::MessagePack.Key(5)]
+        [oldmsgpack::MessagePack.Key(5)]
         [Index(5)]
         [ProtoMember(6)]
         public virtual int MyProperty6 { get; set; }
+
         [newmsgpack::MessagePack.Key(6)]
+        [oldmsgpack::MessagePack.Key(6)]
         [Index(6)]
         [ProtoMember(7)]
         public virtual int MyProperty7 { get; set; }
+
         [ProtoMember(8)]
         [newmsgpack::MessagePack.Key(7)]
+        [oldmsgpack::MessagePack.Key(7)]
         [Index(7)]
         public virtual int MyProperty8 { get; set; }
+
         [ProtoMember(9)]
         [newmsgpack::MessagePack.Key(8)]
+        [oldmsgpack::MessagePack.Key(8)]
         [Index(8)]
         public virtual int MyProperty9 { get; set; }
     }
@@ -594,6 +608,29 @@ namespace PerfBenchmarkDotNet
         public byte[] NewSerialize()
         {
             return newmsgpack::MessagePack.MessagePackSerializer.Serialize<StringKeySerializerTarget>(stringData);
+        }
+    }
+
+    [Config(typeof(BenchmarkConfig))]
+    public class ImproveIntKeyDeserializeBenchmark
+    {
+        byte[] bin;
+
+        public ImproveIntKeyDeserializeBenchmark()
+        {
+            bin = newmsgpack::MessagePack.MessagePackSerializer.Serialize(new IntKeySerializerTarget());
+        }
+
+        [Benchmark]
+        public IntKeySerializerTarget OldDeserialize()
+        {
+            return oldmsgpack::MessagePack.MessagePackSerializer.Deserialize<IntKeySerializerTarget>(bin);
+        }
+
+        [Benchmark(Baseline = true)]
+        public IntKeySerializerTarget NewDeserialize()
+        {
+            return newmsgpack::MessagePack.MessagePackSerializer.Deserialize<IntKeySerializerTarget>(bin);
         }
     }
 

--- a/src/MessagePack/MessagePackBinary.cs
+++ b/src/MessagePack/MessagePackBinary.cs
@@ -5,6 +5,13 @@ using System.IO;
 
 namespace MessagePack
 {
+    // Reading strategy uses OpCodes.Switch
+    // https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.switch.aspx
+    // switch does not uses if value is not sequential, C# Compiler generates binary search code
+    // so we should fill all labels of codes.
+    // one more thing, if switch does not begin from zero, emit OpCodes.Sub before go to jump table
+    // we can avoid it by fill from zero.
+
     /// <summary>
     /// Encode/Decode Utility of MessagePack Spec.
     /// https://github.com/msgpack/msgpack/blob/master/spec.md
@@ -536,6 +543,7 @@ namespace MessagePack
                     case 31:
                         UnsafeMemory32.WriteRaw31(ref bytes, offset, rawMessagePackBlock);
                         break;
+                    case 0:
                     default:
                         Buffer.BlockCopy(rawMessagePackBlock, 0, bytes, offset, rawMessagePackBlock.Length);
                         break;
@@ -638,6 +646,7 @@ namespace MessagePack
                     case 31:
                         UnsafeMemory64.WriteRaw31(ref bytes, offset, rawMessagePackBlock);
                         break;
+                    case 0:
                     default:
                         Buffer.BlockCopy(rawMessagePackBlock, 0, bytes, offset, rawMessagePackBlock.Length);
                         break;
@@ -950,7 +959,244 @@ namespace MessagePack
 #endif
         public static byte ReadByte(byte[] bytes, int offset, out int readSize)
         {
-            return byteDecoders[bytes[offset]].Read(bytes, offset, out readSize);
+            switch (bytes[offset])
+            {
+                case MessagePackCode.MinFixInt: // 0
+                case 1:
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                case 16:
+                case 17:
+                case 18:
+                case 19:
+                case 20:
+                case 21:
+                case 22:
+                case 23:
+                case 24:
+                case 25:
+                case 26:
+                case 27:
+                case 28:
+                case 29:
+                case 30:
+                case 31:
+                case 32:
+                case 33:
+                case 34:
+                case 35:
+                case 36:
+                case 37:
+                case 38:
+                case 39:
+                case 40:
+                case 41:
+                case 42:
+                case 43:
+                case 44:
+                case 45:
+                case 46:
+                case 47:
+                case 48:
+                case 49:
+                case 50:
+                case 51:
+                case 52:
+                case 53:
+                case 54:
+                case 55:
+                case 56:
+                case 57:
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 65:
+                case 66:
+                case 67:
+                case 68:
+                case 69:
+                case 70:
+                case 71:
+                case 72:
+                case 73:
+                case 74:
+                case 75:
+                case 76:
+                case 77:
+                case 78:
+                case 79:
+                case 80:
+                case 81:
+                case 82:
+                case 83:
+                case 84:
+                case 85:
+                case 86:
+                case 87:
+                case 88:
+                case 89:
+                case 90:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                case 97:
+                case 98:
+                case 99:
+                case 100:
+                case 101:
+                case 102:
+                case 103:
+                case 104:
+                case 105:
+                case 106:
+                case 107:
+                case 108:
+                case 109:
+                case 110:
+                case 111:
+                case 112:
+                case 113:
+                case 114:
+                case 115:
+                case 116:
+                case 117:
+                case 118:
+                case 119:
+                case 120:
+                case 121:
+                case 122:
+                case 123:
+                case 124:
+                case 125:
+                case 126:
+                case MessagePackCode.MaxFixInt: // 127
+                    readSize = 1;
+                    return unchecked((byte)bytes[offset]);
+                case MessagePackCode.UInt8:  // 204
+                    readSize = 2;
+                    return unchecked((byte)(bytes[offset + 1]));
+                case MessagePackCode.UInt16: // 205
+                    readSize = 3;
+                    return checked((byte)((UInt16)(bytes[offset + 1] << 8) | (UInt16)(bytes[offset + 2])));
+                case MessagePackCode.UInt32: // 206
+                    readSize = 5;
+                    return checked((byte)(unchecked((UInt32)(bytes[offset + 1] << 24) | (UInt32)(bytes[offset + 2] << 16) | (UInt32)(bytes[offset + 3] << 8) | (UInt32)bytes[offset + 4])));
+                case MessagePackCode.UInt64: // 207
+                    readSize = 9;
+                    return checked((byte)(unchecked(((UInt64)bytes[offset + 1] << 56 | (UInt64)bytes[offset + 2] << 48 | (UInt64)bytes[offset + 3] << 40 | (UInt64)bytes[offset + 4] << 32
+                                                   | (UInt64)bytes[offset + 5] << 24 | (UInt64)bytes[offset + 6] << 16 | (UInt64)bytes[offset + 7] << 8 | (UInt64)bytes[offset + 8]))));
+                case MessagePackCode.Int8:   // 208
+                    readSize = 2;
+                    return checked((byte)(sbyte)(bytes[offset + 1]));
+                case MessagePackCode.Int16:  // 209
+                    readSize = 3;
+                    return checked((byte)(short)((bytes[offset + 1] << 8) | (bytes[offset + 2])));
+                case MessagePackCode.Int32:  // 210
+                    readSize = 5;
+                    return checked((byte)((bytes[offset + 1] << 24) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 8) | bytes[offset + 4]));
+                case MessagePackCode.Int64:  // 211
+                    readSize = 9;
+                    return checked((byte)(((Int64)bytes[offset + 1] << 56 | (Int64)bytes[offset + 2] << 48 | (Int64)bytes[offset + 3] << 40 | (Int64)bytes[offset + 4] << 32
+                                         | (Int64)bytes[offset + 5] << 24 | (Int64)bytes[offset + 6] << 16 | (Int64)bytes[offset + 7] << 8 | (Int64)bytes[offset + 8])));
+                // Invalid Code
+                case MessagePackCode.MinFixMap: // 128
+                case 129:
+                case 130:
+                case 131:
+                case 132:
+                case 133:
+                case 134:
+                case 135:
+                case 136:
+                case 137:
+                case 138:
+                case 139:
+                case 140:
+                case 141:
+                case 142:
+                case MessagePackCode.MaxFixMap: // 143
+                case MessagePackCode.MinFixArray: // 144
+                case 145:
+                case 146:
+                case 147:
+                case 148:
+                case 149:
+                case 150:
+                case 151:
+                case 152:
+                case 153:
+                case 154:
+                case 155:
+                case 156:
+                case 157:
+                case 158:
+                case MessagePackCode.MaxFixArray: // 159
+                case MessagePackCode.MinFixStr: // 160
+                case 161:
+                case 162:
+                case 163:
+                case 164:
+                case 165:
+                case 166:
+                case 167:
+                case 168:
+                case 169:
+                case 170:
+                case 171:
+                case 172:
+                case 173:
+                case 174:
+                case 175:
+                case 176:
+                case 177:
+                case 178:
+                case 179:
+                case 180:
+                case 181:
+                case 182:
+                case 183:
+                case 184:
+                case 185:
+                case 186:
+                case 187:
+                case 188:
+                case 189:
+                case 190:
+                case MessagePackCode.MaxFixStr: // 191
+                case MessagePackCode.Nil: // 192
+                case MessagePackCode.NeverUsed: // 193
+                case MessagePackCode.False: // 194
+                case MessagePackCode.True: // 195
+                case MessagePackCode.Bin8: // 196
+                case MessagePackCode.Bin16: // 197
+                case MessagePackCode.Bin32: // 198
+                case MessagePackCode.Ext8: // 199;
+                case MessagePackCode.Ext16:// 200;
+                case MessagePackCode.Ext32: // 201;
+                case MessagePackCode.Float32: // 202;
+                case MessagePackCode.Float64: // 203;
+                default:
+                    throw new InvalidOperationException(string.Format("code is invalid. code:{0} format:{1}", bytes[offset], MessagePackCode.ToFormatName(bytes[offset])));
+            }
         }
 
 #if NETSTANDARD1_4
@@ -1347,7 +1593,290 @@ namespace MessagePack
 #endif
         public static int ReadInt32(byte[] bytes, int offset, out int readSize)
         {
-            return int32Decoders[bytes[offset]].Read(bytes, offset, out readSize);
+            switch (bytes[offset])
+            {
+                case MessagePackCode.MinFixInt: // 0
+                case 1:
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                case 16:
+                case 17:
+                case 18:
+                case 19:
+                case 20:
+                case 21:
+                case 22:
+                case 23:
+                case 24:
+                case 25:
+                case 26:
+                case 27:
+                case 28:
+                case 29:
+                case 30:
+                case 31:
+                case 32:
+                case 33:
+                case 34:
+                case 35:
+                case 36:
+                case 37:
+                case 38:
+                case 39:
+                case 40:
+                case 41:
+                case 42:
+                case 43:
+                case 44:
+                case 45:
+                case 46:
+                case 47:
+                case 48:
+                case 49:
+                case 50:
+                case 51:
+                case 52:
+                case 53:
+                case 54:
+                case 55:
+                case 56:
+                case 57:
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 65:
+                case 66:
+                case 67:
+                case 68:
+                case 69:
+                case 70:
+                case 71:
+                case 72:
+                case 73:
+                case 74:
+                case 75:
+                case 76:
+                case 77:
+                case 78:
+                case 79:
+                case 80:
+                case 81:
+                case 82:
+                case 83:
+                case 84:
+                case 85:
+                case 86:
+                case 87:
+                case 88:
+                case 89:
+                case 90:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                case 97:
+                case 98:
+                case 99:
+                case 100:
+                case 101:
+                case 102:
+                case 103:
+                case 104:
+                case 105:
+                case 106:
+                case 107:
+                case 108:
+                case 109:
+                case 110:
+                case 111:
+                case 112:
+                case 113:
+                case 114:
+                case 115:
+                case 116:
+                case 117:
+                case 118:
+                case 119:
+                case 120:
+                case 121:
+                case 122:
+                case 123:
+                case 124:
+                case 125:
+                case 126:
+                case MessagePackCode.MaxFixInt: // 127
+                    readSize = 1;
+                    return unchecked((int)bytes[offset]);
+                case MessagePackCode.UInt8:  // 204
+                    readSize = 2;
+                    return unchecked((int)(byte)(bytes[offset + 1]));
+                case MessagePackCode.UInt16: // 205
+                    readSize = 3;
+                    return unchecked((Int32)((UInt16)(bytes[offset + 1] << 8) | (UInt16)(bytes[offset + 2])));
+                case MessagePackCode.UInt32: // 206
+                    readSize = 5;
+                    return checked((Int32)(unchecked((UInt32)(bytes[offset + 1] << 24) | (UInt32)(bytes[offset + 2] << 16) | (UInt32)(bytes[offset + 3] << 8) | (UInt32)bytes[offset + 4])));
+                case MessagePackCode.UInt64: // 207
+                    readSize = 9;
+                    return checked((Int32)(unchecked(((UInt64)bytes[offset + 1] << 56 | (UInt64)bytes[offset + 2] << 48 | (UInt64)bytes[offset + 3] << 40 | (UInt64)bytes[offset + 4] << 32
+                                                    | (UInt64)bytes[offset + 5] << 24 | (UInt64)bytes[offset + 6] << 16 | (UInt64)bytes[offset + 7] << 8 | (UInt64)bytes[offset + 8]))));
+                case MessagePackCode.Int8:   // 208
+                    readSize = 2;
+                    return unchecked((int)(sbyte)(bytes[offset + 1]));
+                case MessagePackCode.Int16:  // 209
+                    readSize = 3;
+                    return unchecked((int)(short)((bytes[offset + 1] << 8) | (bytes[offset + 2])));
+                case MessagePackCode.Int32:  // 210
+                    readSize = 5;
+                    return unchecked((int)((bytes[offset + 1] << 24) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 8) | bytes[offset + 4]));
+                case MessagePackCode.Int64:  // 211
+                    readSize = 9;
+                    return checked((int)(unchecked(((Int64)bytes[offset + 1] << 56 | (Int64)bytes[offset + 2] << 48 | (Int64)bytes[offset + 3] << 40 | (Int64)bytes[offset + 4] << 32
+                                                  | (Int64)bytes[offset + 5] << 24 | (Int64)bytes[offset + 6] << 16 | (Int64)bytes[offset + 7] << 8 | (Int64)bytes[offset + 8]))));
+                case MessagePackCode.MinNegativeFixInt: // 224
+                case 225:
+                case 226:
+                case 227:
+                case 228:
+                case 229:
+                case 230:
+                case 231:
+                case 232:
+                case 233:
+                case 234:
+                case 235:
+                case 236:
+                case 237:
+                case 238:
+                case 239:
+                case 240:
+                case 241:
+                case 242:
+                case 243:
+                case 244:
+                case 245:
+                case 246:
+                case 247:
+                case 248:
+                case 249:
+                case 250:
+                case 251:
+                case 252:
+                case 253:
+                case 254:
+                case MessagePackCode.MaxNegativeFixInt: // 255
+                    readSize = 1;
+                    return unchecked((int)(sbyte)bytes[offset]);
+                // Invalid Code
+                case MessagePackCode.MinFixMap: // 128
+                case 129:
+                case 130:
+                case 131:
+                case 132:
+                case 133:
+                case 134:
+                case 135:
+                case 136:
+                case 137:
+                case 138:
+                case 139:
+                case 140:
+                case 141:
+                case 142:
+                case MessagePackCode.MaxFixMap: // 143
+                case MessagePackCode.MinFixArray: // 144
+                case 145:
+                case 146:
+                case 147:
+                case 148:
+                case 149:
+                case 150:
+                case 151:
+                case 152:
+                case 153:
+                case 154:
+                case 155:
+                case 156:
+                case 157:
+                case 158:
+                case MessagePackCode.MaxFixArray: // 159
+                case MessagePackCode.MinFixStr: // 160
+                case 161:
+                case 162:
+                case 163:
+                case 164:
+                case 165:
+                case 166:
+                case 167:
+                case 168:
+                case 169:
+                case 170:
+                case 171:
+                case 172:
+                case 173:
+                case 174:
+                case 175:
+                case 176:
+                case 177:
+                case 178:
+                case 179:
+                case 180:
+                case 181:
+                case 182:
+                case 183:
+                case 184:
+                case 185:
+                case 186:
+                case 187:
+                case 188:
+                case 189:
+                case 190:
+                case MessagePackCode.MaxFixStr: // 191
+                case MessagePackCode.Nil: // 192
+                case MessagePackCode.NeverUsed: // 193
+                case MessagePackCode.False: // 194
+                case MessagePackCode.True: // 195
+                case MessagePackCode.Bin8: // 196
+                case MessagePackCode.Bin16: // 197
+                case MessagePackCode.Bin32: // 198
+                case MessagePackCode.Ext8: // 199;
+                case MessagePackCode.Ext16:// 200;
+                case MessagePackCode.Ext32: // 201;
+                case MessagePackCode.Float32: // 202;
+                case MessagePackCode.Float64: // 203;
+                case MessagePackCode.FixExt1: // 212;
+                case MessagePackCode.FixExt2: // 213;
+                case MessagePackCode.FixExt4: // 214;
+                case MessagePackCode.FixExt8: // 215;
+                case MessagePackCode.FixExt16: // 216;
+                case MessagePackCode.Str8: // 217
+                case MessagePackCode.Str16: // 218
+                case MessagePackCode.Str32: // 219;
+                case MessagePackCode.Array16: // 220;
+                case MessagePackCode.Array32: // 221;
+                case MessagePackCode.Map16: // 222;
+                case MessagePackCode.Map32: // 223;
+                default:
+                    throw new InvalidOperationException(string.Format("code is invalid. code:{0} format:{1}", bytes[offset], MessagePackCode.ToFormatName(bytes[offset])));
+            }
         }
 
 #if NETSTANDARD1_4
@@ -1478,7 +2007,290 @@ namespace MessagePack
 #endif
         public static long ReadInt64(byte[] bytes, int offset, out int readSize)
         {
-            return int64Decoders[bytes[offset]].Read(bytes, offset, out readSize);
+            switch (bytes[offset])
+            {
+                case MessagePackCode.MinFixInt: // 0
+                case 1:
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                case 16:
+                case 17:
+                case 18:
+                case 19:
+                case 20:
+                case 21:
+                case 22:
+                case 23:
+                case 24:
+                case 25:
+                case 26:
+                case 27:
+                case 28:
+                case 29:
+                case 30:
+                case 31:
+                case 32:
+                case 33:
+                case 34:
+                case 35:
+                case 36:
+                case 37:
+                case 38:
+                case 39:
+                case 40:
+                case 41:
+                case 42:
+                case 43:
+                case 44:
+                case 45:
+                case 46:
+                case 47:
+                case 48:
+                case 49:
+                case 50:
+                case 51:
+                case 52:
+                case 53:
+                case 54:
+                case 55:
+                case 56:
+                case 57:
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 65:
+                case 66:
+                case 67:
+                case 68:
+                case 69:
+                case 70:
+                case 71:
+                case 72:
+                case 73:
+                case 74:
+                case 75:
+                case 76:
+                case 77:
+                case 78:
+                case 79:
+                case 80:
+                case 81:
+                case 82:
+                case 83:
+                case 84:
+                case 85:
+                case 86:
+                case 87:
+                case 88:
+                case 89:
+                case 90:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                case 97:
+                case 98:
+                case 99:
+                case 100:
+                case 101:
+                case 102:
+                case 103:
+                case 104:
+                case 105:
+                case 106:
+                case 107:
+                case 108:
+                case 109:
+                case 110:
+                case 111:
+                case 112:
+                case 113:
+                case 114:
+                case 115:
+                case 116:
+                case 117:
+                case 118:
+                case 119:
+                case 120:
+                case 121:
+                case 122:
+                case 123:
+                case 124:
+                case 125:
+                case 126:
+                case MessagePackCode.MaxFixInt: // 127
+                    readSize = 1;
+                    return unchecked((long)bytes[offset]);
+                case MessagePackCode.UInt8:  // 204
+                    readSize = 2;
+                    return unchecked((long)(byte)(bytes[offset + 1]));
+                case MessagePackCode.UInt16: // 205
+                    readSize = 3;
+                    return unchecked((long)((UInt16)(bytes[offset + 1] << 8) | (UInt16)(bytes[offset + 2])));
+                case MessagePackCode.UInt32: // 206
+                    readSize = 5;
+                    return checked((long)(unchecked((UInt32)(bytes[offset + 1] << 24) | (UInt32)(bytes[offset + 2] << 16) | (UInt32)(bytes[offset + 3] << 8) | (UInt32)bytes[offset + 4])));
+                case MessagePackCode.UInt64: // 207
+                    readSize = 9;
+                    return checked((long)(unchecked(((UInt64)bytes[offset + 1] << 56 | (UInt64)bytes[offset + 2] << 48 | (UInt64)bytes[offset + 3] << 40 | (UInt64)bytes[offset + 4] << 32
+                                                    | (UInt64)bytes[offset + 5] << 24 | (UInt64)bytes[offset + 6] << 16 | (UInt64)bytes[offset + 7] << 8 | (UInt64)bytes[offset + 8]))));
+                case MessagePackCode.Int8:   // 208
+                    readSize = 2;
+                    return unchecked((long)(sbyte)(bytes[offset + 1]));
+                case MessagePackCode.Int16:  // 209
+                    readSize = 3;
+                    return unchecked((long)(short)((bytes[offset + 1] << 8) | (bytes[offset + 2])));
+                case MessagePackCode.Int32:  // 210
+                    readSize = 5;
+                    return unchecked((long)((bytes[offset + 1] << 24) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 8) | bytes[offset + 4]));
+                case MessagePackCode.Int64:  // 211
+                    readSize = 9;
+                    return unchecked(((Int64)bytes[offset + 1] << 56 | (Int64)bytes[offset + 2] << 48 | (Int64)bytes[offset + 3] << 40 | (Int64)bytes[offset + 4] << 32
+                                    | (Int64)bytes[offset + 5] << 24 | (Int64)bytes[offset + 6] << 16 | (Int64)bytes[offset + 7] << 8 | (Int64)bytes[offset + 8]));
+                case MessagePackCode.MinNegativeFixInt: // 224
+                case 225:
+                case 226:
+                case 227:
+                case 228:
+                case 229:
+                case 230:
+                case 231:
+                case 232:
+                case 233:
+                case 234:
+                case 235:
+                case 236:
+                case 237:
+                case 238:
+                case 239:
+                case 240:
+                case 241:
+                case 242:
+                case 243:
+                case 244:
+                case 245:
+                case 246:
+                case 247:
+                case 248:
+                case 249:
+                case 250:
+                case 251:
+                case 252:
+                case 253:
+                case 254:
+                case MessagePackCode.MaxNegativeFixInt: // 255
+                    readSize = 1;
+                    return unchecked((long)(sbyte)bytes[offset]);
+                // Invalid Code
+                case MessagePackCode.MinFixMap: // 128
+                case 129:
+                case 130:
+                case 131:
+                case 132:
+                case 133:
+                case 134:
+                case 135:
+                case 136:
+                case 137:
+                case 138:
+                case 139:
+                case 140:
+                case 141:
+                case 142:
+                case MessagePackCode.MaxFixMap: // 143
+                case MessagePackCode.MinFixArray: // 144
+                case 145:
+                case 146:
+                case 147:
+                case 148:
+                case 149:
+                case 150:
+                case 151:
+                case 152:
+                case 153:
+                case 154:
+                case 155:
+                case 156:
+                case 157:
+                case 158:
+                case MessagePackCode.MaxFixArray: // 159
+                case MessagePackCode.MinFixStr: // 160
+                case 161:
+                case 162:
+                case 163:
+                case 164:
+                case 165:
+                case 166:
+                case 167:
+                case 168:
+                case 169:
+                case 170:
+                case 171:
+                case 172:
+                case 173:
+                case 174:
+                case 175:
+                case 176:
+                case 177:
+                case 178:
+                case 179:
+                case 180:
+                case 181:
+                case 182:
+                case 183:
+                case 184:
+                case 185:
+                case 186:
+                case 187:
+                case 188:
+                case 189:
+                case 190:
+                case MessagePackCode.MaxFixStr: // 191
+                case MessagePackCode.Nil: // 192
+                case MessagePackCode.NeverUsed: // 193
+                case MessagePackCode.False: // 194
+                case MessagePackCode.True: // 195
+                case MessagePackCode.Bin8: // 196
+                case MessagePackCode.Bin16: // 197
+                case MessagePackCode.Bin32: // 198
+                case MessagePackCode.Ext8: // 199;
+                case MessagePackCode.Ext16:// 200;
+                case MessagePackCode.Ext32: // 201;
+                case MessagePackCode.Float32: // 202;
+                case MessagePackCode.Float64: // 203;
+                case MessagePackCode.FixExt1: // 212;
+                case MessagePackCode.FixExt2: // 213;
+                case MessagePackCode.FixExt4: // 214;
+                case MessagePackCode.FixExt8: // 215;
+                case MessagePackCode.FixExt16: // 216;
+                case MessagePackCode.Str8: // 217
+                case MessagePackCode.Str16: // 218
+                case MessagePackCode.Str32: // 219;
+                case MessagePackCode.Array16: // 220;
+                case MessagePackCode.Array32: // 221;
+                case MessagePackCode.Map16: // 222;
+                case MessagePackCode.Map32: // 223;
+                default:
+                    throw new InvalidOperationException(string.Format("code is invalid. code:{0} format:{1}", bytes[offset], MessagePackCode.ToFormatName(bytes[offset])));
+            }
         }
 
 #if NETSTANDARD1_4

--- a/src/MessagePack/MessagePackBinary.cs
+++ b/src/MessagePack/MessagePackBinary.cs
@@ -1321,7 +1321,244 @@ namespace MessagePack
 #endif
         public static sbyte ReadSByte(byte[] bytes, int offset, out int readSize)
         {
-            return sbyteDecoders[bytes[offset]].Read(bytes, offset, out readSize);
+            switch (bytes[offset])
+            {
+                case MessagePackCode.MinFixInt: // 0
+                case 1:
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                case 16:
+                case 17:
+                case 18:
+                case 19:
+                case 20:
+                case 21:
+                case 22:
+                case 23:
+                case 24:
+                case 25:
+                case 26:
+                case 27:
+                case 28:
+                case 29:
+                case 30:
+                case 31:
+                case 32:
+                case 33:
+                case 34:
+                case 35:
+                case 36:
+                case 37:
+                case 38:
+                case 39:
+                case 40:
+                case 41:
+                case 42:
+                case 43:
+                case 44:
+                case 45:
+                case 46:
+                case 47:
+                case 48:
+                case 49:
+                case 50:
+                case 51:
+                case 52:
+                case 53:
+                case 54:
+                case 55:
+                case 56:
+                case 57:
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                case 64:
+                case 65:
+                case 66:
+                case 67:
+                case 68:
+                case 69:
+                case 70:
+                case 71:
+                case 72:
+                case 73:
+                case 74:
+                case 75:
+                case 76:
+                case 77:
+                case 78:
+                case 79:
+                case 80:
+                case 81:
+                case 82:
+                case 83:
+                case 84:
+                case 85:
+                case 86:
+                case 87:
+                case 88:
+                case 89:
+                case 90:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                case 96:
+                case 97:
+                case 98:
+                case 99:
+                case 100:
+                case 101:
+                case 102:
+                case 103:
+                case 104:
+                case 105:
+                case 106:
+                case 107:
+                case 108:
+                case 109:
+                case 110:
+                case 111:
+                case 112:
+                case 113:
+                case 114:
+                case 115:
+                case 116:
+                case 117:
+                case 118:
+                case 119:
+                case 120:
+                case 121:
+                case 122:
+                case 123:
+                case 124:
+                case 125:
+                case 126:
+                case MessagePackCode.MaxFixInt: // 127
+                    readSize = 1;
+                    return unchecked((sbyte)bytes[offset]);
+                case MessagePackCode.UInt8:  // 204
+                    readSize = 2;
+                    return unchecked((sbyte)(bytes[offset + 1]));
+                case MessagePackCode.UInt16: // 205
+                    readSize = 3;
+                    return checked((sbyte)((UInt16)(bytes[offset + 1] << 8) | (UInt16)(bytes[offset + 2])));
+                case MessagePackCode.UInt32: // 206
+                    readSize = 5;
+                    return checked((sbyte)(unchecked((UInt32)(bytes[offset + 1] << 24) | (UInt32)(bytes[offset + 2] << 16) | (UInt32)(bytes[offset + 3] << 8) | (UInt32)bytes[offset + 4])));
+                case MessagePackCode.UInt64: // 207
+                    readSize = 9;
+                    return checked((sbyte)(unchecked(((UInt64)bytes[offset + 1] << 56 | (UInt64)bytes[offset + 2] << 48 | (UInt64)bytes[offset + 3] << 40 | (UInt64)bytes[offset + 4] << 32
+                                                   | (UInt64)bytes[offset + 5] << 24 | (UInt64)bytes[offset + 6] << 16 | (UInt64)bytes[offset + 7] << 8 | (UInt64)bytes[offset + 8]))));
+                case MessagePackCode.Int8:   // 208
+                    readSize = 2;
+                    return checked((sbyte)(sbyte)(bytes[offset + 1]));
+                case MessagePackCode.Int16:  // 209
+                    readSize = 3;
+                    return checked((sbyte)(short)((bytes[offset + 1] << 8) | (bytes[offset + 2])));
+                case MessagePackCode.Int32:  // 210
+                    readSize = 5;
+                    return checked((sbyte)((bytes[offset + 1] << 24) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 8) | bytes[offset + 4]));
+                case MessagePackCode.Int64:  // 211
+                    readSize = 9;
+                    return checked((sbyte)(((Int64)bytes[offset + 1] << 56 | (Int64)bytes[offset + 2] << 48 | (Int64)bytes[offset + 3] << 40 | (Int64)bytes[offset + 4] << 32
+                                         | (Int64)bytes[offset + 5] << 24 | (Int64)bytes[offset + 6] << 16 | (Int64)bytes[offset + 7] << 8 | (Int64)bytes[offset + 8])));
+                // Invalid Code
+                case MessagePackCode.MinFixMap: // 128
+                case 129:
+                case 130:
+                case 131:
+                case 132:
+                case 133:
+                case 134:
+                case 135:
+                case 136:
+                case 137:
+                case 138:
+                case 139:
+                case 140:
+                case 141:
+                case 142:
+                case MessagePackCode.MaxFixMap: // 143
+                case MessagePackCode.MinFixArray: // 144
+                case 145:
+                case 146:
+                case 147:
+                case 148:
+                case 149:
+                case 150:
+                case 151:
+                case 152:
+                case 153:
+                case 154:
+                case 155:
+                case 156:
+                case 157:
+                case 158:
+                case MessagePackCode.MaxFixArray: // 159
+                case MessagePackCode.MinFixStr: // 160
+                case 161:
+                case 162:
+                case 163:
+                case 164:
+                case 165:
+                case 166:
+                case 167:
+                case 168:
+                case 169:
+                case 170:
+                case 171:
+                case 172:
+                case 173:
+                case 174:
+                case 175:
+                case 176:
+                case 177:
+                case 178:
+                case 179:
+                case 180:
+                case 181:
+                case 182:
+                case 183:
+                case 184:
+                case 185:
+                case 186:
+                case 187:
+                case 188:
+                case 189:
+                case 190:
+                case MessagePackCode.MaxFixStr: // 191
+                case MessagePackCode.Nil: // 192
+                case MessagePackCode.NeverUsed: // 193
+                case MessagePackCode.False: // 194
+                case MessagePackCode.True: // 195
+                case MessagePackCode.Bin8: // 196
+                case MessagePackCode.Bin16: // 197
+                case MessagePackCode.Bin32: // 198
+                case MessagePackCode.Ext8: // 199;
+                case MessagePackCode.Ext16:// 200;
+                case MessagePackCode.Ext32: // 201;
+                case MessagePackCode.Float32: // 202;
+                case MessagePackCode.Float64: // 203;
+                default:
+                    throw new InvalidOperationException(string.Format("code is invalid. code:{0} format:{1}", bytes[offset], MessagePackCode.ToFormatName(bytes[offset])));
+            }
         }
 
 #if NETSTANDARD1_4

--- a/tests/MessagePack.Tests/MessagePackBinaryTest.cs
+++ b/tests/MessagePack.Tests/MessagePackBinaryTest.cs
@@ -278,6 +278,33 @@ namespace MessagePack.Tests
             CreateUnpackedReference(bytes).AsInt32().Is(target);
         }
 
+        [Fact]
+        public void IntOverflowTest()
+        {
+            byte[] bytes = null;
+            {
+                MessagePackBinary.WriteUInt32ForceUInt32Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt32(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteUInt32ForceUInt32Block(ref bytes, 0, uint.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt64ForceInt64Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt32(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteInt64ForceInt64Block(ref bytes, 0, long.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt64(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, ulong.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
+        }
+
         [Theory]
         [InlineData(long.MinValue, 9)]
         [InlineData(-3372036854775807, 9)]
@@ -335,6 +362,19 @@ namespace MessagePack.Tests
             readSize.Is(length);
 
             CreateUnpackedReference(bytes).AsInt64().Is(target);
+        }
+
+        [Fact]
+        public void Int64OverflowTest()
+        {
+            byte[] bytes = null;
+            {
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt64(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, ulong.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
         }
 
         [Theory]

--- a/tests/MessagePack.Tests/MessagePackBinaryTest.cs
+++ b/tests/MessagePack.Tests/MessagePackBinaryTest.cs
@@ -278,32 +278,6 @@ namespace MessagePack.Tests
             CreateUnpackedReference(bytes).AsInt32().Is(target);
         }
 
-        [Fact]
-        public void IntOverflowTest()
-        {
-            byte[] bytes = null;
-            {
-                MessagePackBinary.WriteUInt32ForceUInt32Block(ref bytes, 0, 100);
-                MessagePackBinary.ReadInt32(bytes, 0, out var _).Is(100);
-
-                MessagePackBinary.WriteUInt32ForceUInt32Block(ref bytes, 0, uint.MaxValue);
-                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
-            }
-            {
-                MessagePackBinary.WriteInt64ForceInt64Block(ref bytes, 0, 100);
-                MessagePackBinary.ReadInt32(bytes, 0, out var _).Is(100);
-
-                MessagePackBinary.WriteInt64ForceInt64Block(ref bytes, 0, long.MaxValue);
-                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
-            }
-            {
-                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, 100);
-                MessagePackBinary.ReadInt64(bytes, 0, out var _).Is(100);
-
-                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, ulong.MaxValue);
-                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
-            }
-        }
 
         [Theory]
         [InlineData(long.MinValue, 9)]
@@ -362,19 +336,6 @@ namespace MessagePack.Tests
             readSize.Is(length);
 
             CreateUnpackedReference(bytes).AsInt64().Is(target);
-        }
-
-        [Fact]
-        public void Int64OverflowTest()
-        {
-            byte[] bytes = null;
-            {
-                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, 100);
-                MessagePackBinary.ReadInt64(bytes, 0, out var _).Is(100);
-
-                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, ulong.MaxValue);
-                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
-            }
         }
 
         [Theory]
@@ -772,6 +733,178 @@ namespace MessagePack.Tests
                 MessagePackBinary.ReadInt64(small, 0, out readSize).Is(uint.MaxValue);
                 MessagePackBinary.WriteInt64(ref target, 0, uint.MaxValue);
                 target.SequenceEqual(small).IsTrue();
+            }
+        }
+    }
+
+    public class MessagePackBinaryOverflowTest
+    {
+
+        [Fact]
+        public void ByteOverflowTest()
+        {
+            var bytes = new byte[0];
+            {
+                MessagePackBinary.WriteSByte(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteSByte(ref bytes, 0, sbyte.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt16(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteInt16(ref bytes, 0, short.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt32(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteInt32(ref bytes, 0, int.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt64(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteInt64(ref bytes, 0, long.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteByte(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteByte(ref bytes, 0, byte.MaxValue);
+                // Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt16(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteUInt16(ref bytes, 0, UInt16.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt32(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteUInt32(ref bytes, 0, UInt32.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt64(ref bytes, 0, 10);
+                MessagePackBinary.ReadByte(bytes, 0, out var _).Is((byte)10);
+
+                MessagePackBinary.WriteUInt64(ref bytes, 0, UInt64.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadByte(bytes, 0, out var _));
+            }
+        }
+
+        [Fact]
+        public void SByteOverflowTest()
+        {
+            var bytes = new byte[0];
+            {
+                MessagePackBinary.WriteSByte(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteSByte(ref bytes, 0, sbyte.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt16(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteInt16(ref bytes, 0, short.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt32(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteInt32(ref bytes, 0, int.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt64(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteInt64(ref bytes, 0, long.MinValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteByte(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteByte(ref bytes, 0, byte.MaxValue);
+                 Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt16(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteUInt16(ref bytes, 0, UInt16.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt32(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteUInt32(ref bytes, 0, UInt32.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt64(ref bytes, 0, 10);
+                MessagePackBinary.ReadSByte(bytes, 0, out var _).Is((sbyte)10);
+
+                MessagePackBinary.WriteUInt64(ref bytes, 0, UInt64.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadSByte(bytes, 0, out var _));
+            }
+        }
+
+
+
+        [Fact]
+        public void IntOverflowTest()
+        {
+            byte[] bytes = null;
+            {
+                MessagePackBinary.WriteUInt32ForceUInt32Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt32(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteUInt32ForceUInt32Block(ref bytes, 0, uint.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteInt64ForceInt64Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt32(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteInt64ForceInt64Block(ref bytes, 0, long.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
+            {
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt64(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, ulong.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
+            }
+        }
+
+
+
+        [Fact]
+        public void Int64OverflowTest()
+        {
+            byte[] bytes = null;
+            {
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, 100);
+                MessagePackBinary.ReadInt64(bytes, 0, out var _).Is(100);
+
+                MessagePackBinary.WriteUInt64ForceUInt64Block(ref bytes, 0, ulong.MaxValue);
+                Assert.Throws<OverflowException>(() => MessagePackBinary.ReadInt32(bytes, 0, out var _));
             }
         }
     }


### PR DESCRIPTION
Currently read strategy is
lookup from array -> invoke virtual method.
It is slower than simple switch.

New Reading strategy uses OpCodes.Switch.
https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.switch.aspx
switch does not uses if value is not sequential, C# Compiler generates binary search code
so we should fill all labels of codes.
one more thing, if switch does not begin from zero, emit OpCodes.Sub before go to jump table
we can avoid it by fill from zero.

In addition, allow conversion from a large integer type (can not convert, throw overflow exception)
improve performance of float, double by unsafe code in .NET, .NET Standard.