### PR TITLE
Add support for additional platform targets (uap and xamarin.ios) as …

### DIFF
--- a/src/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs
+++ b/src/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD || NETFRAMEWORK
+﻿#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
 
 using MessagePack.Resolvers;
 using System;

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using System.Text;
 
 #if NETSTANDARD || NETFRAMEWORK
@@ -405,7 +406,7 @@ namespace MessagePack.Formatters
     }
 
 #if NETSTANDARD || NETFRAMEWORK
-
+#if !XAMARIN_IOS
     public sealed class BigIntegerFormatter : IMessagePackFormatter<System.Numerics.BigInteger>
     {
         public static readonly IMessagePackFormatter<System.Numerics.BigInteger> Instance = new BigIntegerFormatter();
@@ -462,6 +463,7 @@ namespace MessagePack.Formatters
             return new System.Numerics.Complex(real, imaginary);
         }
     }
+#endif
 
     public sealed class LazyFormatter<T> : IMessagePackFormatter<Lazy<T>>
     {

--- a/src/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack/Formatters/TypelessFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD || NETFRAMEWORK
+﻿#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
 
 using MessagePack.Internal;
 using System;

--- a/src/MessagePack/Internal/AutomataDictionary.cs
+++ b/src/MessagePack/Internal/AutomataDictionary.cs
@@ -172,7 +172,7 @@ namespace MessagePack.Internal
 
         // IL Emit
 
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
         public void EmitMatch(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
         {
@@ -338,7 +338,7 @@ namespace MessagePack.Internal
                 }
             }
 
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
             // SearchNext(ref byte* p, ref int rest, ref ulong key)
             public void EmitSearchNext(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
@@ -474,7 +474,7 @@ namespace MessagePack.Internal
 
 #if !NETSTANDARD
 
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
         static MethodInfo dynamicGetKeyMethod;
         static readonly object gate = new object();

--- a/src/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack/Internal/DynamicAssembly.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
 using System;
 using System.Reflection;

--- a/src/MessagePack/Internal/ILGeneratorExtensions.cs
+++ b/src/MessagePack/Internal/ILGeneratorExtensions.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
 using System;
 using System.Linq;

--- a/src/MessagePack/LZ4/LZ4MessagePackSerializer.JSON.cs
+++ b/src/MessagePack/LZ4/LZ4MessagePackSerializer.JSON.cs
@@ -192,7 +192,7 @@ namespace MessagePack
                         builder.Append(dt.ToString("o", CultureInfo.InvariantCulture));
                         builder.Append("\"");
                     }
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
                     else if (extHeader.TypeCode == TypelessFormatter.ExtensionTypeCode)
                     {
                         int startOffset = offset;

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.68">
+  <!-- Using MSBuild.Sdk.Extras from oren novotny to support uap.10 and xamarin.ios10 platform targets out of the box
+        see: https://github.com/onovotny/MSBuildSdkExtras -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net47;uap10.0;xamarin.ios10</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK</DefineConstants>
@@ -26,13 +27,33 @@
     <None Include="MessagePackSerializer.Typeless.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!-- for all standard .net targets, change nothing -->
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net')) ">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
+
+  <!-- for iOS and UWP (.NET Native) remove the IL nugets -->
+  <ItemGroup Condition=" $(TargetFramework) == 'uap10.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework) == 'xamarin.ios10'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+  </ItemGroup>
+  <!-- for iOS and UWP (.NET Native) remove the IL code using NO_IL_CODE flag -->
+  <PropertyGroup Condition=" $(TargetFramework) == 'uap10.0'">
+    <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;NO_IL_CODE;NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" $(TargetFramework) == 'xamarin.ios10' ">
+    <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;NO_IL_CODE;NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
 
   <ItemGroup>
     <None Update="Formatters\ForceSizePrimitiveFormatter.tt">

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <!-- for iOS and UWP (.NET Native) remove the IL code using NO_IL_CODE flag -->
   <PropertyGroup Condition=" $(TargetFramework) == 'uap10.0'">
-    <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;NO_IL_CODE;NETSTANDARD</DefineConstants>
+    <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;NO_IL_CODE;NETSTANDARD;UWP_AOT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework) == 'xamarin.ios10' ">
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;NO_IL_CODE;NETSTANDARD</DefineConstants>

--- a/src/MessagePack/MessagePackBinary.cs
+++ b/src/MessagePack/MessagePackBinary.cs
@@ -248,7 +248,7 @@ namespace MessagePack
             dateTimeDecoders[MessagePackCode.Ext8] = Decoders.Ext8DateTime.Instance;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static void EnsureCapacity(ref byte[] bytes, int offset, int appendLength)
@@ -297,7 +297,7 @@ namespace MessagePack
         }
 
         // Buffer.BlockCopy version of Array.Resize
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static void FastResize(ref byte[] array, int newSize)
@@ -319,7 +319,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static byte[] FastCloneWithResize(byte[] array, int newSize)
@@ -338,7 +338,7 @@ namespace MessagePack
             return array3;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static MessagePackType GetMessagePackType(byte[] bytes, int offset)
@@ -346,7 +346,7 @@ namespace MessagePack
             return MessagePackCode.ToMessagePackType(bytes[offset]);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadNext(byte[] bytes, int offset)
@@ -354,7 +354,7 @@ namespace MessagePack
             return readNextDecoders[bytes[offset]].Read(bytes, offset);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadNextBlock(byte[] bytes, int offset)
@@ -399,7 +399,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteNil(ref byte[] bytes, int offset)
@@ -410,7 +410,7 @@ namespace MessagePack
             return 1;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static Nil ReadNil(byte[] bytes, int offset, out int readSize)
@@ -426,7 +426,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static bool IsNil(byte[] bytes, int offset)
@@ -438,7 +438,7 @@ namespace MessagePack
         {
             EnsureCapacity(ref bytes, offset, rawMessagePackBlock.Length);
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
             if (UnsafeMemory.Is32Bit)
             {
                 switch (rawMessagePackBlock.Length)
@@ -653,7 +653,7 @@ namespace MessagePack
         /// Unsafe. If value is guranteed 0 ~ MessagePackRange.MaxFixMapCount(15), can use this method.
         /// </summary>
         /// <returns></returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteFixedMapHeaderUnsafe(ref byte[] bytes, int offset, int count)
@@ -666,7 +666,7 @@ namespace MessagePack
         /// <summary>
         /// Write map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteMapHeader(ref byte[] bytes, int offset, int count)
@@ -680,7 +680,7 @@ namespace MessagePack
         /// <summary>
         /// Write map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteMapHeader(ref byte[] bytes, int offset, uint count)
@@ -720,7 +720,7 @@ namespace MessagePack
         /// <summary>
         /// Write map format header, always use map32 format(length is fixed, 5).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteMapHeaderForceMap32Block(ref byte[] bytes, int offset, uint count)
@@ -740,7 +740,7 @@ namespace MessagePack
         /// <summary>
         /// Return map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadMapHeader(byte[] bytes, int offset, out int readSize)
@@ -754,7 +754,7 @@ namespace MessagePack
         /// <summary>
         /// Return map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static uint ReadMapHeaderRaw(byte[] bytes, int offset, out int readSize)
@@ -762,7 +762,7 @@ namespace MessagePack
             return mapHeaderDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int GetArrayHeaderLength(int count)
@@ -785,7 +785,7 @@ namespace MessagePack
         /// Unsafe. If value is guranteed 0 ~ MessagePackRange.MaxFixArrayCount(15), can use this method.
         /// </summary>
         /// <returns></returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteFixedArrayHeaderUnsafe(ref byte[] bytes, int offset, int count)
@@ -798,7 +798,7 @@ namespace MessagePack
         /// <summary>
         /// Write array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteArrayHeader(ref byte[] bytes, int offset, int count)
@@ -812,7 +812,7 @@ namespace MessagePack
         /// <summary>
         /// Write array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteArrayHeader(ref byte[] bytes, int offset, uint count)
@@ -852,7 +852,7 @@ namespace MessagePack
         /// <summary>
         /// Write array format header, always use array32 format(length is fixed, 5).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteArrayHeaderForceArray32Block(ref byte[] bytes, int offset, uint count)
@@ -872,7 +872,7 @@ namespace MessagePack
         /// <summary>
         /// Return array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadArrayHeader(byte[] bytes, int offset, out int readSize)
@@ -886,7 +886,7 @@ namespace MessagePack
         /// <summary>
         /// Return array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static uint ReadArrayHeaderRaw(byte[] bytes, int offset, out int readSize)
@@ -894,7 +894,7 @@ namespace MessagePack
             return arrayHeaderDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteBoolean(ref byte[] bytes, int offset, bool value)
@@ -905,7 +905,7 @@ namespace MessagePack
             return 1;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static bool ReadBoolean(byte[] bytes, int offset, out int readSize)
@@ -914,7 +914,7 @@ namespace MessagePack
             return booleanDecoders[bytes[offset]].Read();
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteByte(ref byte[] bytes, int offset, byte value)
@@ -934,7 +934,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteByteForceByteBlock(ref byte[] bytes, int offset, byte value)
@@ -945,7 +945,7 @@ namespace MessagePack
             return 2;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static byte ReadByte(byte[] bytes, int offset, out int readSize)
@@ -953,7 +953,7 @@ namespace MessagePack
             return byteDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteBytes(ref byte[] bytes, int offset, byte[] value)
@@ -968,7 +968,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteBytes(ref byte[] dest, int dstOffset, byte[] src, int srcOffset, int count)
@@ -1023,7 +1023,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static byte[] ReadBytes(byte[] bytes, int offset, out int readSize)
@@ -1031,7 +1031,7 @@ namespace MessagePack
             return bytesDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ArraySegment<byte> ReadBytesSegment(byte[] bytes, int offset, out int readSize)
@@ -1039,7 +1039,7 @@ namespace MessagePack
             return bytesSegmentDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteSByte(ref byte[] bytes, int offset, sbyte value)
@@ -1059,7 +1059,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteSByteForceSByteBlock(ref byte[] bytes, int offset, sbyte value)
@@ -1070,7 +1070,7 @@ namespace MessagePack
             return 2;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static sbyte ReadSByte(byte[] bytes, int offset, out int readSize)
@@ -1078,7 +1078,7 @@ namespace MessagePack
             return sbyteDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteSingle(ref byte[] bytes, int offset, float value)
@@ -1106,7 +1106,7 @@ namespace MessagePack
             return 5;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static float ReadSingle(byte[] bytes, int offset, out int readSize)
@@ -1114,7 +1114,7 @@ namespace MessagePack
             return singleDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteDouble(ref byte[] bytes, int offset, double value)
@@ -1150,7 +1150,7 @@ namespace MessagePack
             return 9;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static double ReadDouble(byte[] bytes, int offset, out int readSize)
@@ -1158,7 +1158,7 @@ namespace MessagePack
             return doubleDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt16(ref byte[] bytes, int offset, short value)
@@ -1215,7 +1215,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt16ForceInt16Block(ref byte[] bytes, int offset, short value)
@@ -1227,7 +1227,7 @@ namespace MessagePack
             return 3;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static short ReadInt16(byte[] bytes, int offset, out int readSize)
@@ -1238,7 +1238,7 @@ namespace MessagePack
         /// <summary>
         /// Unsafe. If value is guranteed 0 ~ MessagePackCode.MaxFixInt(127), can use this method.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WritePositiveFixedIntUnsafe(ref byte[] bytes, int offset, int value)
@@ -1248,7 +1248,7 @@ namespace MessagePack
             return 1;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt32(ref byte[] bytes, int offset, int value)
@@ -1328,7 +1328,7 @@ namespace MessagePack
         /// <summary>
         /// Acquire static message block(always 5 bytes).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt32ForceInt32Block(ref byte[] bytes, int offset, int value)
@@ -1342,7 +1342,7 @@ namespace MessagePack
             return 5;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadInt32(byte[] bytes, int offset, out int readSize)
@@ -1350,7 +1350,7 @@ namespace MessagePack
             return int32Decoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt64(ref byte[] bytes, int offset, long value)
@@ -1455,7 +1455,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt64ForceInt64Block(ref byte[] bytes, int offset, long value)
@@ -1473,7 +1473,7 @@ namespace MessagePack
             return 9;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static long ReadInt64(byte[] bytes, int offset, out int readSize)
@@ -1481,7 +1481,7 @@ namespace MessagePack
             return int64Decoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt16(ref byte[] bytes, int offset, ushort value)
@@ -1509,7 +1509,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt16ForceUInt16Block(ref byte[] bytes, int offset, ushort value)
@@ -1521,7 +1521,7 @@ namespace MessagePack
             return 3;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ushort ReadUInt16(byte[] bytes, int offset, out int readSize)
@@ -1529,7 +1529,7 @@ namespace MessagePack
             return uint16Decoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt32(ref byte[] bytes, int offset, uint value)
@@ -1567,7 +1567,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt32ForceUInt32Block(ref byte[] bytes, int offset, uint value)
@@ -1581,7 +1581,7 @@ namespace MessagePack
             return 5;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static uint ReadUInt32(byte[] bytes, int offset, out int readSize)
@@ -1589,7 +1589,7 @@ namespace MessagePack
             return uint32Decoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt64(ref byte[] bytes, int offset, ulong value)
@@ -1641,7 +1641,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt64ForceUInt64Block(ref byte[] bytes, int offset, ulong value)
@@ -1659,7 +1659,7 @@ namespace MessagePack
             return 9;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ulong ReadUInt64(byte[] bytes, int offset, out int readSize)
@@ -1667,7 +1667,7 @@ namespace MessagePack
             return uint64Decoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteChar(ref byte[] bytes, int offset, char value)
@@ -1675,7 +1675,7 @@ namespace MessagePack
             return WriteUInt16(ref bytes, offset, (ushort)value);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static char ReadChar(byte[] bytes, int offset, out int readSize)
@@ -1686,7 +1686,7 @@ namespace MessagePack
         /// <summary>
         /// Unsafe. If value is guranteed length is 0 ~ 31, can use this method.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteFixedStringUnsafe(ref byte[] bytes, int offset, string value, int byteCount)
@@ -1701,7 +1701,7 @@ namespace MessagePack
         /// <summary>
         /// Unsafe. If pre-calculated byteCount of target string, can use this method.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteStringUnsafe(ref byte[] bytes, int offset, string value, int byteCount)
@@ -1743,7 +1743,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteStringBytes(ref byte[] bytes, int offset, byte[] utf8stringBytes)
@@ -1923,7 +1923,7 @@ namespace MessagePack
             return byteCount + 5;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static string ReadString(byte[] bytes, int offset, out int readSize)
@@ -1931,7 +1931,7 @@ namespace MessagePack
             return stringDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ArraySegment<byte> ReadStringSegment(byte[] bytes, int offset, out int readSize)
@@ -1939,7 +1939,7 @@ namespace MessagePack
             return stringSegmentDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteExtensionFormatHeader(ref byte[] bytes, int offset, sbyte typeCode, int dataLength)
@@ -2009,7 +2009,7 @@ namespace MessagePack
         /// <summary>
         /// Write extension format header, always use ext32 format(length is fixed, 6).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteExtensionFormatHeaderForceExt32Block(ref byte[] bytes, int offset, sbyte typeCode, int dataLength)
@@ -2024,7 +2024,7 @@ namespace MessagePack
             return 6;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteExtensionFormat(ref byte[] bytes, int offset, sbyte typeCode, byte[] data)
@@ -2126,7 +2126,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ExtensionResult ReadExtensionFormat(byte[] bytes, int offset, out int readSize)
@@ -2137,7 +2137,7 @@ namespace MessagePack
         /// <summary>
         /// return byte length of ExtensionFormat.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ExtensionHeader ReadExtensionFormatHeader(byte[] bytes, int offset, out int readSize)
@@ -2145,7 +2145,7 @@ namespace MessagePack
             return extHeaderDecoders[bytes[offset]].Read(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int GetExtensionFormatHeaderLength(int dataLength)
@@ -2180,7 +2180,7 @@ namespace MessagePack
         // FixExt8(-1) => nanoseconds + seconds | [1970-01-01 00:00:00.000000000 UTC, 2514-05-30 01:53:04.000000000 UTC) range
         // Ext8(12,-1) => nanoseconds + seconds | [-584554047284-02-23 16:59:44 UTC, 584554051223-11-09 07:00:16.000000000 UTC) range
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteDateTime(ref byte[] bytes, int offset, DateTime dateTime)
@@ -2275,7 +2275,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static DateTime ReadDateTime(byte[] bytes, int offset, out int readSize)
@@ -2570,7 +2570,7 @@ namespace MessagePack
             }
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadNext(Stream stream)
@@ -2579,7 +2579,7 @@ namespace MessagePack
             return ReadMessageBlockFromStreamCore(stream, ref bytes, 0, true);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadNextBlock(Stream stream)
@@ -2589,7 +2589,7 @@ namespace MessagePack
             return ReadMessageBlockFromStreamCore(stream, ref bytes, offset, false);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteNil(Stream stream)
@@ -2598,7 +2598,7 @@ namespace MessagePack
             return 1;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static Nil ReadNil(Stream stream)
@@ -2610,7 +2610,7 @@ namespace MessagePack
             return ReadNil(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static bool IsNil(Stream stream)
@@ -2625,7 +2625,7 @@ namespace MessagePack
         /// Unsafe. If value is guranteed 0 ~ MessagePackRange.MaxFixMapCount(15), can use this method.
         /// </summary>
         /// <returns></returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteFixedMapHeaderUnsafe(Stream stream, int count)
@@ -2637,7 +2637,7 @@ namespace MessagePack
         /// <summary>
         /// Write map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteMapHeader(Stream stream, int count)
@@ -2651,7 +2651,7 @@ namespace MessagePack
         /// <summary>
         /// Write map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteMapHeader(Stream stream, uint count)
@@ -2665,7 +2665,7 @@ namespace MessagePack
         /// <summary>
         /// Write map format header, always use map32 format(length is fixed, 5).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteMapHeaderForceMap32Block(Stream stream, uint count)
@@ -2679,7 +2679,7 @@ namespace MessagePack
         /// <summary>
         /// Return map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadMapHeader(Stream stream)
@@ -2696,7 +2696,7 @@ namespace MessagePack
         /// <summary>
         /// Return map count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static uint ReadMapHeaderRaw(Stream stream)
@@ -2711,7 +2711,7 @@ namespace MessagePack
         /// Unsafe. If value is guranteed 0 ~ MessagePackRange.MaxFixArrayCount(15), can use this method.
         /// </summary>
         /// <returns></returns>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteFixedArrayHeaderUnsafe(Stream stream, int count)
@@ -2723,7 +2723,7 @@ namespace MessagePack
         /// <summary>
         /// Write array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteArrayHeader(Stream stream, int count)
@@ -2737,7 +2737,7 @@ namespace MessagePack
         /// <summary>
         /// Write array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteArrayHeader(Stream stream, uint count)
@@ -2751,7 +2751,7 @@ namespace MessagePack
         /// <summary>
         /// Write array format header, always use array32 format(length is fixed, 5).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteArrayHeaderForceArray32Block(Stream stream, uint count)
@@ -2765,7 +2765,7 @@ namespace MessagePack
         /// <summary>
         /// Return array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadArrayHeader(Stream stream)
@@ -2779,7 +2779,7 @@ namespace MessagePack
         /// <summary>
         /// Return array count.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static uint ReadArrayHeaderRaw(Stream stream)
@@ -2790,7 +2790,7 @@ namespace MessagePack
             return ReadArrayHeaderRaw(bytes, 0, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteBoolean(Stream stream, bool value)
@@ -2801,7 +2801,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static bool ReadBoolean(Stream stream)
@@ -2813,7 +2813,7 @@ namespace MessagePack
             return ReadBoolean(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteByte(Stream stream, byte value)
@@ -2824,7 +2824,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteByteForceByteBlock(Stream stream, byte value)
@@ -2835,7 +2835,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static byte ReadByte(Stream stream)
@@ -2847,7 +2847,7 @@ namespace MessagePack
             return ReadByte(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteBytes(Stream stream, byte[] value)
@@ -2858,7 +2858,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteBytes(Stream stream, byte[] src, int srcOffset, int count)
@@ -2869,7 +2869,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static byte[] ReadBytes(Stream stream)
@@ -2881,7 +2881,7 @@ namespace MessagePack
             return ReadBytes(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteSByte(Stream stream, sbyte value)
@@ -2892,7 +2892,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteSByteForceSByteBlock(Stream stream, sbyte value)
@@ -2903,7 +2903,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static sbyte ReadSByte(Stream stream)
@@ -2915,7 +2915,7 @@ namespace MessagePack
             return ReadSByte(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteSingle(Stream stream, float value)
@@ -2926,7 +2926,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static float ReadSingle(Stream stream)
@@ -2938,7 +2938,7 @@ namespace MessagePack
             return ReadSingle(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteDouble(Stream stream, double value)
@@ -2949,7 +2949,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static double ReadDouble(Stream stream)
@@ -2961,7 +2961,7 @@ namespace MessagePack
             return ReadDouble(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt16(Stream stream, short value)
@@ -2972,7 +2972,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt16ForceInt16Block(Stream stream, short value)
@@ -2983,7 +2983,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static short ReadInt16(Stream stream)
@@ -2998,7 +2998,7 @@ namespace MessagePack
         /// <summary>
         /// Unsafe. If value is guranteed 0 ~ MessagePackCode.MaxFixInt(127), can use this method.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WritePositiveFixedIntUnsafe(Stream stream, int value)
@@ -3009,7 +3009,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt32(Stream stream, int value)
@@ -3023,7 +3023,7 @@ namespace MessagePack
         /// <summary>
         /// Acquire static message block(always 5 bytes).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt32ForceInt32Block(Stream stream, int value)
@@ -3034,7 +3034,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int ReadInt32(Stream stream)
@@ -3046,7 +3046,7 @@ namespace MessagePack
             return ReadInt32(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt64(Stream stream, long value)
@@ -3057,7 +3057,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteInt64ForceInt64Block(Stream stream, long value)
@@ -3068,7 +3068,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static long ReadInt64(Stream stream)
@@ -3080,7 +3080,7 @@ namespace MessagePack
             return ReadInt64(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt16(Stream stream, ushort value)
@@ -3091,7 +3091,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt16ForceUInt16Block(Stream stream, ushort value)
@@ -3102,7 +3102,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ushort ReadUInt16(Stream stream)
@@ -3114,7 +3114,7 @@ namespace MessagePack
             return ReadUInt16(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt32(Stream stream, uint value)
@@ -3125,7 +3125,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt32ForceUInt32Block(Stream stream, uint value)
@@ -3136,7 +3136,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static uint ReadUInt32(Stream stream)
@@ -3148,7 +3148,7 @@ namespace MessagePack
             return ReadUInt32(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt64(Stream stream, ulong value)
@@ -3159,7 +3159,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteUInt64ForceUInt64Block(Stream stream, ulong value)
@@ -3170,7 +3170,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ulong ReadUInt64(Stream stream)
@@ -3182,7 +3182,7 @@ namespace MessagePack
             return ReadUInt64(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteChar(Stream stream, char value)
@@ -3193,7 +3193,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static char ReadChar(Stream stream)
@@ -3208,7 +3208,7 @@ namespace MessagePack
         /// <summary>
         /// Unsafe. If value is guranteed length is 0 ~ 31, can use this method.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteFixedStringUnsafe(Stream stream, string value, int byteCount)
@@ -3222,7 +3222,7 @@ namespace MessagePack
         /// <summary>
         /// Unsafe. If pre-calculated byteCount of target string, can use this method.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteStringUnsafe(Stream stream, string value, int byteCount)
@@ -3233,7 +3233,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteStringBytes(Stream stream, byte[] utf8stringBytes)
@@ -3260,7 +3260,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static string ReadString(Stream stream)
@@ -3272,7 +3272,7 @@ namespace MessagePack
             return ReadString(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteExtensionFormatHeader(Stream stream, sbyte typeCode, int dataLength)
@@ -3286,7 +3286,7 @@ namespace MessagePack
         /// <summary>
         /// Write extension format header, always use ext32 format(length is fixed, 6).
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteExtensionFormatHeaderForceExt32Block(Stream stream, sbyte typeCode, int dataLength)
@@ -3297,7 +3297,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteExtensionFormat(Stream stream, sbyte typeCode, byte[] data)
@@ -3308,7 +3308,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ExtensionResult ReadExtensionFormat(Stream stream)
@@ -3323,7 +3323,7 @@ namespace MessagePack
         /// <summary>
         /// return byte length of ExtensionFormat.
         /// </summary>
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static ExtensionHeader ReadExtensionFormatHeader(Stream stream)
@@ -3335,7 +3335,7 @@ namespace MessagePack
             return ReadExtensionFormatHeader(bytes, offset, out readSize);
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static int WriteDateTime(Stream stream, DateTime dateTime)
@@ -3346,7 +3346,7 @@ namespace MessagePack
             return writeCount;
         }
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !UWP_AOT // UWP AOT compiler crashes with OutOfMemoryException if this is enabled
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 #endif
         public static DateTime ReadDateTime(Stream stream)

--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -262,7 +262,7 @@ namespace MessagePack
                         builder.Append(dt.ToString("o", CultureInfo.InvariantCulture));
                         builder.Append("\"");
                     }
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
                     else if (extHeader.TypeCode == TypelessFormatter.ExtensionTypeCode)
                     {
                         int startOffset = offset;

--- a/src/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack/Resolvers/BuiltinResolver.cs
@@ -129,10 +129,12 @@ namespace MessagePack.Internal
             { typeof(ArraySegment<byte>?),new StaticNullableFormatter<ArraySegment<byte>>(ByteArraySegmentFormatter.Instance) },
 
 #if NETSTANDARD || NETFRAMEWORK
+#if !XAMARIN_IOS
             {typeof(System.Numerics.BigInteger), BigIntegerFormatter.Instance},
             {typeof(System.Numerics.BigInteger?), new StaticNullableFormatter<System.Numerics.BigInteger>(BigIntegerFormatter.Instance)},
             {typeof(System.Numerics.Complex), ComplexFormatter.Instance},
             {typeof(System.Numerics.Complex?), new StaticNullableFormatter<System.Numerics.Complex>(ComplexFormatter.Instance)},
+#endif
             {typeof(System.Threading.Tasks.Task), TaskUnitFormatter.Instance},
 #endif
         };

--- a/src/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
 using System;
 using MessagePack.Formatters;

--- a/src/MessagePack/Resolvers/DynamicGenericResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicGenericResolver.cs
@@ -299,5 +299,4 @@ namespace MessagePack.Internal
         }
     }
 }
-
 #endif

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
 using System;
 using System.Linq;

--- a/src/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace MessagePack.Resolvers
 {
 #if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && !NO_IL_CODE
 
     /// <summary>
     /// UnionResolver by dynamic code generation.

--- a/src/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack/Resolvers/StandardResolver.cs
@@ -12,7 +12,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new StandardResolver();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverCore.Instance);
 #endif
 
@@ -34,7 +34,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -52,7 +52,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new ContractlessStandardResolver();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverCore.Instance);
 #endif
 
@@ -74,7 +74,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -92,7 +92,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new StandardResolverAllowPrivate();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverAllowPrivateCore.Instance);
 #endif
 
@@ -114,7 +114,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -132,7 +132,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new ContractlessStandardResolverAllowPrivate();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverAllowPrivateCore.Instance);
 #endif
 
@@ -154,7 +154,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();

--- a/src/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack/Resolvers/StandardResolver.cs
@@ -182,7 +182,7 @@ namespace MessagePack.Internal
             MessagePack.Unity.UnityResolver.Instance,
 #endif
 
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && !NO_IL_CODE
 
             DynamicEnumResolver.Instance, // Try Enum
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection
@@ -197,7 +197,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && !NO_IL_CODE
             DynamicObjectResolver.Instance, // Try Object
 #endif
         }).ToArray();
@@ -236,7 +236,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && !NO_IL_CODE
             DynamicObjectResolver.Instance, // Try Object
             DynamicContractlessObjectResolver.Instance, // Serializes keys as strings
 #endif
@@ -277,7 +277,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && !NO_IL_CODE
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
 #endif
         }).ToArray();
@@ -316,7 +316,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && !NO_IL_CODE
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
 #endif

--- a/src/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -26,8 +26,8 @@ namespace MessagePack.Resolvers
 #endif
 #if !NO_IL_CODE
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
-#endif
             TypelessObjectResolver.Instance
+#endif
         };
 
         TypelessContractlessStandardResolver()

--- a/src/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -17,12 +17,16 @@ namespace MessagePack.Resolvers
             BuiltinResolver.Instance, // Try Builtin
             AttributeFormatterResolver.Instance, // Try use [MessagePackFormatter]
 #if !ENABLE_IL2CPP
+#if !NO_IL_CODE
             DynamicEnumResolver.Instance, // Try Enum
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection
             DynamicUnionResolver.Instance, // Try Union(Interface)
             DynamicObjectResolver.Instance, // Try Object
 #endif
+#endif
+#if !NO_IL_CODE
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
+#endif
             TypelessObjectResolver.Instance
         };
 

--- a/src/MessagePack/Resolvers/TypelessObjectResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessObjectResolver.cs
@@ -5,7 +5,7 @@ using MessagePack.Internal;
 
 namespace MessagePack.Resolvers
 {
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && !NO_IL_CODE
 
     /// <summary>
     /// Used for `object` fields/collections, ex: var arr = new object[] { 1, "a", new Model() };


### PR DESCRIPTION
…these forbid any IL code to be created or even referenced.

Otherwise e.g. when referencing MessagePack in an UWP solution and you run the publish wizard to publish it in Microsoft Store, you will get a bunch of compiler errors. It boils down to the one error regarding MessagePack:

> Type 'System.Reflection.Emit.ModuleBuilder' from assembly 'System.Reflection.Emit' was not included in compilation, but was referenced in type 'MessagePack.Internal.DynamicAssembly'. There may have been a missing assembly, or a dependency on a more recent Windows SDK release.	<someproject>.UWP  	

So this PR adds two additional platform targetx: ios and uwp
In these, all IL creating code is not included