### PR TITLE
Fixes the ASP.NET Core I/O formatters to be async

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -118,7 +118,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.Streams" Version="2.1.28-beta" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.38" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>

--- a/sandbox/SharedData/Class1.cs
+++ b/sandbox/SharedData/Class1.cs
@@ -34,7 +34,7 @@ namespace SharedData
     public enum ULongEnum : ulong { A, B, C, D, E }
 
     [MessagePackObject]
-    public class FirstSimpleData
+    public class FirstSimpleData : IEquatable<FirstSimpleData>
     {
         [Key(0)]
         public int Prop1 { get; set; }
@@ -44,6 +44,14 @@ namespace SharedData
 
         [Key(2)]
         public int Prop3 { get; set; }
+
+        public bool Equals(FirstSimpleData other)
+        {
+            return other != null
+                && this.Prop1 == other.Prop1
+                && this.Prop2 == other.Prop2
+                && this.Prop3 == other.Prop3;
+        }
     }
 
     [MessagePackObject]

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePackInputFormatter.cs
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePackInputFormatter.cs
@@ -24,12 +24,11 @@ namespace MessagePack.AspNetCoreMvcFormatter
         public bool CanRead(InputFormatterContext context) =>
             context.HttpContext.Request.ContentType == ContentType;
 
-        public Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
+        public async Task<InputFormatterResult> ReadAsync(InputFormatterContext context)
         {
-            // TODO: switch to async typeless method when available.
             Microsoft.AspNetCore.Http.HttpRequest request = context.HttpContext.Request;
-            var result = MessagePackSerializer.Deserialize(context.ModelType, request.Body, this.options);
-            return InputFormatterResult.SuccessAsync(result);
+            object result = await MessagePackSerializer.DeserializeAsync(context.ModelType, request.Body, this.options, context.HttpContext.RequestAborted);
+            return await InputFormatterResult.SuccessAsync(result);
         }
     }
 }

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
@@ -37,16 +37,12 @@ namespace MessagePack.AspNetCoreMvcFormatter
                 }
                 else
                 {
-                    // TODO: switch to async typeless method when available.
-                    MessagePackSerializer.Serialize(context.Object.GetType(), context.HttpContext.Response.Body, context.Object, this.options);
-                    return Task.CompletedTask;
+                    return MessagePackSerializer.SerializeAsync(context.Object.GetType(), context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
                 }
             }
             else
             {
-                // TODO: switch to async typeless method when available.
-                MessagePackSerializer.Serialize(context.ObjectType, context.HttpContext.Response.Body, context.Object, this.options);
-                return Task.CompletedTask;
+                return MessagePackSerializer.SerializeAsync(context.ObjectType, context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
             }
         }
     }

--- a/src/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/src/MessagePack.Internal/MessagePack.Internal.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.Streams" Version="2.1.28-beta" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.38" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>
 

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -33,8 +33,9 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.1.28-beta" />
-    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.38" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MessagePack/MessagePackSerializer+Typeless.cs
+++ b/src/MessagePack/MessagePackSerializer+Typeless.cs
@@ -32,7 +32,7 @@ namespace MessagePack
 
             public static void Serialize(Stream stream, object obj, MessagePackSerializerOptions options = null) => Serialize<object>(stream, obj, options ?? DefaultOptions);
 
-            public static ValueTask SerializeAsync(Stream stream, object obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => SerializeAsync<object>(stream, obj, options ?? DefaultOptions, cancellationToken);
+            public static Task SerializeAsync(Stream stream, object obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => SerializeAsync<object>(stream, obj, options ?? DefaultOptions, cancellationToken);
 
             public static object Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options = null) => Deserialize<object>(ref reader, options ?? DefaultOptions);
 

--- a/src/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack/MessagePackSerializer.cs
@@ -120,7 +120,7 @@ namespace MessagePack
         /// <param name="options">The options. Use <c>null</c> to use default options.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A task that completes with the result of the async serialization operation.</returns>
-        public static async ValueTask SerializeAsync<T>(Stream stream, T value, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static async Task SerializeAsync<T>(Stream stream, T value, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             System.IO.Pipelines.PipeWriter writer = stream.UseStrictPipeWriter();
             Serialize(writer, value, options);

--- a/src/MessagePack/Resolvers/DynamicEnumAsStringResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicEnumAsStringResolver.cs
@@ -15,12 +15,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly DynamicEnumAsStringResolver Instance = new DynamicEnumAsStringResolver();
+        public static readonly DynamicEnumAsStringResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static DynamicEnumAsStringResolver()
+        {
+            Instance = new DynamicEnumAsStringResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
         private DynamicEnumAsStringResolver()
         {

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -24,27 +24,29 @@ namespace MessagePack.Resolvers
     /// </summary>
     public sealed class DynamicObjectResolver : IFormatterResolver
     {
+        private const string ModuleName = "MessagePack.Resolvers.DynamicObjectResolver";
+
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly DynamicObjectResolver Instance = new DynamicObjectResolver();
+        public static readonly DynamicObjectResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
-
-        private const string ModuleName = "MessagePack.Resolvers.DynamicObjectResolver";
+        public static readonly MessagePackSerializerOptions Options;
 
         internal static readonly DynamicAssembly DynamicAssembly;
 
-        private DynamicObjectResolver()
-        {
-        }
-
         static DynamicObjectResolver()
         {
+            Instance = new DynamicObjectResolver();
+            Options = new MessagePackSerializerOptions(Instance);
             DynamicAssembly = new DynamicAssembly(ModuleName);
+        }
+
+        private DynamicObjectResolver()
+        {
         }
 
 #if NETFRAMEWORK

--- a/src/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -24,34 +24,36 @@ namespace MessagePack.Resolvers
     /// </summary>
     public sealed class DynamicUnionResolver : IFormatterResolver
     {
+        private const string ModuleName = "MessagePack.Resolvers.DynamicUnionResolver";
+
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly DynamicUnionResolver Instance = new DynamicUnionResolver();
+        public static readonly DynamicUnionResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
-
-        private const string ModuleName = "MessagePack.Resolvers.DynamicUnionResolver";
+        public static readonly MessagePackSerializerOptions Options;
 
         private static readonly DynamicAssembly DynamicAssembly;
 #if !UNITY
         private static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+", RegexOptions.Compiled);
 #else
-        static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+");
+        private static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+");
 #endif
 
         private static int nameSequence = 0;
 
-        private DynamicUnionResolver()
-        {
-        }
-
         static DynamicUnionResolver()
         {
+            Instance = new DynamicUnionResolver();
+            Options = new MessagePackSerializerOptions(Instance);
             DynamicAssembly = new DynamicAssembly(ModuleName);
+        }
+
+        private DynamicUnionResolver()
+        {
         }
 
 #if NETFRAMEWORK

--- a/src/MessagePack/Resolvers/NativeDateTimeResolver.cs
+++ b/src/MessagePack/Resolvers/NativeDateTimeResolver.cs
@@ -14,12 +14,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly NativeDateTimeResolver Instance = new NativeDateTimeResolver();
+        public static readonly NativeDateTimeResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static NativeDateTimeResolver()
+        {
+            Instance = new NativeDateTimeResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
         private NativeDateTimeResolver()
         {

--- a/src/MessagePack/Resolvers/PrimitiveObjectResolver.cs
+++ b/src/MessagePack/Resolvers/PrimitiveObjectResolver.cs
@@ -10,12 +10,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly PrimitiveObjectResolver Instance = new PrimitiveObjectResolver();
+        public static readonly PrimitiveObjectResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static PrimitiveObjectResolver()
+        {
+            Instance = new PrimitiveObjectResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
         private PrimitiveObjectResolver()
         {

--- a/src/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack/Resolvers/StandardResolver.cs
@@ -18,16 +18,22 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly StandardResolver Instance = new StandardResolver();
+        public static readonly StandardResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
 
 #if !UNITY
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverCore.Instance);
 #endif
+
+        static StandardResolver()
+        {
+            Instance = new StandardResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
         private StandardResolver()
         {
@@ -66,12 +72,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly ContractlessStandardResolver Instance = new ContractlessStandardResolver();
+        public static readonly ContractlessStandardResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static ContractlessStandardResolver()
+        {
+            Instance = new ContractlessStandardResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
 #if !UNITY
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverCore.Instance);
@@ -114,12 +126,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly StandardResolverAllowPrivate Instance = new StandardResolverAllowPrivate();
+        public static readonly StandardResolverAllowPrivate Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static StandardResolverAllowPrivate()
+        {
+            Instance = new StandardResolverAllowPrivate();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
 #if !UNITY
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverAllowPrivateCore.Instance);
@@ -162,12 +180,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly ContractlessStandardResolverAllowPrivate Instance = new ContractlessStandardResolverAllowPrivate();
+        public static readonly ContractlessStandardResolverAllowPrivate Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static ContractlessStandardResolverAllowPrivate()
+        {
+            Instance = new ContractlessStandardResolverAllowPrivate();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
 #if !UNITY
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverAllowPrivateCore.Instance);

--- a/src/MessagePack/Resolvers/TypelessObjectResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessObjectResolver.cs
@@ -52,12 +52,18 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly ForceSizePrimitiveObjectResolver Instance = new ForceSizePrimitiveObjectResolver();
+        public static readonly ForceSizePrimitiveObjectResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
+
+        static ForceSizePrimitiveObjectResolver()
+        {
+            Instance = new ForceSizePrimitiveObjectResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
         private ForceSizePrimitiveObjectResolver()
         {
@@ -127,16 +133,22 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The singleton instance that can be used.
         /// </summary>
-        public static readonly TypelessFormatterFallbackResolver Instance = new TypelessFormatterFallbackResolver();
+        public static readonly TypelessFormatterFallbackResolver Instance;
 
         /// <summary>
         /// A <see cref="MessagePackSerializerOptions"/> instance with this formatter pre-configured.
         /// </summary>
-        public static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(Instance);
+        public static readonly MessagePackSerializerOptions Options;
 
         private static readonly IMessagePackFormatter<object> FallbackFormatter = new DynamicObjectTypeFallbackFormatter(
             ForceSizePrimitiveObjectResolver.Instance,
             ContractlessStandardResolverAllowPrivateCore.Instance);
+
+        static TypelessFormatterFallbackResolver()
+        {
+            Instance = new TypelessFormatterFallbackResolver();
+            Options = new MessagePackSerializerOptions(Instance);
+        }
 
         private TypelessFormatterFallbackResolver()
         {

--- a/tests/MessagePack.Tests/MessagePackSerializerTest.cs
+++ b/tests/MessagePack.Tests/MessagePackSerializerTest.cs
@@ -15,12 +15,6 @@ namespace MessagePack.Tests
 {
     public class MessagePackSerializerTest
     {
-        private T ConvertNonGeneric<T>(T obj)
-        {
-            Type t = obj.GetType();
-            return (T)MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, obj));
-        }
-
         [Fact]
         public void NonGeneric()
         {
@@ -43,6 +37,20 @@ namespace MessagePack.Tests
             new[] { data1.Prop1, data2.Prop1, data3.Prop1, data4.Prop1 }.Distinct().Is(data.Prop1);
             new[] { data1.Prop2, data2.Prop2, data3.Prop2, data4.Prop2 }.Distinct().Is(data.Prop2);
             new[] { data1.Prop3, data2.Prop3, data3.Prop3, data4.Prop3 }.Distinct().Is(data.Prop3);
+        }
+
+        [Fact]
+        public async Task NonGeneric_Async()
+        {
+            var data = new FirstSimpleData { Prop1 = 9, Prop2 = "hoge", Prop3 = 999 };
+            Type t = typeof(FirstSimpleData);
+            var ms = new MemoryStream();
+
+            await MessagePackSerializer.SerializeAsync(t, ms, data);
+            ms.Position = 0;
+            var data2 = (FirstSimpleData)await MessagePackSerializer.DeserializeAsync(t, ms);
+
+            Assert.Equal(data, data2);
         }
 
         [Fact]


### PR DESCRIPTION
As part of the required fix, this adds a couple async, non-generic overloads to MessagePackSerializer.

I switched the pre-existing SerializerAsync method's return type from ValueTask to Task because Task is more natural in more places and does not incur an extra allocation because it doesn't return a value.

Fixes #411