### PR TITLE
Make OldSpecFormatters' constructor public

### DIFF
--- a/src/MessagePack/Formatters/OldSpecFormatter.cs
+++ b/src/MessagePack/Formatters/OldSpecFormatter.cs
@@ -98,11 +98,6 @@ namespace MessagePack.Formatters
     {
         public static readonly OldSpecStringFormatter Instance = new OldSpecStringFormatter();
 
-        OldSpecStringFormatter()
-        {
-
-        }
-
         // Old spec does not exists str 8 format.
         public int Serialize(ref byte[] bytes, int offset, string value, IFormatterResolver formatterResolver)
         {
@@ -178,11 +173,6 @@ namespace MessagePack.Formatters
     public sealed class OldSpecBinaryFormatter : IMessagePackFormatter<byte[]>
     {
         public static readonly OldSpecBinaryFormatter Instance = new OldSpecBinaryFormatter();
-
-        OldSpecBinaryFormatter()
-        {
-
-        }
 
         public int Serialize(ref byte[] bytes, int offset, byte[] value, IFormatterResolver formatterResolver)
         {


### PR DESCRIPTION
I tried to use the new `MessagePackFormatterAtribute` to deserialize an old spec MessagePack data.
But I got an error because the `OldSpecBinaryFormatter` does not have public constructor.


```c#
[DataContract]
public class Foo
{
    [DataMember]
    public int Id { get; set; }

    [DataMember]
    [MessagePackFormatter(typeof(OldSpecBinaryFormatter))]
    public byte[] Value { get; set; }
}
```
```c#
// serialize by MsgPack.Cli using old spec 
private static byte[] SerializeByClassicMsgPack<T>(T obj)
{
    var context = new MsgPack.Serialization.SerializationContext
    {
        SerializationMethod = MsgPack.Serialization.SerializationMethod,Map,
        CompatibilityOptions = { PackerCompatibilityOptions = MsgPack.PackerCompatibilityOptions.Classic }
    };
    var serializer = MsgPack.Serialization.MessagePackSerializer.Get<T>(context);
    using (var memory = new MemoryStream())
    {
        serializer.Pack(memory, obj);
        return memory.ToArray();
    }
}
```
```c#
var foo = new Foo {
    Id = 123,
    Value = new byte[]{ 1,2,3 }
};

// serialize by MsgPack.Cli using old spec 
var messagePackBytes = SerializeByClassicMsgPack(foo);

// an execption occurs
var deserializedFoo = MessagePackSerializer.Deserialize<Foo>(messagePackBytes);
```

Error message:
```
System.MissingMethodException
型 'MessagePack.Formatters.OldSpecBinaryFormatter' にコンストラクターが見つかりませんでした。
   場所 MessagePack.FormatterResolverExtensions.GetFormatterWithVerify[T](IFormatterResolver resolver)
   場所 MessagePack.MessagePackSerializer.Deserialize[T](Byte[] bytes, IFormatterResolver resolver)
   場所 MessagePack.MessagePackSerializer.Deserialize[T](Byte[] bytes)
   場所 MessagePack.Tests.OldSpecBinaryFormatterTest.DeserializeObject(Int32 arrayLength) 場所 C:\Projects\MessagePack-CSharp\tests\MessagePack.Tests\OldSpecBinaryFormatterTest.cs:行 81

```

This pull request is to make serialization for old spec data easier.