### PR TITLE
throw exception when getting attribute's metadata is failed.(#355)

### DIFF
--- a/src/MessagePack.UniversalCodeGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.UniversalCodeGenerator/CodeAnalysis/TypeCollector.cs
@@ -20,14 +20,46 @@ namespace MessagePack.CodeGenerator
         public ReferenceSymbols(Compilation compilation)
         {
             TaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            if(TaskOfT == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of System.Threading.Tasks.Task`1");
+            }
             Task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+            if (Task == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of System.Threading.Tasks.Task");
+            }
             MessagePackObjectAttribute = compilation.GetTypeByMetadataName("MessagePack.MessagePackObjectAttribute");
+            if (MessagePackObjectAttribute == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of MessagePack.MessagePackObjectAttribute");
+            }
             UnionAttribute = compilation.GetTypeByMetadataName("MessagePack.UnionAttribute");
+            if (UnionAttribute == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of MessagePack.UnionAttribute");
+            }
             SerializationConstructorAttribute = compilation.GetTypeByMetadataName("MessagePack.SerializationConstructorAttribute");
+            if (SerializationConstructorAttribute == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of MessagePack.SerializationConstructorAttribute");
+            }
             KeyAttribute = compilation.GetTypeByMetadataName("MessagePack.KeyAttribute");
+            if (KeyAttribute == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of MessagePack.KeyAttribute");
+            }
             IgnoreAttribute = compilation.GetTypeByMetadataName("MessagePack.IgnoreMemberAttribute");
+            if (IgnoreAttribute == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of MessagePack.IgnoreMemberAttribute");
+            }
             IgnoreDataMemberAttribute = compilation.GetTypeByMetadataName("System.Runtime.Serialization.IgnoreDataMemberAttribute");
             IMessagePackSerializationCallbackReceiver = compilation.GetTypeByMetadataName("MessagePack.IMessagePackSerializationCallbackReceiver");
+            if (IMessagePackSerializationCallbackReceiver == null)
+            {
+                throw new InvalidOperationException("failed to get metadata of MessagePack.IMessagePackSerializationCallbackReceiver");
+            }
         }
     }
 

--- a/src/MessagePack.UniversalCodeGenerator/Utils/RoslynExtensions.cs
+++ b/src/MessagePack.UniversalCodeGenerator/Utils/RoslynExtensions.cs
@@ -25,7 +25,8 @@ namespace MessagePack.CodeGenerator
             // https://github.com/daveaglick/Buildalyzer/blob/b42d2e3ba1b3673a8133fb41e72b507b01bce1d6/src/Buildalyzer/Environment/BuildEnvironment.cs#L86-L96
             Dictionary<string, string> properties = new Dictionary<string, string>()
                 {
-                    {"IntermediateOutputPath", tempPath},
+                    // trailing '\' may cause unexpected escape
+                    {"IntermediateOutputPath", tempPath + "/"},
                     {"ProviderCommandLineArgs", "true"},
                     {"GenerateResourceMSBuildArchitecture", "CurrentArchitecture"},
                     {"DesignTimeBuild", "true"},
@@ -40,7 +41,7 @@ namespace MessagePack.CodeGenerator
                     {"UseCommonOutputDirectory", "true"},
                     {"GeneratePackageOnBuild", "false"},
                     {"RunPostBuildEvent", "false"},
-                    {"SolutionDir", new FileInfo(csprojPath).FullName}
+                    {"SolutionDir", (new FileInfo(csprojPath).Directory.FullName) + "/"}
                 };
             var propargs = string.Join(" ", properties.Select(kv => $"/p:{kv.Key}=\"{kv.Value}\""));
             // how to determine whether command should be executed('dotnet msbuild' or 'msbuild')?


### PR DESCRIPTION
This PR makes mpc to throw Exception when getting attribute's metadata is failed.
This may help the issue #355

non-MessagePack's class or attribute cannot be gotten when project has no reference(e.g. `System.Runtime.Serialization.IgnoreDataMemberAttribute`)
