### PR TITLE
Downgrade Nerdbank.Streams in use

### DIFF
--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.2.38" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.26" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>


### PR DESCRIPTION
This avoids a regression in 2.2.38, which hasn't been fully fixed yet.