### PR TITLE
Fixed bug where indexers were treated as data properties.

### DIFF
--- a/sandbox/SharedData/Class1.cs
+++ b/sandbox/SharedData/Class1.cs
@@ -785,6 +785,26 @@ namespace SharedData
         [Key(0)]
         public string OPQ { get; set; }
     }
+    
+    [MessagePackObject]
+    public class WithIndexer
+    {
+        [Key(0)]
+        public int Data1 { get; set; }
+        
+        [Key(1)]
+        public string Data2 { get; set; }
+
+        [Key(2)]
+        public int this[int i] { get { return 0; } }
+    }
+    
+    public class WithIndexerContractless
+    {
+        public int Data1 { get; set; }
+        public string Data2 { get; set; }
+        public int this[int i] { get { return 0; } }
+    }
 }
 
 namespace Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad

--- a/src/MessagePack/Internal/ReflectionExtensions.cs
+++ b/src/MessagePack/Internal/ReflectionExtensions.cs
@@ -28,6 +28,11 @@ namespace MessagePack.Internal
                 && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
         }
 
+        public static bool IsIndexer(this System.Reflection.PropertyInfo propertyInfo)
+        {
+            return propertyInfo.GetIndexParameters().Length > 0;
+        }
+
 #if NETSTANDARD1_4
 
         public static bool IsConstructedGenericType(this System.Reflection.TypeInfo type)

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1239,6 +1239,7 @@ typeof(int), typeof(int) });
                 {
                     if (item.GetCustomAttribute<IgnoreMemberAttribute>(true) != null) continue;
                     if (item.GetCustomAttribute<IgnoreDataMemberAttribute>(true) != null) continue;
+                    if (item.IsIndexer()) continue;
 
                     var member = new EmittableMember
                     {

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1295,6 +1295,7 @@ typeof(int), typeof(int) });
                 {
                     if (item.GetCustomAttribute<IgnoreMemberAttribute>(true) != null) continue;
                     if (item.GetCustomAttribute<IgnoreDataMemberAttribute>(true) != null) continue;
+                    if (item.IsIndexer()) continue;
 
                     var member = new EmittableMember
                     {

--- a/tests/MessagePack.Tests/ContractlessStandardResolverTest.cs
+++ b/tests/MessagePack.Tests/ContractlessStandardResolverTest.cs
@@ -76,14 +76,6 @@ namespace MessagePack.Tests
             public int OAFADFZEWFSDFSDFKSLJFWEFNWOZFUSEWWEFWEWFFFFFFFFFFFFFFZFEWBFOWUEGWHOUDGSOGUDSZNOFRWEUFWGOWHOGHWOG000000000000000000000000000000000000000HOGZ { get; set; }
         }
 
-        public class HasIndexer
-        {
-            public int Data1 { get; set; }
-            public string Data2 { get; set; }
-
-            public int this[int i] { get { return 0; } }
-        }
-
         [Fact]
         public void SimpleTest()
         {
@@ -191,20 +183,6 @@ namespace MessagePack.Tests
             };
             var bin = MessagePack.MessagePackSerializer.Serialize(o, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var v = MessagePackSerializer.Deserialize<LongestString>(bin, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
-
-            v.IsStructuralEqual(o);
-        }
-
-        [Fact]
-        public void IndexerCheck()
-        {
-            var o = new HasIndexer
-            {
-                Data1 = 15,
-                Data2 = "15"
-            };
-            var bin = MessagePack.MessagePackSerializer.Serialize(o, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
-            var v = MessagePackSerializer.Deserialize<HasIndexer>(bin, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
             v.IsStructuralEqual(o);
         }

--- a/tests/MessagePack.Tests/ContractlessStandardResolverTest.cs
+++ b/tests/MessagePack.Tests/ContractlessStandardResolverTest.cs
@@ -76,7 +76,13 @@ namespace MessagePack.Tests
             public int OAFADFZEWFSDFSDFKSLJFWEFNWOZFUSEWWEFWEWFFFFFFFFFFFFFFZFEWBFOWUEGWHOUDGSOGUDSZNOFRWEUFWGOWHOGHWOG000000000000000000000000000000000000000HOGZ { get; set; }
         }
 
-   
+        public class HasIndexer
+        {
+            public int Data1 { get; set; }
+            public string Data2 { get; set; }
+
+            public int this[int i] { get { return 0; } }
+        }
 
         [Fact]
         public void SimpleTest()
@@ -185,6 +191,20 @@ namespace MessagePack.Tests
             };
             var bin = MessagePack.MessagePackSerializer.Serialize(o, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var v = MessagePackSerializer.Deserialize<LongestString>(bin, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+
+            v.IsStructuralEqual(o);
+        }
+
+        [Fact]
+        public void IndexerCheck()
+        {
+            var o = new HasIndexer
+            {
+                Data1 = 15,
+                Data2 = "15"
+            };
+            var bin = MessagePack.MessagePackSerializer.Serialize(o, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            var v = MessagePackSerializer.Deserialize<HasIndexer>(bin, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
             v.IsStructuralEqual(o);
         }

--- a/tests/MessagePack.Tests/ObjectResolverTest.cs
+++ b/tests/MessagePack.Tests/ObjectResolverTest.cs
@@ -336,5 +336,33 @@ namespace MessagePack.Tests
                 re.MyProperty.Is(1000);
             }
         }
+        
+        [Fact]
+        public void WithIndexer()
+        {
+            var o = new WithIndexer
+            {
+                Data1 = 15,
+                Data2 = "15"
+            };
+            var bin = MessagePack.MessagePackSerializer.Serialize(o, MessagePack.Resolvers.StandardResolver.Instance);
+            var v = MessagePackSerializer.Deserialize<WithIndexer>(bin, MessagePack.Resolvers.StandardResolver.Instance);
+
+            v.IsStructuralEqual(o);
+        }
+        
+        [Fact]
+        public void WithIndexerContractless()
+        {
+            var o = new WithIndexerContractless
+            {
+                Data1 = 15,
+                Data2 = "15"
+            };
+            var bin = MessagePack.MessagePackSerializer.Serialize(o, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            var v = MessagePackSerializer.Deserialize<WithIndexerContractless>(bin, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+
+            v.IsStructuralEqual(o);
+        }
     }
 }

--- a/tests/MessagePack.Tests/Utils/ChainingAssertion.Xunit.cs
+++ b/tests/MessagePack.Tests/Utils/ChainingAssertion.Xunit.cs
@@ -471,7 +471,8 @@ namespace Xunit
 
             // is object
             var fields = left.GetType().GetTypeInfo().GetFields(BindingFlags.Instance | BindingFlags.Public);
-            var properties = left.GetType().GetTypeInfo().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.GetGetMethod(false) != null);
+            var properties = left.GetType().GetTypeInfo().GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(x => x.GetGetMethod(false) != null && x.GetIndexParameters().Length == 0);
             var members = fields.Cast<MemberInfo>().Concat(properties);
 
             foreach (dynamic mi in fields.Cast<MemberInfo>().Concat(properties))


### PR DESCRIPTION
Hi! I'm new with OS (actually this is my first PR), so trying to help with small tasks.

Here I fixed bug, where indexers were treated as serializable properties in dynamic code generation ( `DynamicObjectResolver` ). Also I've adopted testing `IsStructuralEqual` method to match correct properties requirements.

The main motivation is that every indexer cannot be declared without body, so they're always representing syntactic sugar for method, thereby cannot by serialized as data.

[Related issue.](https://github.com/neuecc/MessagePack-CSharp/issues/138)