### PR TITLE
Use [in] for ReadOnlySequence<byte> parameters

### DIFF
--- a/src/MessagePack/Internal/AutomataDictionary.cs
+++ b/src/MessagePack/Internal/AutomataDictionary.cs
@@ -46,7 +46,7 @@ namespace MessagePack.Internal
             }
         }
 
-        public bool TryGetValue(ReadOnlySequence<byte> bytes, out int value) => TryGetValue(bytes.ToArray(), out value);
+        public bool TryGetValue(in ReadOnlySequence<byte> bytes, out int value) => TryGetValue(bytes.ToArray(), out value);
 
         public bool TryGetValue(ReadOnlySpan<byte> bytes, out int value)
         {

--- a/src/MessagePack/Internal/ByteArrayStringHashTable.cs
+++ b/src/MessagePack/Internal/ByteArrayStringHashTable.cs
@@ -77,7 +77,7 @@ namespace MessagePack.Internal
             return true;
         }
 
-        public bool TryGetValue(ReadOnlySequence<byte> key, out int value) => TryGetValue(CodeGenHelpers.GetSpanFromSequence(key), out value);
+        public bool TryGetValue(in ReadOnlySequence<byte> key, out int value) => TryGetValue(CodeGenHelpers.GetSpanFromSequence(key), out value);
 
         public bool TryGetValue(ReadOnlySpan<byte> key, out int value)
         {

--- a/src/MessagePack/LZ4/LZ4MessagePackSerializer.cs
+++ b/src/MessagePack/LZ4/LZ4MessagePackSerializer.cs
@@ -80,7 +80,7 @@ namespace MessagePack
         /// <param name="output">The buffer to write the result of the operation.</param>
         /// <param name="lz4Operation">The LZ4 codec transformation.</param>
         /// <returns>The number of bytes written to the <paramref name="output"/>.</returns>
-        private static int LZ4Operation(ReadOnlySequence<byte> input, Span<byte> output, LZ4Transform lz4Operation)
+        private static int LZ4Operation(in ReadOnlySequence<byte> input, Span<byte> output, LZ4Transform lz4Operation)
         {
             ReadOnlySpan<byte> inputSpan;
             byte[] rentedInputArray = null;
@@ -138,7 +138,7 @@ namespace MessagePack
             return false;
         }
 
-        private static void ToLZ4BinaryCore(ReadOnlySequence<byte> msgpackUncompressedData, ref MessagePackWriter writer)
+        private static void ToLZ4BinaryCore(in ReadOnlySequence<byte> msgpackUncompressedData, ref MessagePackWriter writer)
         {
             if (msgpackUncompressedData.Length < NotCompressionSize)
             {

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -41,7 +41,7 @@ namespace MessagePack
         /// Initializes a new instance of the <see cref="MessagePackReader"/> struct.
         /// </summary>
         /// <param name="readOnlySequence">The sequence to read from.</param>
-        public MessagePackReader(ReadOnlySequence<byte> readOnlySequence)
+        public MessagePackReader(in ReadOnlySequence<byte> readOnlySequence)
         {
             this.reader = new SequenceReader<byte>(readOnlySequence);
         }
@@ -99,7 +99,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="readOnlySequence">The sequence to read from.</param>
         /// <returns>The new reader.</returns>
-        public MessagePackReader Clone(ReadOnlySequence<byte> readOnlySequence) => new MessagePackReader(readOnlySequence)
+        public MessagePackReader Clone(in ReadOnlySequence<byte> readOnlySequence) => new MessagePackReader(readOnlySequence)
         {
         };
 

--- a/src/MessagePack/MessagePackSerializer+Typeless.cs
+++ b/src/MessagePack/MessagePackSerializer+Typeless.cs
@@ -39,7 +39,7 @@ namespace MessagePack
 
             public object Deserialize(ref MessagePackReader reader) => serializer.Deserialize<object>(ref reader);
 
-            public object Deserialize(ReadOnlySequence<byte> byteSequence) => serializer.Deserialize<object>(byteSequence);
+            public object Deserialize(in ReadOnlySequence<byte> byteSequence) => serializer.Deserialize<object>(byteSequence);
 
             public object Deserialize(Stream stream) => serializer.Deserialize<object>(stream);
 

--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -44,7 +44,7 @@ namespace MessagePack
         /// <summary>
         /// Convert a message-pack binary to a JSON string.
         /// </summary>
-        public string ConvertToJson(ReadOnlySequence<byte> bytes)
+        public string ConvertToJson(in ReadOnlySequence<byte> bytes)
         {
             var jsonWriter = new StringWriter();
             var reader = new MessagePackReader(bytes);

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -139,7 +139,7 @@ namespace MessagePack
         /// <param name="byteSequence">The sequence to deserialize from.</param>
         /// <param name="resolver">The resolver to use during deserialization. Use <c>null</c> to use the <see cref="DefaultResolver"/>.</param>
         /// <returns>The deserialized value.</returns>
-        public T Deserialize<T>(ReadOnlySequence<byte> byteSequence, IFormatterResolver resolver = null)
+        public T Deserialize<T>(in ReadOnlySequence<byte> byteSequence, IFormatterResolver resolver = null)
         {
             var reader = new MessagePackReader(byteSequence);
             return this.Deserialize<T>(ref reader, resolver);

--- a/src/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack/MessagePackWriter.cs
@@ -90,7 +90,7 @@ namespace MessagePack
         /// Copies bytes directly into the message pack writer.
         /// </summary>
         /// <param name="rawMessagePackBlock">The span of bytes to copy from.</param>
-        public void WriteRaw(ReadOnlySequence<byte> rawMessagePackBlock)
+        public void WriteRaw(in ReadOnlySequence<byte> rawMessagePackBlock)
         {
             foreach (var segment in rawMessagePackBlock)
             {
@@ -812,7 +812,7 @@ namespace MessagePack
         /// <see cref="MessagePackCode.Bin32"/>,
         /// </summary>
         /// <param name="src">The span of bytes to write.</param>
-        public void Write(ReadOnlySequence<byte> src)
+        public void Write(in ReadOnlySequence<byte> src)
         {
             if (this.OldSpec)
             {
@@ -863,7 +863,7 @@ namespace MessagePack
         /// <see cref="MessagePackCode.Str32"/>,
         /// </summary>
         /// <param name="utf8stringBytes">The bytes to write.</param>
-        public void WriteString(ReadOnlySequence<byte> utf8stringBytes)
+        public void WriteString(in ReadOnlySequence<byte> utf8stringBytes)
         {
             var byteCount = (int)utf8stringBytes.Length;
             if (byteCount <= MessagePackRange.MaxFixStringLength)

--- a/src/MessagePack/SequenceReader.cs
+++ b/src/MessagePack/SequenceReader.cs
@@ -49,7 +49,7 @@ namespace System.Buffers
         /// over the given <see cref="ReadOnlySequence{T}"/>.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public SequenceReader(ReadOnlySequence<T> sequence)
+        public SequenceReader(in ReadOnlySequence<T> sequence)
         {
             _usingSequence = true;
             CurrentSpanIndex = 0;


### PR DESCRIPTION
This is a small perf improvement since this is a large struct and pushing an address to the stack is faster than copying the struct.

See Utf8JsonReader from corefx which does the same thing.

For public API, this is a binary breaking change since the IL emitted by the compiler for a caller pushes an address to the struct rather than the struct itself. So it's important to make such changes before our API is finalized.