### PR TITLE
Remove trailing whitespace on MessagePack.CodeGenerator text templates

### DIFF
--- a/src/MessagePack.CodeGenerator/Generator/EnumTemplate.tt
+++ b/src/MessagePack.CodeGenerator/Generator/EnumTemplate.tt
@@ -20,7 +20,7 @@ namespace <#= Namespace #>
         {
             return MessagePackBinary.Write<#= info.UnderlyingType #>(ref bytes, offset, (<#= info.UnderlyingType #>)value);
         }
-        
+
         public <#= info.FullName #> Deserialize(byte[] bytes, int offset, global::MessagePack.IFormatterResolver formatterResolver, out int readSize)
         {
             return (<#= info.FullName #>)MessagePackBinary.Read<#= info.UnderlyingType #>(bytes, offset, out readSize);

--- a/src/MessagePack.CodeGenerator/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.CodeGenerator/Generator/FormatterTemplate.tt
@@ -35,7 +35,7 @@ namespace <#= Namespace #>
             {
 <# foreach(var x in objInfo.Members.Where(x => x.IsReadable)) { #>
                 global::MessagePack.MessagePackBinary.GetEncodedStringBytes("<#= x.StringKey #>"),
-<# } #>                
+<# } #>
             };
         }
 
@@ -48,7 +48,7 @@ namespace <#= Namespace #>
             {
                 return global::MessagePack.MessagePackBinary.WriteNil(ref bytes, offset);
             }
-<# } #>            
+<# } #>
 <#if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBefore) { #>
             ((IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
 <# } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { #>

--- a/src/MessagePack.CodeGenerator/Generator/UnionTemplate.tt
+++ b/src/MessagePack.CodeGenerator/Generator/UnionTemplate.tt
@@ -60,7 +60,7 @@ namespace <#= Namespace #>
 
             return MessagePackBinary.WriteNil(ref bytes, offset);
         }
-        
+
         public <#= info.FullName #> Deserialize(byte[] bytes, int offset, global::MessagePack.IFormatterResolver formatterResolver, out int readSize)
         {
             if (MessagePackBinary.IsNil(bytes, offset))
@@ -98,9 +98,9 @@ namespace <#= Namespace #>
                     offset += MessagePackBinary.ReadNextBlock(bytes, offset);
                     break;
             }
-            
+
             readSize = offset - startOffset;
-            
+
             return result;
         }
     }


### PR DESCRIPTION
Output file MessagePackGenerated.cs has some white spaces on it, so I removed whitespaces on text templates.
(should re-generate changed text template as cs, I didn`t committed generated cs cause auto-generated comments/write file path has been changed due to my environment.)