### PR TITLE
Allows use of IL2CPP on Unsafe implementation on Android armv7

### DIFF
--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe.cs
@@ -34,39 +34,6 @@ namespace MessagePack.LZ4
     /// <summary>Unsafe LZ4 codec.</summary>
     partial class LZ4Codec
     {
-        /// <summary>Copies block of memory.</summary>
-        /// <param name="src">The source.</param>
-        /// <param name="dst">The destination.</param>
-        /// <param name="len">The length (in bytes).</param>
-        private static unsafe void BlockCopy(byte* src, byte* dst, int len)
-        {
-            while (len >= 8)
-            {
-                *(ulong*)dst = *(ulong*)src;
-                dst += 8;
-                src += 8;
-                len -= 8;
-            }
-            if (len >= 4)
-            {
-                *(uint*)dst = *(uint*)src;
-                dst += 4;
-                src += 4;
-                len -= 4;
-            }
-            if (len >= 2)
-            {
-                *(ushort*)dst = *(ushort*)src;
-                dst += 2;
-                src += 2;
-                len -= 2;
-            }
-            if (len >= 1)
-            {
-                *dst = *src; /* d++; s++; l--; */
-            }
-        }
-
         /// <summary>Encodes the specified input.</summary>
         /// <param name="input">The input.</param>
         /// <param name="output">The output.</param>

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe32.Dirty.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe32.Dirty.cs
@@ -164,7 +164,7 @@ namespace MessagePack.LZ4
                                     len -= 255;
                                 } while (len > 254);
                                 *dst_p++ = (byte)len;
-                                BlockCopy(src_anchor, dst_p, (length));
+                                BlockCopy32(src_anchor, dst_p, (length));
                                 dst_p += length;
                                 goto _next_match;
                             }
@@ -291,7 +291,7 @@ namespace MessagePack.LZ4
                             *dst_p++ = (byte)lastRun;
                         }
                         else *dst_p++ = (byte)(lastRun << ML_BITS);
-                        BlockCopy(src_anchor, dst_p, (int)(src_end - src_anchor));
+                        BlockCopy32(src_anchor, dst_p, (int)(src_end - src_anchor));
                         dst_p += src_end - src_anchor;
                     }
 
@@ -393,7 +393,7 @@ namespace MessagePack.LZ4
                                     len -= 255;
                                 } while (len > 254);
                                 *dst_p++ = (byte)len;
-                                BlockCopy(src_anchor, dst_p, (length));
+                                BlockCopy32(src_anchor, dst_p, (length));
                                 dst_p += length;
                                 goto _next_match;
                             }
@@ -515,7 +515,7 @@ namespace MessagePack.LZ4
                             *dst_p++ = (byte)lastRun;
                         }
                         else *dst_p++ = (byte)(lastRun << ML_BITS);
-                        BlockCopy(src_anchor, dst_p, (int)(src_end - src_anchor));
+                        BlockCopy32(src_anchor, dst_p, (int)(src_end - src_anchor));
                         dst_p += src_end - src_anchor;
                     }
 
@@ -575,7 +575,7 @@ namespace MessagePack.LZ4
                         if (dst_cpy > dst_COPYLENGTH)
                         {
                             if (dst_cpy != dst_end) goto _output_error; // Error : not enough place for another match (min 4) + 5 literals
-                            BlockCopy(src_p, dst_p, (length));
+                            BlockCopy32(src_p, dst_p, (length));
                             src_p += length;
                             break; // EOF
                         }
@@ -670,6 +670,32 @@ namespace MessagePack.LZ4
         }
 
         #endregion
+
+        /// <summary>Copies block of memory.</summary>
+        /// <param name="src">The source.</param>
+        /// <param name="dst">The destination.</param>
+        /// <param name="len">The length (in bytes).</param>
+        private static unsafe void BlockCopy32(byte* src, byte* dst, int len)
+        {
+            while (len >= 4)
+            {
+                *(uint*)dst = *(uint*)src;
+                dst += 4;
+                src += 4;
+                len -= 4;
+            }
+            if (len >= 2)
+            {
+                *(ushort*)dst = *(ushort*)src;
+                dst += 2;
+                src += 2;
+                len -= 2;
+            }
+            if (len >= 1)
+            {
+                *dst = *src; /* d++; s++; l--; */
+            }
+        }
     }
 }
 

--- a/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe64.Dirty.cs
+++ b/src/MessagePack/LZ4/Codec/LZ4Codec.Unsafe64.Dirty.cs
@@ -164,7 +164,7 @@ namespace MessagePack.LZ4
                                     len -= 255;
                                 } while (len > 254);
                                 *dst_p++ = (byte)len;
-                                BlockCopy(src_anchor, dst_p, (length));
+                                BlockCopy64(src_anchor, dst_p, (length));
                                 dst_p += length;
                                 goto _next_match;
                             }
@@ -292,7 +292,7 @@ namespace MessagePack.LZ4
                         *dst_p++ = (byte)lastRun;
                     }
                     else *dst_p++ = (byte)(lastRun << ML_BITS);
-                    BlockCopy(src_anchor, dst_p, (int)(src_end - src_anchor));
+                    BlockCopy64(src_anchor, dst_p, (int)(src_end - src_anchor));
                     dst_p += src_end - src_anchor;
 
                     // End
@@ -396,7 +396,7 @@ namespace MessagePack.LZ4
                                     len -= 255;
                                 } while (len > 254);
                                 *dst_p++ = (byte)len;
-                                BlockCopy(src_anchor, dst_p, (length));
+                                BlockCopy64(src_anchor, dst_p, (length));
                                 dst_p += length;
                                 goto _next_match;
                             }
@@ -526,7 +526,7 @@ namespace MessagePack.LZ4
                         *dst_p++ = (byte)lastRun;
                     }
                     else *dst_p++ = (byte)(lastRun << ML_BITS);
-                    BlockCopy(src_anchor, dst_p, (int)(src_end - src_anchor));
+                    BlockCopy64(src_anchor, dst_p, (int)(src_end - src_anchor));
                     dst_p += src_end - src_anchor;
 
                     // End
@@ -586,7 +586,7 @@ namespace MessagePack.LZ4
                         if (dst_cpy > dst_COPYLENGTH)
                         {
                             if (dst_cpy != dst_end) goto _output_error; // Error : not enough place for another match (min 4) + 5 literals
-                            BlockCopy(src_p, dst_p, (length));
+                            BlockCopy64(src_p, dst_p, (length));
                             src_p += length;
                             break; // EOF
                         }
@@ -672,6 +672,39 @@ namespace MessagePack.LZ4
         }
 
         #endregion
+
+        /// <summary>Copies block of memory.</summary>
+        /// <param name="src">The source.</param>
+        /// <param name="dst">The destination.</param>
+        /// <param name="len">The length (in bytes).</param>
+        private static unsafe void BlockCopy64(byte* src, byte* dst, int len)
+        {
+            while (len >= 8)
+            {
+                *(ulong*)dst = *(ulong*)src;
+                dst += 8;
+                src += 8;
+                len -= 8;
+            }
+            if (len >= 4)
+            {
+                *(uint*)dst = *(uint*)src;
+                dst += 4;
+                src += 4;
+                len -= 4;
+            }
+            if (len >= 2)
+            {
+                *(ushort*)dst = *(ushort*)src;
+                dst += 2;
+                src += 2;
+                len -= 2;
+            }
+            if (len >= 1)
+            {
+                *dst = *src; /* d++; s++; l--; */
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Related to #376 and MiloszKrajewski/K4os.Compression.LZ4#19

The `*ulong` path in BlockCopy was causing this issue on 32 bits processors, so the method has been split in a 32 bit and a 64 bit version instead.

Once it has been more tested, I think we can remove the branch by UNITY define.