### PR TITLE
replacing Buildalyzer to MSBuild.StructuredLogger for Unity project(#386)

### DIFF
--- a/sandbox/TestData.InvalidProject/Class1.cs
+++ b/sandbox/TestData.InvalidProject/Class1.cs
@@ -1,0 +1,35 @@
+﻿using MessagePack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestData2
+{
+    [MessagePackObject(true)]
+    public class A { public int a; public List<B> bs; public C c; }
+
+    [MessagePackObject(true)]
+    public class B { public List<A> ass; public C c; public int a; }
+
+    [MessagePackObject(true)]
+    public class C { public B b; public int a; }
+
+
+    [MessagePackObject(true)]
+    public class PropNameCheck1
+    {
+        public string MyProperty1 { get; set; }
+        public virtual string MyProperty2 { get; set; }
+    }
+
+    [MessagePackObject(true)]
+    public class PropNameCheck2 : PropNameCheck1
+    {
+        public override string MyProperty2
+        {
+            get => base.MyProperty2;
+             set => base.MyProperty2 = value; }
+    }
+}

--- a/sandbox/TestData.InvalidProject/TestData.InvalidProject.csproj
+++ b/sandbox/TestData.InvalidProject/TestData.InvalidProject.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MessagePack" version="1.6.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" version="4.5.0" />
+    <!-- deliberated msbuild error(source not found) -->
+    <Compile Include="NotExist.cs"/>
+  </ItemGroup>
+</Project>

--- a/sandbox/TestData.InvalidSyntax/Class1.cs
+++ b/sandbox/TestData.InvalidSyntax/Class1.cs
@@ -1,0 +1,37 @@
+﻿using MessagePack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestData.InvalidSyntax
+{
+    // delibrated syntax error
+    abcde
+    [MessagePackObject(true)]
+    public class A { public int a; public List<B> bs; public C c; }
+
+    [MessagePackObject(true)]
+    public class B { public List<A> ass; public C c; public int a; }
+
+    [MessagePackObject(true)]
+    public class C { public B b; public int a; }
+
+
+    [MessagePackObject(true)]
+    public class PropNameCheck1
+    {
+        public string MyProperty1 { get; set; }
+        public virtual string MyProperty2 { get; set; }
+    }
+
+    [MessagePackObject(true)]
+    public class PropNameCheck2 : PropNameCheck1
+    {
+        public override string MyProperty2
+        {
+            get => base.MyProperty2;
+             set => base.MyProperty2 = value; }
+    }
+}

--- a/sandbox/TestData.InvalidSyntax/TestData.InvalidSyntax.csproj
+++ b/sandbox/TestData.InvalidSyntax/TestData.InvalidSyntax.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MessagePack" version="1.6.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/MessagePack.UniversalCodeGenerator/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.UniversalCodeGenerator/CodeAnalysis/TypeCollector.cs
@@ -242,6 +242,11 @@ namespace MessagePack.CodeGenerator
         {
             this.csProjPath = csProjPath;
             var compilation = RoslynExtensions.GetCompilationFromProject(csProjPath, conditinalSymbols.Concat(new[] { CodegeneratorOnlyPreprocessorSymbol }).ToArray()).GetAwaiter().GetResult();
+            var compilationErrors = compilation.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error).ToArray();
+            if(compilationErrors.Length != 0)
+            {
+                throw new InvalidOperationException($"detect compilation error:{string.Join("\n", compilationErrors.Select(x => x.ToString()))}");
+            }
             this.typeReferences = new ReferenceSymbols(compilation);
             this.disallowInternal = disallowInternal;
             this.isForceUseMap = isForceUseMap;

--- a/src/MessagePack.UniversalCodeGenerator/MessagePack.UniversalCodeGenerator.csproj
+++ b/src/MessagePack.UniversalCodeGenerator/MessagePack.UniversalCodeGenerator.csproj
@@ -9,48 +9,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer.Workspaces" Version="2.2.0" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.0.68"/>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Generator\EnumTemplate.cs">
+    <Compile Update="Generator\*.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>EnumTemplate.tt</DependentUpon>
-    </Compile>
-    <Compile Update="Generator\FormatterTemplate.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>FormatterTemplate.tt</DependentUpon>
-    </Compile>
-    <Compile Update="Generator\ResolverTemplate.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>ResolverTemplate.tt</DependentUpon>
-    </Compile>
-    <Compile Update="Generator\UnionTemplate.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>UnionTemplate.tt</DependentUpon>
+      <DependentUpon>%(FileName).tt</DependentUpon>
     </Compile>
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Generator\EnumTemplate.tt">
+    <None Update="Generator\*.tt">
       <Generator>TextTemplatingFilePreprocessor</Generator>
-      <LastGenOutput>EnumTemplate.cs</LastGenOutput>
-    </None>
-    <None Update="Generator\FormatterTemplate.tt">
-      <Generator>TextTemplatingFilePreprocessor</Generator>
-      <LastGenOutput>FormatterTemplate.cs</LastGenOutput>
-    </None>
-    <None Update="Generator\ResolverTemplate.tt">
-      <Generator>TextTemplatingFilePreprocessor</Generator>
-      <LastGenOutput>ResolverTemplate.cs</LastGenOutput>
-    </None>
-    <None Update="Generator\UnionTemplate.tt">
-      <Generator>TextTemplatingFilePreprocessor</Generator>
-      <LastGenOutput>UnionTemplate.cs</LastGenOutput>
+      <LastGenOutput>%(FileName).cs</LastGenOutput>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
This PR may help #386.
Buildalyzer may expect general build pattern, but some special project, Buildalyzer's analyzing is always failed.
so replace Buildalyzer to [MSBuild.StructuredLogger](https://github.com/KirillOsenkov/MSBuildStructuredLog) and analyze build log directly.

This PR may not be needed if #396 is merged.