### PR TITLE
add DataContractSerializerResolver to simulate DataContractSerializer…

### DIFF
--- a/src/MessagePack/Resolvers/ContractlessReflectionObjectResolver.cs
+++ b/src/MessagePack/Resolvers/ContractlessReflectionObjectResolver.cs
@@ -20,6 +20,7 @@ namespace MessagePack.Resolvers
             const bool ForceStringKey = false;
             const bool Contractless = false;
             const bool AllowPrivate = false;
+            const bool SimulateDataContractSerializer = false;
 
             public IMessagePackFormatter<T> GetFormatter<T>()
             {
@@ -32,7 +33,7 @@ namespace MessagePack.Resolvers
 
                 static Cache()
                 {
-                    var metaInfo = ObjectSerializationInfo.CreateOrNull(typeof(T), ForceStringKey, Contractless, AllowPrivate);
+                    var metaInfo = ObjectSerializationInfo.CreateOrNull(typeof(T), ForceStringKey, Contractless, AllowPrivate, SimulateDataContractSerializer);
                     if (metaInfo != null)
                     {
                         formatter = new ReflectionObjectFormatter<T>(metaInfo);
@@ -46,6 +47,7 @@ namespace MessagePack.Resolvers
             const bool ForceStringKey = false;
             const bool Contractless = true;
             const bool AllowPrivate = false;
+            const bool SimulateDataContractSerializer = false;
 
             public IMessagePackFormatter<T> GetFormatter<T>()
             {
@@ -58,7 +60,7 @@ namespace MessagePack.Resolvers
 
                 static Cache()
                 {
-                    var metaInfo = ObjectSerializationInfo.CreateOrNull(typeof(T), ForceStringKey, Contractless, AllowPrivate);
+                    var metaInfo = ObjectSerializationInfo.CreateOrNull(typeof(T), ForceStringKey, Contractless, AllowPrivate, SimulateDataContractSerializer);
                     if (metaInfo != null)
                     {
                         formatter = new ReflectionObjectFormatter<T>(metaInfo);
@@ -72,6 +74,7 @@ namespace MessagePack.Resolvers
             const bool ForceStringKey = true;
             const bool Contractless = true;
             const bool AllowPrivate = false;
+            const bool SimulateDataContractSerializer = false;
 
             public IMessagePackFormatter<T> GetFormatter<T>()
             {
@@ -84,7 +87,7 @@ namespace MessagePack.Resolvers
 
                 static Cache()
                 {
-                    var metaInfo = ObjectSerializationInfo.CreateOrNull(typeof(T), ForceStringKey, Contractless, AllowPrivate);
+                    var metaInfo = ObjectSerializationInfo.CreateOrNull(typeof(T), ForceStringKey, Contractless, AllowPrivate, SimulateDataContractSerializer);
                     if (metaInfo != null)
                     {
                         formatter = new ReflectionObjectFormatter<T>(metaInfo);

--- a/tests/MessagePack.Tests/DataContractTest.cs
+++ b/tests/MessagePack.Tests/DataContractTest.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿using MessagePack.Formatters;
+using MessagePack.Resolvers;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -36,6 +39,29 @@ namespace MessagePack.Tests
             [DataMember]
             public string MyProperty2;
         }
+
+        [DataContract]
+        public class PublicPropWithoutAttrModel
+        {
+            public string PublicProp { get; set; }
+            public string PublicFld;
+            [DataMember]
+            internal string PrivateProp { get; set; }
+            [DataMember]
+            internal string PrivateFld;
+            [DataMember]
+            public SubModel Sub { get; set; }
+            [DataMember]
+            public string AttrPublicProp { get; set; }
+        }
+
+        public class SubModel
+        {
+            public string SubPublicProp { get; set; }
+            internal string SubPrivateProp { get; set; }
+        }
+
+
 
         [Fact]
         public void SerializeOrder()
@@ -79,5 +105,70 @@ namespace MessagePack.Tests
 
             MessagePackSerializer.ToJson(bin).Is(@"{""MyProperty1"":100,""MyProperty2"":""foobar""}");
         }
+
+        [Fact]
+        public void SimulateDataContractSerializer()
+        {
+            var model = new PublicPropWithoutAttrModel
+            {
+                PublicProp = "a",
+                PublicFld = "b",
+                PrivateProp = "i",
+                PrivateFld = "j",
+                Sub = new SubModel { SubPublicProp = "sub1", SubPrivateProp = "sub2" },
+                AttrPublicProp = "zzz"
+            };
+
+            //compare DataContractSerializerResolver clone
+            var resolver = DataContractSerializerCompositeResolver.Instance;
+            var packBin = MessagePackSerializer.Serialize(model, resolver);
+            var packModel = MessagePackSerializer.Deserialize<PublicPropWithoutAttrModel>(packBin, resolver);
+            packModel.PublicProp.Is(default(string));
+            packModel.PublicFld.Is(default(string));
+            packModel.PrivateProp.Is(model.PrivateProp);
+            packModel.PrivateFld.Is(model.PrivateFld);
+            packModel.AttrPublicProp.Is(model.AttrPublicProp);
+            packModel.Sub.IsNotNull();
+            packModel.Sub.SubPublicProp.Is(model.Sub.SubPublicProp);
+            packModel.Sub.SubPrivateProp.Is(default(string));
+
+            MessagePackSerializer.ToJson(packBin).Is(@"{""PrivateProp"":""i"",""Sub"":{""SubPublicProp"":""sub1""},""AttrPublicProp"":""zzz"",""PrivateFld"":""j""}");
+
+            //compare MessagePackSerializer and DataContractSerializer
+            var dataContractSerializer = new DataContractSerializer(typeof(PublicPropWithoutAttrModel));
+            var dataStream = new MemoryStream();
+            dataContractSerializer.WriteObject(dataStream, model);
+            dataStream.Position = 0;
+            var dataModel = (PublicPropWithoutAttrModel)dataContractSerializer.ReadObject(dataStream);
+            dataStream.Dispose();
+            dataModel.PublicProp.Is(packModel.PublicProp);
+            dataModel.PublicFld.Is(packModel.PublicFld);
+            dataModel.PrivateProp.Is(packModel.PrivateProp);
+            dataModel.PrivateFld.Is(packModel.PrivateFld);
+            dataModel.AttrPublicProp.Is(packModel.AttrPublicProp);
+            dataModel.Sub.IsNotNull();
+            dataModel.Sub.SubPublicProp.Is(packModel.Sub.SubPublicProp);
+            dataModel.Sub.SubPrivateProp.Is(packModel.Sub.SubPrivateProp);
+        }
+
+        internal sealed class DataContractSerializerCompositeResolver : IFormatterResolver
+        {
+            public static IFormatterResolver Instance = new DataContractSerializerCompositeResolver();
+            static readonly IFormatterResolver[] resolvers = new[]
+            {
+                DataContractSerializerResolver.Instance,
+                ContractlessStandardResolver.Instance
+            };
+
+            DataContractSerializerCompositeResolver() { }
+
+            public IMessagePackFormatter<T> GetFormatter<T>() => FormatterCache<T>.formatter;
+
+            static class FormatterCache<T>
+            {
+                public static readonly IMessagePackFormatter<T> formatter = resolvers.Select(n => n.GetFormatter<T>()).FirstOrDefault(f => f != null);
+            }
+        }
+
     }
 }

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -88,6 +88,7 @@
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>


### PR DESCRIPTION
for issue #292 

add DataContractSerializerResolver to simulate DataContractSerializer behavior for DataContractAttribute.
detail implement in MessagePack.Internal.ObjectSerializationInfo's CreateOrNull.
I add a argument "bool simulateDataContractSerializer", 
* if allowPrivateoriginal behavior, include private member. when without DataMemberAttribute then throw exception.
* if !allowPrivate and !simulateDataContractSerializer, same original behavior, skip private member. then throw exception when without DataMemberAttribute.
* if !allowPrivate and simulateDataContractSerializer, include all member with DataMemberAttribute.
