### PR TITLE
MVC output Formatter does not check correctly for contenttype - fix #499

### DIFF
--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Extensions.Primitives;
 
 namespace MessagePack.AspNetCoreMvcFormatter
 {
@@ -21,8 +22,16 @@ namespace MessagePack.AspNetCoreMvcFormatter
             this.options = options;
         }
 
-        public bool CanWriteResult(OutputFormatterCanWriteContext context) =>
-            context.HttpContext.Request.ContentType == ContentType;
+        public bool CanWriteResult(OutputFormatterCanWriteContext context)
+        {
+            if (!context.ContentType.HasValue)
+            {
+                context.ContentType = new StringSegment(ContentType);
+                return true;
+            }
+
+            return context.ContentType.Value == ContentType;
+        }
 
         public Task WriteAsync(OutputFormatterWriteContext context)
         {


### PR DESCRIPTION
Check if desired content type is application/x-msgpack to tell if formatter can write output.

If desired content type is null then the formatter can write a format he want. So here we set the content type to application/x-msgpack

fix #499