### PR TITLE
Add a project to build the reader \ writer with internal visibility

### DIFF
--- a/MessagePack.sln
+++ b/MessagePack.sln
@@ -70,6 +70,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmark", "benchmark", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SerializerBenchmark", "benchmark\SerializerBenchmark\SerializerBenchmark.csproj", "{4142EA80-FEF4-44A5-8553-1AE84BEBAFED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePack.Internal", "src\MessagePack.Internal\MessagePack.Internal.csproj", "{C100FBA6-4164-4D6A-A532-5984D2B8DCB0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePack.Internal.Tests", "tests\MessagePack.Internal.Tests\MessagePack.Internal.Tests.csproj", "{8D9FD130-7905-47D8-A25C-7FDEE28EA0E8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -148,6 +152,14 @@ Global
 		{4142EA80-FEF4-44A5-8553-1AE84BEBAFED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4142EA80-FEF4-44A5-8553-1AE84BEBAFED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4142EA80-FEF4-44A5-8553-1AE84BEBAFED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C100FBA6-4164-4D6A-A532-5984D2B8DCB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C100FBA6-4164-4D6A-A532-5984D2B8DCB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C100FBA6-4164-4D6A-A532-5984D2B8DCB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C100FBA6-4164-4D6A-A532-5984D2B8DCB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D9FD130-7905-47D8-A25C-7FDEE28EA0E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D9FD130-7905-47D8-A25C-7FDEE28EA0E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D9FD130-7905-47D8-A25C-7FDEE28EA0E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D9FD130-7905-47D8-A25C-7FDEE28EA0E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -171,6 +183,8 @@ Global
 		{79C2B2CB-872A-4BA9-82DC-60F6DD77F940} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 		{85763F30-7733-44AB-89AB-D1B64F6E0D93} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
 		{4142EA80-FEF4-44A5-8553-1AE84BEBAFED} = {51A614B0-E583-4DD2-AC7D-6A65634582E0}
+		{C100FBA6-4164-4D6A-A532-5984D2B8DCB0} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
+		{8D9FD130-7905-47D8-A25C-7FDEE28EA0E8} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3911209-2DBF-47F8-98F6-BBC0EDFE63DE}

--- a/src/MessagePack.Internal/AssemblyInfo.cs
+++ b/src/MessagePack.Internal/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MessagePack.Internal.Tests")]

--- a/src/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/src/MessagePack.Internal/MessagePack.Internal.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK;SPAN_BUILTIN;MESSAGEPACK_INTERNAL</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    <NoWarn>CS0436;$(NoWarn)</NoWarn>
+
+    <Description>
+      A project that compiles MessagePackReader \ MessagePackWriter and related types with internal visibility modifier.
+      This is used as a way to verify that sources in AspNetCore where MessagePackage is
+      consumed as an implementation detail can compile and run.
+    </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.Streams" Version="2.1.28-beta" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MessagePack\BufferWriter.cs" />
+    <Compile Include="..\MessagePack\ExtensionHeader.cs" />
+    <Compile Include="..\MessagePack\ExtensionResult.cs" />
+    <Compile Include="..\MessagePack\FloatBits.cs" />
+    <Compile Include="..\MessagePack\MessagePackCode.cs" />
+    <Compile Include="..\MessagePack\MessagePackReader.cs" />
+    <Compile Include="..\MessagePack\MessagePackReader.Integers.cs" />
+    <Compile Include="..\MessagePack\MessagePackWriter.cs" />
+    <Compile Include="..\MessagePack\Nil.cs" />
+    <Compile Include="..\MessagePack\SequencePool.cs" />
+    <Compile Include="..\MessagePack\SequenceReader.cs" />
+    <Compile Include="..\MessagePack\SequenceReaderExtensions.cs" />
+    <Compile Include="..\MessagePack\StringEncoding.cs" />
+    <Compile Include="..\MessagePack\Internal\DateTimeConstants.cs" />
+    <Compile Include="..\MessagePack\Internal\GuidBits.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/MessagePack/ExtensionHeader.cs
+++ b/src/MessagePack/ExtensionHeader.cs
@@ -1,6 +1,11 @@
 ﻿namespace MessagePack
 {
-    public struct ExtensionHeader
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    struct ExtensionHeader
     {
         public sbyte TypeCode { get; private set; }
         public uint Length { get; private set; }

--- a/src/MessagePack/ExtensionResult.cs
+++ b/src/MessagePack/ExtensionResult.cs
@@ -3,7 +3,12 @@ using System.Buffers;
 
 namespace MessagePack
 {
-    public struct ExtensionResult
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    struct ExtensionResult
     {
         public sbyte TypeCode { get; private set; }
 

--- a/src/MessagePack/Formatters/NilFormatter.cs
+++ b/src/MessagePack/Formatters/NilFormatter.cs
@@ -1,0 +1,43 @@
+namespace MessagePack.Formatters
+{
+    public class NilFormatter : IMessagePackFormatter<Nil>
+    {
+        public static readonly IMessagePackFormatter<Nil> Instance = new NilFormatter();
+
+        NilFormatter()
+        {
+
+        }
+
+        public void Serialize(ref MessagePackWriter writer, Nil value, IFormatterResolver typeResolver)
+        {
+            writer.WriteNil();
+        }
+
+        public Nil Deserialize(ref MessagePackReader reader, IFormatterResolver typeResolver)
+        {
+            return reader.ReadNil();
+        }
+    }
+
+    // NullableNil is same as Nil.
+    public class NullableNilFormatter : IMessagePackFormatter<Nil?>
+    {
+        public static readonly IMessagePackFormatter<Nil?> Instance = new NullableNilFormatter();
+
+        NullableNilFormatter()
+        {
+
+        }
+
+        public void Serialize(ref MessagePackWriter writer, Nil? value, IFormatterResolver typeResolver)
+        {
+            writer.WriteNil();
+        }
+
+        public Nil? Deserialize(ref MessagePackReader reader, IFormatterResolver typeResolver)
+        {
+            return reader.ReadNil();
+        }
+    }
+}

--- a/src/MessagePack/MessagePackCode.cs
+++ b/src/MessagePack/MessagePackCode.cs
@@ -7,7 +7,12 @@ namespace MessagePack
     /// <summary>
     /// https://github.com/msgpack/msgpack/blob/master/spec.md#serialization-type-to-format-conversion
     /// </summary>
-    public enum MessagePackType : byte
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    enum MessagePackType : byte
     {
         Unknown = 0,
 
@@ -25,7 +30,12 @@ namespace MessagePack
     /// <summary>
     /// https://github.com/msgpack/msgpack/blob/master/spec.md#overview
     /// </summary>
-    public static class MessagePackCode
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class MessagePackCode
     {
         public const byte MinFixInt = 0x00; // 0
         public const byte MaxFixInt = 0x7f; // 127
@@ -200,12 +210,22 @@ namespace MessagePack
         }
     }
 
-    public static class ReservedMessagePackExtensionTypeCode
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class ReservedMessagePackExtensionTypeCode
     {
         public const sbyte DateTime = -1;
     }
 
-    public static class MessagePackRange
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class MessagePackRange
     {
         public const int MinFixNegativeInt = -32;
         public const int MaxFixNegativeInt = -1;

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -16,7 +16,12 @@ namespace MessagePack
     /// <remarks>
     /// <see href="https://github.com/msgpack/msgpack/blob/master/spec.md">The MessagePack spec.</see>
     /// </remarks>
-    public ref partial struct MessagePackReader
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    ref partial struct MessagePackReader
     {
         /// <summary>
         /// The reader over the sequence.

--- a/src/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack/MessagePackWriter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
-using MessagePack.Formatters;
 using MessagePack.Internal;
 using Microsoft;
 using System;
@@ -19,7 +18,12 @@ namespace MessagePack
     /// <remarks>
     /// <see href="https://github.com/msgpack/msgpack/blob/master/spec.md">The MessagePack spec.</see>
     /// </remarks>
-    public ref struct MessagePackWriter
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    ref struct MessagePackWriter
     {
         /// <summary>
         /// The writer to use.
@@ -86,7 +90,13 @@ namespace MessagePack
         /// Copies bytes directly into the message pack writer.
         /// </summary>
         /// <param name="rawMessagePackBlock">The span of bytes to copy from.</param>
-        public void WriteRaw(ReadOnlySequence<byte> rawMessagePackBlock) => rawMessagePackBlock.CopyTo(ref writer);
+        public void WriteRaw(ReadOnlySequence<byte> rawMessagePackBlock)
+        {
+            foreach (var segment in rawMessagePackBlock)
+            {
+                writer.Write(segment.Span);
+            }
+        }
 
         /// <summary>
         /// Write the length of the next array to be written in the most compact form of
@@ -665,7 +675,7 @@ namespace MessagePack
         {
             if (this.OldSpec)
             {
-                throw new NotSupportedException($"The MsgPack spec does not define a format for {nameof(DateTime)} in {nameof(OldSpec)} mode. Turn off {nameof(OldSpec)} mode or use the {nameof(NativeDateTimeFormatter)}.");
+                throw new NotSupportedException($"The MsgPack spec does not define a format for {nameof(DateTime)} in {nameof(OldSpec)} mode. Turn off {nameof(OldSpec)} mode or use NativeDateTimeFormatter.");
             }
             else
             {

--- a/src/MessagePack/Nil.cs
+++ b/src/MessagePack/Nil.cs
@@ -3,7 +3,12 @@ using System.Buffers;
 
 namespace MessagePack
 {
-    public struct Nil : IEquatable<Nil>
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
+    struct Nil : IEquatable<Nil>
     {
         public static readonly Nil Default = new Nil();
 
@@ -25,52 +30,6 @@ namespace MessagePack
         public override string ToString()
         {
             return "()";
-        }
-    }
-}
-
-namespace MessagePack.Formatters
-{
-    public class NilFormatter : IMessagePackFormatter<Nil>
-    {
-        public static readonly IMessagePackFormatter<Nil> Instance = new NilFormatter();
-
-        NilFormatter()
-        {
-
-        }
-
-        public void Serialize(ref MessagePackWriter writer, Nil value, IFormatterResolver typeResolver)
-           
-        {
-            writer.WriteNil();
-        }
-
-        public Nil Deserialize(ref MessagePackReader reader, IFormatterResolver typeResolver)
-        {
-            return reader.ReadNil();
-        }
-    }
-
-    // NullableNil is same as Nil.
-    public class NullableNilFormatter : IMessagePackFormatter<Nil?>
-    {
-        public static readonly IMessagePackFormatter<Nil?> Instance = new NullableNilFormatter();
-
-        NullableNilFormatter()
-        {
-
-        }
-
-        public void Serialize(ref MessagePackWriter writer, Nil? value, IFormatterResolver typeResolver)
-           
-        {
-            writer.WriteNil();
-        }
-
-        public Nil? Deserialize(ref MessagePackReader reader, IFormatterResolver typeResolver)
-        {
-            return reader.ReadNil();
         }
     }
 }

--- a/src/MessagePack/Utilities.cs
+++ b/src/MessagePack/Utilities.cs
@@ -11,19 +11,6 @@ namespace MessagePack
     /// </summary>
     internal static class Utilities
     {
-        /// <summary>
-        /// Writes a sequence to the specified writer.
-        /// </summary>
-        /// <param name="source">The sequence to be copied.</param>
-        /// <param name="writer">The writer to copy to.</param>
-        internal static void CopyTo(this ReadOnlySequence<byte> source, ref BufferWriter writer)
-        {
-            foreach (var segment in source)
-            {
-                writer.Write(segment.Span);
-            }
-        }
-
         internal delegate void GetWriterBytesAction<TArg>(ref MessagePackWriter writer, TArg argument);
 
         internal static byte[] GetWriterBytes<TArg>(TArg arg, GetWriterBytesAction<TArg> action)

--- a/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
+++ b/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <CodeAnalysisRuleSet>..\MessagePack.Tests\MessagePack.Tests.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MessagePack.Internal\MessagePack.Internal.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MsgPack.Cli" version="0.9.0-beta2" />
+    <PackageReference Include="xunit" version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MessagePack.Tests\MessagePackBinaryTest.cs" />
+    <Compile Include="..\MessagePack.Tests\MessagePackReaderTests.cs" />
+    <Compile Include="..\MessagePack.Tests\MessagePackReaderTests.ReadInt.cs" />
+    <Compile Include="..\MessagePack.Tests\Utils\ChainingAssertion.Xunit.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/MessagePack.Internal.Tests/MessagePackInternalTest.cs
+++ b/tests/MessagePack.Internal.Tests/MessagePackInternalTest.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MessagePack.Internal.Test
+{
+    public class MessagePackInternalTest
+    {
+        [Fact]
+        public void NoTypesAreExportedByMessagePackInternalAssembly()
+        {
+            var assembly = typeof(MessagePackReader).Assembly;
+
+            Assert.Empty(assembly.ExportedTypes);
+        }
+    }
+}

--- a/tests/MessagePack.Tests/MessagePackBinaryTest.cs
+++ b/tests/MessagePack.Tests/MessagePackBinaryTest.cs
@@ -5,7 +5,6 @@ using Xunit;
 using System.Text;
 using Nerdbank.Streams;
 using System.Buffers;
-using MessagePack.Formatters;
 
 namespace MessagePack.Tests
 {


### PR DESCRIPTION
AspNetCore uses an source copy of MessagePack-CSharp for blazor-server support. We discussed with @AArnott and as part of https://github.com/aspnet/AspNetCore/issues/9291, the plan was to add a project to this repo that verifies that the reader \ writer components can be built and consumed by AspNetCore correctly.