### PR TITLE
Drop any targets below netstandard2.0 / netcoreapp2.1

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/sandbox/PerfNetFramework/PerfNetFramework.csproj
+++ b/sandbox/PerfNetFramework/PerfNetFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/sandbox/Sandbox/Sandbox.csproj
+++ b/sandbox/Sandbox/Sandbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Prefer32Bit>False</Prefer32Bit>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/sandbox/SharedData/SharedData.csproj
+++ b/sandbox/SharedData/SharedData.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MessagePack\MessagePack.csproj" />

--- a/src/MessagePack.Annotations/MessagePack.Annotations.csproj
+++ b/src/MessagePack.Annotations/MessagePack.Annotations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0</TargetFrameworks>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <RootNamespace>MessagePack</RootNamespace>
 

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <Title>ASP.NET Core MVC Input/Output MessagePack formatter</Title>

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <Title>ASP.NET Core MVC Input/Output MessagePack formatter</Title>

--- a/src/MessagePack.ImmutableCollection/MessagePack.ImmutableCollection.csproj
+++ b/src/MessagePack.ImmutableCollection/MessagePack.ImmutableCollection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <Title>MessagePack for C# Extension Support for ImmutableCollection</Title>

--- a/src/MessagePack.ImmutableCollection/MessagePack.ImmutableCollection.csproj
+++ b/src/MessagePack.ImmutableCollection/MessagePack.ImmutableCollection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <Title>MessagePack for C# Extension Support for ImmutableCollection</Title>

--- a/src/MessagePack.ReactiveProperty/MessagePack.ReactiveProperty.csproj
+++ b/src/MessagePack.ReactiveProperty/MessagePack.ReactiveProperty.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <Title>MessagePack for C# Extension Support for ReactiveProperty</Title>

--- a/src/MessagePack.ReactiveProperty/MessagePack.ReactiveProperty.csproj
+++ b/src/MessagePack.ReactiveProperty/MessagePack.ReactiveProperty.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <Title>MessagePack for C# Extension Support for ReactiveProperty</Title>

--- a/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
+++ b/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <RootNamespace>MessagePack.Unity</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK</DefineConstants>

--- a/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
+++ b/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MessagePack.Unity</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK</DefineConstants>

--- a/src/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack/Internal/DynamicAssembly.cs
@@ -8,7 +8,7 @@ namespace MessagePack.Internal
 {
     internal class DynamicAssembly
     {
-#if NETFRAMEWORK
+#if NETFRAMEWORK // We don't ship a net472 target, but we might add one for debugging purposes
         readonly string moduleName;
 #endif
         readonly AssemblyBuilder assemblyBuilder;
@@ -21,19 +21,14 @@ namespace MessagePack.Internal
 
         public DynamicAssembly(string moduleName)
         {
-#if NETFRAMEWORK
+#if NETFRAMEWORK // We don't ship a net472 target, but we might add one for debugging purposes
+            var builderAccess = AssemblyBuilderAccess.RunAndSave;
             this.moduleName = moduleName;
-            this.assemblyBuilder = System.AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(moduleName), AssemblyBuilderAccess.RunAndSave);
-            this.moduleBuilder = assemblyBuilder.DefineDynamicModule(moduleName, moduleName + ".dll");
 #else
-#if !UNITY
-            this.assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(moduleName), AssemblyBuilderAccess.Run);
-#else
-            this.assemblyBuilder = System.AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(moduleName), AssemblyBuilderAccess.Run);
+            var builderAccess = AssemblyBuilderAccess.Run;
 #endif
-
+            this.assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(moduleName), builderAccess);
             this.moduleBuilder = assemblyBuilder.DefineDynamicModule(moduleName);
-#endif
         }
 
         // requires lock on mono environment. see: https://github.com/neuecc/MessagePack-CSharp/issues/161
@@ -66,7 +61,7 @@ namespace MessagePack.Internal
 
         public AssemblyBuilder Save()
         {
-            assemblyBuilder.Save(moduleName + ".dll");
+            assemblyBuilder.Save(this.moduleName + ".dll");
             return assemblyBuilder;
         }
 

--- a/src/MessagePack/Internal/ILGeneratorExtensions.cs
+++ b/src/MessagePack/Internal/ILGeneratorExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+﻿#if !UNITY_WSA && !NET_STANDARD_2_0
 
 using System;
 using System.Linq;
@@ -391,5 +390,4 @@ namespace MessagePack.Internal
 
 }
 
-#endif
 #endif

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;netcoreapp2.1;net46;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net472</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK</DefineConstants>

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK</DefineConstants>

--- a/src/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack/MessagePackReader.cs
@@ -809,14 +809,7 @@ namespace MessagePack
         private string ReadStringSlow(int byteLength)
         {
             ThrowInsufficientBufferUnless(this.reader.Remaining >= byteLength);
-#if NETSTANDARD1_6
-            // We need to concatenate all the bytes together into one array.
-            byte[] byteArray = ArrayPool<byte>.Shared.Rent(byteLength);
-            ThrowInsufficientBufferUnless(this.reader.TryCopyTo(byteArray.AsSpan(0, byteLength)));
-            string value = StringEncoding.UTF8.GetString(byteArray, 0, byteLength);
-            ArrayPool<byte>.Shared.Return(byteArray);
-            return value;
-#else
+
             // We need to decode bytes incrementally across multiple spans.
             int maxCharLength = StringEncoding.UTF8.GetMaxCharCount(byteLength);
             char[] charArray = ArrayPool<char>.Shared.Rent(maxCharLength);
@@ -847,7 +840,6 @@ namespace MessagePack
             string value = new string(charArray, 0, initializedChars);
             ArrayPool<char>.Shared.Return(charArray);
             return value;
-#endif
         }
 
         private void ReadNextArray()

--- a/src/MessagePack/Resolvers/ContractlessReflectionObjectResolver.cs
+++ b/src/MessagePack/Resolvers/ContractlessReflectionObjectResolver.cs
@@ -1,6 +1,4 @@
-﻿#if NETSTANDARD
-
-using MessagePack.Formatters;
+﻿using MessagePack.Formatters;
 using MessagePack.Internal;
 using System;
 using System.Collections.Generic;
@@ -301,5 +299,3 @@ namespace MessagePack.Resolvers
     //    }
     //}
 }
-
-#endif

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>


### PR DESCRIPTION
This drops our target frameworks from 5 to 2 for the main library, and several more targets are removed from other assemblies since netstandard2.0 is sufficient for them.

The VS editing experience has been rather slow lately. I expect it's because of all the target frameworks that essentially multiply the size of the solution. This should aid in improving perf for editing and running tests.

Closes #475