### PR TITLE
Set up event source for easier perf investigations

### DIFF
--- a/sandbox/PerfNetFramework/BenchmarkEventSource.cs
+++ b/sandbox/PerfNetFramework/BenchmarkEventSource.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PerfNetFramework
+{
+    [EventSource(Name = "MessagePack-Benchmark")]
+    internal sealed class BenchmarkEventSource : EventSource
+    {
+        private const int MessagePackSerializeStartEvent = 1;
+        private const int MessagePackSerializeStopEvent = 2;
+        private const int MessagePackDeserializeStartEvent = 3;
+        private const int MessagePackDeserializeStopEvent = 4;
+        private const int MessagePackSessionStartEvent = 5;
+        private const int MessagePackSessionStopEvent = 6;
+
+        internal static readonly BenchmarkEventSource Instance = new BenchmarkEventSource();
+
+        private BenchmarkEventSource() { }
+
+        /// <summary>
+        /// Marks the start of a serialization benchmark.
+        /// </summary>
+        /// <param name="impl">The library performing the serialization.</param>
+        [Event(MessagePackSerializeStartEvent, Task = Tasks.Serialize, Opcode = EventOpcode.Start)]
+        public void Serialize(string impl)
+        {
+            this.WriteEvent(MessagePackSerializeStartEvent, impl);
+        }
+
+        [Event(MessagePackSerializeStopEvent, Task = Tasks.Serialize, Opcode = EventOpcode.Stop)]
+        public void SerializeEnd()
+        {
+            this.WriteEvent(MessagePackSerializeStopEvent);
+        }
+
+        /// <summary>
+        /// Marks the start of a deserialization benchmark.
+        /// </summary>
+        /// <param name="impl">The library performing the serialization.</param>
+        [Event(MessagePackDeserializeStartEvent, Task = Tasks.Deserialize, Opcode = EventOpcode.Start)]
+        public void Deserialize(string impl)
+        {
+            this.WriteEvent(MessagePackDeserializeStartEvent, impl);
+        }
+
+        [Event(MessagePackDeserializeStopEvent, Task = Tasks.Deserialize, Opcode = EventOpcode.Stop)]
+        public void DeserializeEnd()
+        {
+            this.WriteEvent(MessagePackDeserializeStopEvent);
+        }
+
+        [Event(MessagePackSessionStartEvent, Task = Tasks.Session, Opcode = EventOpcode.Start)]
+        public void Session(int count)
+        {
+            this.WriteEvent(MessagePackSessionStartEvent, count);
+        }
+
+        [Event(MessagePackSessionStopEvent, Task = Tasks.Session, Opcode = EventOpcode.Stop)]
+        public void SessionEnd()
+        {
+            this.WriteEvent(MessagePackSessionStopEvent);
+        }
+
+        internal static class Tasks
+        {
+            internal const EventTask Session = (EventTask)1;
+            internal const EventTask Serialize = (EventTask)2;
+            internal const EventTask Deserialize = (EventTask)3;
+        }
+    }
+}

--- a/sandbox/PerfNetFramework/README.md
+++ b/sandbox/PerfNetFramework/README.md
@@ -1,0 +1,26 @@
+﻿# Performance analysis
+
+Build and use the release configuration of the project so you're measuring real perf with optimizations turned on:
+
+    dotnet build -c release  .\sandbox\PerfNetFramework\
+
+Use [PerfView](https://github.com/Microsoft/perfview/blob/master/documentation/Downloading.md) to analyze performance
+to look for opportunities to improve.
+When collecting ETL traces, use these settings in the Collect->Run dialog:
+
+| Setting     | Value |
+|-------------|-------|
+| Command     | `dotnet run -c release -p .\sandbox\PerfNetFramework\ -f net461 --no-build`
+| Current Dir | `d:\git\messagepack-csharp` (or wherever your enlistment is)
+| Additional Providers | `*MessagePack-Benchmark`
+| No V3.X NGen | Checked
+
+Start your investigation using the Events window to find the scenario that you're interested in,
+with these settings:
+
+| Setting    | Value |
+|------------|-------|
+| Filter     | `MessagePack`
+| Columns to display | `count DURATION_MSEC impl`
+
+Select the two `Time MSec` values that bound the scenario you're interested in, right-click and select CPU Stacks.


### PR DESCRIPTION
This makes PerfView perf investigations much easier to find the right time range to investigate:

![image](https://user-images.githubusercontent.com/3548/52894868-db2b0b80-3165-11e9-845f-400e4d9ba88a.png)
