### PR TITLE
Adding implicit conversion from byte[] to string and backward

### DIFF
--- a/src/MessagePack/MessagePackBinary.cs
+++ b/src/MessagePack/MessagePackBinary.cs
@@ -179,8 +179,12 @@ namespace MessagePack
                 stringDecoders[i] = Decoders.FixString.Instance;
                 stringSegmentDecoders[i] = Decoders.FixStringSegment.Instance;
                 readNextDecoders[i] = Decoders.ReadNextFixStr.Instance;
+                bytesDecoders[i] = Decoders.FixBytes.Instance;
             }
 
+            stringDecoders[MessagePackCode.Bin8] = Decoders.Str8String.Instance;
+            stringDecoders[MessagePackCode.Bin16] = Decoders.Str16String.Instance;
+            stringDecoders[MessagePackCode.Bin32] = Decoders.Str32String.Instance;
             stringDecoders[MessagePackCode.Str8] = Decoders.Str8String.Instance;
             stringDecoders[MessagePackCode.Str16] = Decoders.Str16String.Instance;
             stringDecoders[MessagePackCode.Str32] = Decoders.Str32String.Instance;
@@ -206,6 +210,9 @@ namespace MessagePack
             bytesDecoders[MessagePackCode.Bin8] = Decoders.Bin8Bytes.Instance;
             bytesDecoders[MessagePackCode.Bin16] = Decoders.Bin16Bytes.Instance;
             bytesDecoders[MessagePackCode.Bin32] = Decoders.Bin32Bytes.Instance;
+            bytesDecoders[MessagePackCode.Str8] = Decoders.Bin8Bytes.Instance;
+            bytesDecoders[MessagePackCode.Str16] = Decoders.Bin16Bytes.Instance;
+            bytesDecoders[MessagePackCode.Str32] = Decoders.Bin32Bytes.Instance;
             bytesSegmentDecoders[MessagePackCode.Bin8] = Decoders.Bin8BytesSegment.Instance;
             bytesSegmentDecoders[MessagePackCode.Bin16] = Decoders.Bin16BytesSegment.Instance;
             bytesSegmentDecoders[MessagePackCode.Bin32] = Decoders.Bin32BytesSegment.Instance;
@@ -3655,6 +3662,26 @@ namespace MessagePack.Decoders
         {
             readSize = 1;
             return null;
+        }
+    }
+
+    internal sealed class FixBytes : IBytesDecoder
+    {
+        internal static readonly IBytesDecoder Instance = new FixBytes();
+
+        FixBytes()
+        {
+
+        }
+
+        public byte[] Read(byte[] bytes, int offset, out int readSize)
+        {
+            var length = bytes[offset] & 0x1F;
+            var newBytes = new byte[length];
+            Buffer.BlockCopy(bytes, offset + 1, newBytes, 0, length);
+
+            readSize = length + 1;
+            return newBytes;
         }
     }
 

--- a/tests/MessagePack.Tests/MessagePackBinaryTest.cs
+++ b/tests/MessagePack.Tests/MessagePackBinaryTest.cs
@@ -543,6 +543,33 @@ namespace MessagePack.Tests
 
         [Theory]
         [MemberData(nameof(stringTestData))]
+        public void ImplicitStringBytesConversion(string target)
+        {
+            var targetBytes = Encoding.UTF8.GetBytes(target);
+            {
+                byte[] bytes = null;
+
+                var writtenBytes = MessagePackBinary.WriteString(ref bytes, 0, target);
+                int readBytes;
+                var result = MessagePackBinary.ReadBytes(bytes, 0, out readBytes);
+
+                readBytes.Is(writtenBytes);
+                result.Is(targetBytes);
+            }
+            {
+                byte[] bytes = null;
+
+                var writtenBytes = MessagePackBinary.WriteBytes(ref bytes, 0, targetBytes);
+                int readBytes;
+                var result = MessagePackBinary.ReadString(bytes, 0, out readBytes);
+
+                readBytes.Is(writtenBytes);
+                result.Is(target);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(stringTestData))]
         public void StringSegmentTest(string target)
         {
             (var stream, var packer) = CreateReferencePacker();


### PR DESCRIPTION
This PR adds a support for implicit conversions from byte arrays to string and from strings to byte arrays. The initial idea was to add support for languages such as Python that use a common representation for both types, as illustrated in the example:
```>>> msgpack.dumps("ABC")
b'\xa3ABC'
>>> msgpack.dumps(b"ABC")
b'\xa3ABC'
>>> msgpack.dumps("\x01\x02\x03")
b'\xa3\x01\x02\x03'
>>> msgpack.dumps(b"\x01\x02\x03")
b'\xa3\x01\x02\x03'
```
In this case both binary data and a standard string were serialized to 0xA3 (FixStr3). It raises problems when you want to send data like this:
`{"filename": "image.png", "content": "\x89PNG\x0D\x0A\x1A\x0A..."}`

On C# side, when deserializing, an intuitive choice would be to use `string` type for the first field and `byte[]` for the second but because the content was marked as 0xA3 we are forced to use `string` for the second field too. This, on the other hand, creates a performance problem when encoding large binary data. For 100MB content transmited this way, an invocation of `Encoding.UTF8.GetBytes` may take up to 3 seconds (where the real deserialization time is ~300ms). To overcome this problem the library user is forced to create his own formatter resolver for `byte[]` type and manually deserialize MessagePack bytes. Because library decoders are internal code, the user can't even reuse the standard deserialization procecures but he needs to implement them on his own. In short, in order to achieve a simple goal of deserializing string as byte array we need to use quite complex constructs.

This patch solves the problem by registering string decoders for `Bin8`, `Bin16` and `Bin32` codes and bytes decoders for all fix strings, `Str8`, `Str16` and `Str32`. The backward compability is not affected. The performance is affected only in a positive way for certain scenarios (as mentioned above).
