### PR TITLE
Re-throw an exception without losing the original context

### DIFF
--- a/src/MessagePack/IFormatterResolver.cs
+++ b/src/MessagePack/IFormatterResolver.cs
@@ -2,6 +2,7 @@
 using MessagePack.Formatters;
 using System;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 namespace MessagePack
 {
@@ -27,7 +28,8 @@ namespace MessagePack
                     inner = inner.InnerException;
                 }
 
-                throw inner;
+                ExceptionDispatchInfo.Capture(inner).Throw(); // rethrow
+                throw inner; // this is never called
             }
 
             if (formatter == null)


### PR DESCRIPTION
When you have an exception `ex` and re-throw it with `throw ex`, its stack trace is overwritten with a new one. You can preserve its stack trace with an `ExceptionServices` helper function.