### PR TITLE
fix path normalization for linux and mac(#386)

### DIFF
--- a/sandbox/TestData.SubDir/Class1.cs
+++ b/sandbox/TestData.SubDir/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using MessagePack;
+
+namespace TestData.SubDir
+{
+
+    [MessagePackObject(true)]
+    public class A
+    {
+        public int X { get; set; }
+    }
+}

--- a/sandbox/TestData.SubDir/Sub/SubA.cs
+++ b/sandbox/TestData.SubDir/Sub/SubA.cs
@@ -1,0 +1,12 @@
+using System;
+using MessagePack;
+
+namespace TestData.SubDir.Sub
+{
+
+    [MessagePackObject(true)]
+    public class SubA
+    {
+        public int Y { get; set; }
+    }
+}

--- a/sandbox/TestData.SubDir/TestData.SubDir.csproj
+++ b/sandbox/TestData.SubDir/TestData.SubDir.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack" Version="1.7.3.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Sub\*.cs"/>
+    <Compile Include="Sub\SubA.cs"/>
+  </ItemGroup>
+
+</Project>

--- a/src/MessagePack.UniversalCodeGenerator/Utils/RoslynExtensions.cs
+++ b/src/MessagePack.UniversalCodeGenerator/Utils/RoslynExtensions.cs
@@ -222,7 +222,7 @@ namespace MessagePack.CodeGenerator
             }
             foreach (var asm in assemblies)
             {
-                roslynProject = roslynProject.AddMetadataReference(MetadataReference.CreateFromFile(asm.Text));
+                roslynProject = roslynProject.AddMetadataReference(MetadataReference.CreateFromFile(asm.Text.Replace('\\', Path.DirectorySeparatorChar)));
             }
             var compopt = roslynProject.CompilationOptions as CSharpCompilationOptions;
             compopt = roslynProject.CompilationOptions as CSharpCompilationOptions;

--- a/src/MessagePack.UniversalCodeGenerator/Utils/RoslynExtensions.cs
+++ b/src/MessagePack.UniversalCodeGenerator/Utils/RoslynExtensions.cs
@@ -216,7 +216,8 @@ namespace MessagePack.CodeGenerator
             foreach (var compile in compileItems)
             {
                 var filePath = compile.Text;
-                var absFilePath = Path.Combine(projectDir, filePath);
+                // normalize path separater char
+                var absFilePath = Path.Combine(projectDir, filePath).Replace('\\', Path.DirectorySeparatorChar);
                 roslynProject = roslynProject.AddDocument(filePath, File.ReadAllText(absFilePath)).Project;
             }
             foreach (var asm in assemblies)


### PR DESCRIPTION
This PR is very similar to #419, but this PR for MessagePack.UniversalCodeGenerator.
It'll fix mpc error on mac when the compile item path include `\`.