### PR TITLE
TypelessFormatter allow to customize BindToType

### DIFF
--- a/src/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack/Formatters/TypelessFormatter.cs
@@ -75,14 +75,9 @@ namespace MessagePack.Formatters
             typeof(Double?),
         };
 
-        public Func<string, Type> BindToType { get; set; }
+        public static Func<string, Type> BindToType { get; set; }
 
-        public TypelessFormatter()
-        {
-            BindToType = DefaultBindToType;
-        }
-
-        Type DefaultBindToType(string typeName)
+        static Type DefaultBindToType(string typeName)
         {
             return Type.GetType(typeName, false);
         }
@@ -111,6 +106,8 @@ namespace MessagePack.Formatters
                 p5 = 0;
                 return new object();
             }));
+
+            BindToType = DefaultBindToType;
         }
 
         // see:http://msdn.microsoft.com/en-us/library/w3f99sx1.aspx

--- a/src/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack/Formatters/TypelessFormatter.cs
@@ -75,6 +75,18 @@ namespace MessagePack.Formatters
             typeof(Double?),
         };
 
+        public Func<string, Type> BindToType { get; set; }
+
+        public TypelessFormatter()
+        {
+            BindToType = DefaultBindToType;
+        }
+
+        Type DefaultBindToType(string typeName)
+        {
+            return Type.GetType(typeName, false);
+        }
+
         // mscorlib or System.Private.CoreLib
         static bool isMscorlib = typeof(int).AssemblyQualifiedName.Contains("mscorlib");
 
@@ -251,7 +263,7 @@ namespace MessagePack.Formatters
                 var buffer = new byte[typeName.Count];
                 Buffer.BlockCopy(typeName.Array, typeName.Offset, buffer, 0, buffer.Length);
                 var str = StringEncoding.UTF8.GetString(buffer);
-                type = Type.GetType(str, false);
+                type = BindToType(str);
                 if (type == null)
                 {
                     if (isMscorlib && str.Contains("System.Private.CoreLib"))
@@ -318,6 +330,7 @@ namespace MessagePack.Formatters
             return formatterAndDelegate.Value(formatterAndDelegate.Key, bytes, offset, formatterResolver, out readSize);
         }
     }
+
 }
 
 #endif


### PR DESCRIPTION
Hi,
given object stored for long period of time, this allow the code base to be refactored, because it allow users to customize how a type is resolved.
Here is an usage example : 

 ((MessagePack.Formatters.TypelessFormatter)MessagePack.Formatters.TypelessFormatter.Instance).BindToType = typeName =>
            {
                if (typeName.StartsWith("SomeNamespace"))
                {
                    typeName = typeName.Replace("SomeNamespace", "AnotherNamespace");
                }
                return Type.GetType(typeName, false);
            };

I'm not entirely happy with usage because of the .Instance and the cast.