### PR TITLE
Fix path normalization for new compiler

### DIFF
--- a/src/MessagePackCompiler/MessagePackCompilation.cs
+++ b/src/MessagePackCompiler/MessagePackCompilation.cs
@@ -43,7 +43,7 @@ namespace MessagePackCompiler
             var hasAnnotations = false;
             foreach (var file in sources.Distinct())
             {
-                var text = await File.ReadAllTextAsync(file, Encoding.UTF8, cancellationToken);
+                var text = await File.ReadAllTextAsync(file.Replace('\\', Path.DirectorySeparatorChar), Encoding.UTF8, cancellationToken);
                 var syntax = CSharpSyntaxTree.ParseText(text, parseOption);
                 syntaxTrees.Add(syntax);
                 if (Path.GetFileNameWithoutExtension(file) == "Attributes")
@@ -167,7 +167,7 @@ namespace MessagePackCompiler
             var syntaxTrees = new List<SyntaxTree>();
             foreach (var file in IterateCsFileWithoutBinObj(directoryRoot))
             {
-                var text = await File.ReadAllTextAsync(file, Encoding.UTF8, cancellationToken);
+                var text = await File.ReadAllTextAsync(file.Replace('\\', Path.DirectorySeparatorChar), Encoding.UTF8, cancellationToken);
                 var syntax = CSharpSyntaxTree.ParseText(text, parseOption);
                 syntaxTrees.Add(syntax);
                 if (Path.GetFileNameWithoutExtension(file) == "Attributes")


### PR DESCRIPTION
in mac or linux, `\` in filepath is not interpreted as path separator, it's interpreted as the part of filename.

so `System.IO.FileNotFoundException` may be caused if `<Compile Include="Sub\Sub.cs"/>` in `Compile` item.