### PR TITLE
Typo cleanup

### DIFF
--- a/src/MessagePack.UniversalCodeGenerator/Properties/launchSettings.json
+++ b/src/MessagePack.UniversalCodeGenerator/Properties/launchSettings.json
@@ -1,9 +1,0 @@
-{
-  "profiles": {
-    "MessagePack.UniversalCodeGenerator": {
-      "commandName": "Project",
-      "commandLineArgs": "-i .\\sandbox\\shareddata\\shareddata.csproj -o .\\sandbox\\Sandbox\\Generated.cs",
-      "workingDirectory": "D:\\git\\MessagePack-CSharp"
-    }
-  }
-}

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -417,7 +417,7 @@ namespace MessagePack.Internal
             }
             foreach (var item in serializationInfo.Members.Where(x => x.IsReadable))
             {
-                var attr = item.GetMessagePackFormatterAttribtue();
+                var attr = item.GetMessagePackFormatterAttribute();
                 if (attr != null)
                 {
                     var formatter = Activator.CreateInstance(attr.FormatterType, attr.Arguments);
@@ -430,7 +430,7 @@ namespace MessagePack.Internal
             }
             foreach (var item in serializationInfo.Members) // not only for writable because for use ctor.
             {
-                var attr = item.GetMessagePackFormatterAttribtue();
+                var attr = item.GetMessagePackFormatterAttribute();
                 if (attr != null)
                 {
                     var formatter = Activator.CreateInstance(attr.FormatterType, attr.Arguments);
@@ -520,7 +520,7 @@ namespace MessagePack.Internal
             Dictionary<ObjectSerializationInfo.EmittableMember, FieldInfo> dict = new Dictionary<ObjectSerializationInfo.EmittableMember, FieldInfo>();
             foreach (var item in info.Members.Where(x => x.IsReadable || x.IsWritable))
             {
-                var attr = item.GetMessagePackFormatterAttribtue();
+                var attr = item.GetMessagePackFormatterAttribute();
                 if (attr != null)
                 {
                     var f = builder.DefineField(item.Name + "_formatter", attr.FormatterType, FieldAttributes.Private | FieldAttributes.InitOnly);
@@ -1759,7 +1759,7 @@ typeof(int), typeof(int) });
                 }
             }
 
-            public MessagePackFormatterAttribute GetMessagePackFormatterAttribtue()
+            public MessagePackFormatterAttribute GetMessagePackFormatterAttribute()
             {
                 if (IsProperty)
                 {

--- a/src/MessagePack/Resolvers/TypelessObjectResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessObjectResolver.cs
@@ -81,8 +81,8 @@ namespace MessagePack.Resolvers
                 {typeof(UInt64), ForceUInt64BlockFormatter.Instance},
                 {typeof(byte), ForceByteBlockFormatter.Instance},
                 {typeof(sbyte), ForceSByteBlockFormatter.Instance},
-            
-                // Nulllable Primitive
+
+                // Nullable Primitive
                 {typeof(Nullable<Int16>), NullableForceInt16BlockFormatter.Instance},
                 {typeof(Nullable<Int32>), NullableForceInt32BlockFormatter.Instance},
                 {typeof(Nullable<Int64>), NullableForceInt64BlockFormatter.Instance},
@@ -91,8 +91,8 @@ namespace MessagePack.Resolvers
                 {typeof(Nullable<UInt64>), NullableForceUInt64BlockFormatter.Instance},
                 {typeof(Nullable<byte>), NullableForceByteBlockFormatter.Instance},
                 {typeof(Nullable<sbyte>), NullableForceSByteBlockFormatter.Instance},
-            
-                // otpmitized primitive array formatter
+
+                // optimized primitive array formatter
                 {typeof(Int16[]), ForceInt16BlockArrayFormatter.Instance},
                 {typeof(Int32[]), ForceInt32BlockArrayFormatter.Instance},
                 {typeof(Int64[]), ForceInt64BlockArrayFormatter.Instance},


### PR DESCRIPTION
Fix typos in comments, method name.
Remove an errant file that should not have been checked in.