### PR TITLE
Add AllowNil to attributes to enable preventing (de)serialization of …

### DIFF
--- a/src/MessagePack.Annotations/Attributes.cs
+++ b/src/MessagePack.Annotations/Attributes.cs
@@ -6,10 +6,18 @@ namespace MessagePack
     public class MessagePackObjectAttribute : Attribute
     {
         public bool KeyAsPropertyName { get; private set; }
+        public bool AllowNil { get; private set; }
 
         public MessagePackObjectAttribute(bool keyAsPropertyName = false)
         {
             this.KeyAsPropertyName = keyAsPropertyName;
+            this.AllowNil = true;
+        }
+
+        public MessagePackObjectAttribute(bool keyAsPropertyName, bool allowNil)
+        {
+            this.KeyAsPropertyName = keyAsPropertyName;
+            this.AllowNil = allowNil;
         }
     }
 
@@ -18,6 +26,7 @@ namespace MessagePack
     {
         public int? IntKey { get; private set; }
         public string StringKey { get; private set; }
+        public bool AllowNil { get; private set; } = true;
 
         public KeyAttribute(int x)
         {
@@ -27,6 +36,18 @@ namespace MessagePack
         public KeyAttribute(string x)
         {
             this.StringKey = x;
+        }
+
+        public KeyAttribute(int x, bool allowNil)
+        {
+            this.IntKey = x;
+            AllowNil = allowNil;
+        }
+
+        public KeyAttribute(string x, bool allowNil)
+        {
+            this.StringKey = x;
+            AllowNil = allowNil;
         }
     }
 

--- a/tests/MessagePack.Tests/DynamicObjectResolverAllowNilTest.cs
+++ b/tests/MessagePack.Tests/DynamicObjectResolverAllowNilTest.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class DynamicObjectResolverAllowNilTest
+    {
+        private readonly MessagePackSerializer serializer = new MessagePackSerializer();
+
+        [Fact]
+        public void MessagePackObjectAllowNilSerializeTest()
+        {
+            CannotBeNull cannotBeNull = null;
+
+            Action action = () => this.serializer.Serialize(cannotBeNull);
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void MessagePackObjectAllowNilDeserializeTest()
+        {
+            CanBeNull canBeNull = null;
+
+            var buffer = serializer.Serialize(canBeNull);
+
+            Action action = () =>
+            {
+                var unused = this.serializer.Deserialize<CannotBeNull>(buffer);
+            };
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void MessagePackObjectGenericAllowNilSerializeTest()
+        {
+            GenericCannotBeNull<string> cannotBeNull = null;
+
+            Action action = () => this.serializer.Serialize(cannotBeNull);
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void MessagePackObjectGenericAllowNilDeserializeTest()
+        {
+            GenericCanBeNull<string> canBeNull = null;
+
+            var buffer = serializer.Serialize(canBeNull);
+
+            Action action = () =>
+            {
+                var unused =
+                    this.serializer.Deserialize<GenericCannotBeNull<string>>(
+                        buffer);
+            };
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void KeyAllowNilSerializeTest()
+        {
+            var nullPropertyDisallowed = new NullPropertyDisallowed();
+
+            Action action = () =>
+                this.serializer.Serialize(nullPropertyDisallowed);
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void KeyAllowNilDeserializeTest()
+        {
+            var nullPropertyAllowed = new NullPropertyAllowed();
+
+            var buffer = serializer.Serialize(nullPropertyAllowed);
+
+            Action action = () =>
+            {
+                var unused =
+                    this.serializer.Deserialize<NullPropertyDisallowed>(buffer);
+            };
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void StringKeyAllowNilSerializeTest()
+        {
+            var nullPropertyDisallowed = new NullPropertyDisallowedStringKey();
+
+            Action action = () =>
+                this.serializer.Serialize(nullPropertyDisallowed);
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void StringKeyAllowNilDeserializeTest()
+        {
+            var nullPropertyAllowed = new NullPropertyAllowedStringKey();
+
+            var buffer = serializer.Serialize(nullPropertyAllowed);
+
+            Action action = () =>
+            {
+                var unused =
+                    this.serializer.Deserialize<NullPropertyDisallowedStringKey>(buffer);
+            };
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void GenericKeyAllowNilSerializeTest()
+        {
+            var nullPropertyDisallowed =
+                new GenericNullPropertyDisallowed<string>();
+
+            Action action = () =>
+                this.serializer.Serialize(nullPropertyDisallowed);
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public void GenericKeyAllowNilDeserializeTest()
+        {
+            var nullPropertyAllowed = new GenericNullPropertyAllowed<string>();
+
+            var buffer = serializer.Serialize(nullPropertyAllowed);
+
+            Action action = () =>
+            {
+                var unused =
+                    this.serializer.Deserialize<NullPropertyDisallowed>(buffer);
+            };
+
+            Assert.Throws<InvalidOperationException>(action);
+        }
+    }
+
+    [MessagePackObject(keyAsPropertyName: false, allowNil: false)]
+    public class CannotBeNull
+    {
+        [Key(0)]
+        public int Value { get; set; }
+    }
+
+    [MessagePackObject]
+    public class CanBeNull
+    {
+        [Key(0)]
+        public int Value { get; set; }
+    }
+
+    [MessagePackObject]
+    public class NullPropertyDisallowed
+    {
+        [Key(0, false)]
+        public string PropertyValue { get; set; }
+    }
+
+    [MessagePackObject]
+    public class NullPropertyAllowed
+    {
+        [Key(0)]
+        public string PropertyValue { get; set; }
+    }
+
+    [MessagePackObject]
+    public class NullPropertyDisallowedStringKey
+    {
+        [Key("abc", false)]
+        public string PropertyValue { get; set; }
+    }
+
+    [MessagePackObject]
+    public class NullPropertyAllowedStringKey
+    {
+        [Key("abc")]
+        public string PropertyValue { get; set; }
+    }
+
+    [MessagePackObject(keyAsPropertyName: false, allowNil: false)]
+    public class GenericCannotBeNull<T>
+    {
+        [Key(0)]
+        public T Value { get; set; }
+    }
+
+    [MessagePackObject]
+    public class GenericCanBeNull<T>
+    {
+        [Key(0)]
+        public T Value { get; set; }
+    }
+
+    [MessagePackObject]
+    public class GenericNullPropertyDisallowed<T>
+    {
+        [Key(0, false)]
+        public T PropertyValue { get; set; }
+    }
+
+    [MessagePackObject]
+    public class GenericNullPropertyAllowed<T>
+    {
+        [Key(0)]
+        public T PropertyValue { get; set; }
+    }
+
+}


### PR DESCRIPTION
MessagePack allows (de)serialization of null references, and of course that is really great to have. However there are some cases where having the serialization layer guarantee that some objects or class members are non null can provide some safety to the code (like it is done for example in [another MessagePack implementation for C#](https://github.com/scopely/msgpack-sharp/blob/master/msgpack-sharp/NilImplication.cs). This PR adds a `AllowNil` property on `MessagePackObjectAttribute` and `KeyAttribute` to allow users of the library to specify when they would like to prevent certain classes of members to be null at (de)serialization time.

I added some tests, but if I have overlooked some implications of the changes please let me know.

I was actually surprised that the required change is relatively small, for an added functionality that I believe could be beneficial to others, and is not uncommon for a serialization library.