### PR TITLE
Allow using attributes derived from MessagePackObject on child classes

### DIFF
--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1316,7 +1316,7 @@ typeof(int), typeof(int) });
             var ti = type.GetTypeInfo();
             var isClass = ti.IsClass || ti.IsInterface || ti.IsAbstract;
 
-            var contractAttr = ti.GetCustomAttribute<MessagePackObjectAttribute>();
+            var contractAttr = ti.GetCustomAttributes<MessagePackObjectAttribute>().FirstOrDefault();
             var dataContractAttr = ti.GetCustomAttribute<DataContractAttribute>();
             if (contractAttr == null && dataContractAttr == null && !forceStringKey && !contractless)
             {

--- a/tests/MessagePack.Tests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs
+++ b/tests/MessagePack.Tests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class DynamicObjectResolverDerivedAttributeInheritanceTest
+    {
+        [Fact]
+        public void InheritanceAndDerivedAttributeTest()
+        {
+            var value = new ChildClass(1, "Hello", 2);
+            var serialized = MessagePackSerializer.Serialize(value);
+            var deserialized =
+                MessagePackSerializer.Deserialize<ChildClass>(serialized);
+            deserialized.OtherValue.Is(value.OtherValue);
+            deserialized.Text.Is(value.Text);
+            deserialized.Value.Is(value.Value);
+        }
+    }
+
+    [MessagePackObject]
+    public abstract class BaseClass
+    {
+        public BaseClass(int value, string text)
+        {
+            Value = value;
+            Text = text;
+        }
+
+        [Key(0)]
+        public int Value { get; }
+
+        [Key(1)]
+        public string Text { get; }
+    }
+
+    [Message(1)]
+    public class ChildClass : BaseClass
+    {
+        public ChildClass(int value, string text, int otherValue) : base(
+            value,
+            text)
+        {
+            OtherValue = otherValue;
+        }
+
+        [Key(2)]
+        public int OtherValue { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    class MessageAttribute : MessagePackObjectAttribute
+    {
+        public MessageAttribute(short version)
+        {
+            Version = version;
+        }
+
+        public short Version { get; }
+    }
+}


### PR DESCRIPTION
We wanted to combine the `MessagePackObject` attribute with one of our custom attribute to simplify the code and make things simpler. However, when trying this, I ran into an issue with classes using our custom attribute and deriving from classes using the `MessagePackObject` attribute. This PR proposes a fix and adds a test for the mentioned use case. The fix is very small and should hopefully not have any significant impact.