### PR TITLE
Allow parent interface in constructor

### DIFF
--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1593,7 +1593,9 @@ typeof(int), typeof(int) });
                         {
                             if (intMembers.TryGetValue(ctorParamIndex, out paramMember))
                             {
-                                if (item.ParameterType == paramMember.Type && paramMember.IsReadable)
+                                if ((item.ParameterType == paramMember.Type ||
+                                    item.ParameterType.GetTypeInfo().IsAssignableFrom(paramMember.Type))
+                                    && paramMember.IsReadable)
                                 {
                                     constructorParameters.Add(paramMember);
                                 }

--- a/tests/MessagePack.Tests/DynamicObjectResolverInterfaceTest.cs
+++ b/tests/MessagePack.Tests/DynamicObjectResolverInterfaceTest.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class DynamicObjectResolverInterfaceTest
+    {
+        [Fact]
+        void TestConstructorWithParentInterface()
+        {
+            var myClass = new ConstructorEnumerableTest(new[] { "0", "2", "3" });
+            var serialized = MessagePackSerializer.Serialize(myClass);
+            var deserialized =
+                MessagePackSerializer.Deserialize<ConstructorEnumerableTest>(serialized);
+            deserialized.Values.IsStructuralEqual(myClass.Values);
+        }
+
+    }
+
+    [MessagePackObject]
+    public class ConstructorEnumerableTest
+    {
+        [SerializationConstructor]
+        public ConstructorEnumerableTest(IEnumerable<string> values)
+        {
+            Values = values.ToList().AsReadOnly();
+        }
+
+        [Key(0)]
+        public IReadOnlyList<string> Values { get; }
+    }
+}


### PR DESCRIPTION
It is quite common (at least for us) to have a constructor that takes an interface that is more generic than the type of the member or property of a class. This makes a small change to recognize such constructor parameters. I added a test to show the behavior.