### PR TITLE
Enable ETL collection in SerializerBenchmark

### DIFF
--- a/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
+++ b/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3" />
     <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
     <PackageReference Include="Ceras" Version="4.0.27" />
     <PackageReference Include="FsPickler" Version="5.2.0" />


### PR DESCRIPTION
This allows passing the `-p etw` parameter when running the benchmark in order to get ETL files for analyzing the perf costs.