### PR TITLE
Make CompositeResolver faster and immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,7 +1210,13 @@ By default, `mpc.exe` generates resolver to `MessagePack.Resolvers.GeneratedReso
 
 ```csharp
 // Do this once and store it for reuse.
-var resolver = MessagePack.Resolvers.CompositeResolver.CreateForAot(MessagePack.Resolvers.GeneratedResolver.Instance);
+var resolver = MessagePack.Resolvers.CompositeResolver.Create(
+    Array.Empty<IMessagePackFormatter>(),
+    new IFormatterResolver[]
+    {
+        MessagePack.Resolvers.GeneratedResolver.Instance,
+        MessagePack.Resolvers.StandardResolver.Instance,
+    });
 var options = MessagePackSerializerOptions.Default.WithResolver(resolver);
 
 // Each time you serialize/deserialize, specify the options:

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IMessagePackFormatter`1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IMessagePackFormatter`1.cs
@@ -2,14 +2,26 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.ComponentModel;
 
 namespace MessagePack.Formatters
 {
+#pragma warning disable SA1649 // File name should match first type name
+    /// <summary>
+    /// A base interface for <see cref="IMessagePackFormatter{T}"/> so that all generic implementations
+    /// can be detected by a common base type.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IMessagePackFormatter
+    {
+    }
+#pragma warning restore SA1649 // File name should match first type name
+
     /// <summary>
     /// The contract for serialization of some specific type.
     /// </summary>
     /// <typeparam name="T">The type to be serialized or deserialized.</typeparam>
-    public interface IMessagePackFormatter<T>
+    public interface IMessagePackFormatter<T> : IMessagePackFormatter
     {
         /// <summary>
         /// Serializes a value.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CachingFormatterResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CachingFormatterResolver.cs
@@ -16,12 +16,12 @@ namespace MessagePack.Resolvers
         /// <summary>
         /// The cache of types to their formatters.
         /// </summary>
-        private readonly ThreadsafeTypeKeyHashTable<object> formatters = new ThreadsafeTypeKeyHashTable<object>();
+        private readonly ThreadsafeTypeKeyHashTable<IMessagePackFormatter> formatters = new ThreadsafeTypeKeyHashTable<IMessagePackFormatter>();
 
         /// <inheritdoc />
         public IMessagePackFormatter<T> GetFormatter<T>()
         {
-            if (!this.formatters.TryGetValue(typeof(T), out object formatter))
+            if (!this.formatters.TryGetValue(typeof(T), out IMessagePackFormatter formatter))
             {
                 formatter = this.GetFormatterCore<T>();
                 this.formatters.TryAdd(typeof(T), formatter);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
@@ -22,30 +22,21 @@ namespace MessagePack.Resolvers
         private static readonly ReadOnlyDictionary<Type, IMessagePackFormatter> EmptyFormattersByType = new ReadOnlyDictionary<Type, IMessagePackFormatter>(new Dictionary<Type, IMessagePackFormatter>());
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CompositeResolver"/> class
-        /// with the supplied resolver that was pre-generated, and adds the standard non-AOT resolvers.
+        /// Initializes a new instance of an <see cref="IFormatterResolver"/> with the specified formatters and sub-resolvers.
         /// </summary>
-        /// <param name="aotResolver">An instance of the AOT code generated resolver.</param>
+        /// <param name="formatters">
+        /// A list of instances of <see cref="IMessagePackFormatter{T}"/> to prefer (above the <paramref name="resolvers"/>).
+        /// The formatters are searched in the order given, so if two formatters support serializing the same type, the first one is used.
+        /// May not be null, but may be <see cref="Array.Empty{T}"/>.
+        /// </param>
+        /// <param name="resolvers">
+        /// A list of resolvers to use for serializing types for which <paramref name="formatters"/> does not include a formatter.
+        /// The resolvers are searched in the order given, so if two resolvers support serializing the same type, the first one is used.
+        /// May not be null, but may be <see cref="Array.Empty{T}"/>.
+        /// </param>
         /// <returns>
-        /// The composite resolver that includes the AOT code generated resolver and several standard ones
-        /// that the AOT code generator expects to be present.
+        /// An instance of <see cref="IFormatterResolver"/>.
         /// </returns>
-        public static IFormatterResolver CreateForAot(IFormatterResolver aotResolver)
-        {
-            if (aotResolver is null)
-            {
-                throw new ArgumentNullException(nameof(aotResolver));
-            }
-
-            return Create(new[]
-            {
-                aotResolver,
-                BuiltinResolver.Instance,
-                AttributeFormatterResolver.Instance,
-                PrimitiveObjectResolver.Instance,
-            });
-        }
-
         public static IFormatterResolver Create(IReadOnlyList<IMessagePackFormatter> formatters, IReadOnlyList<IFormatterResolver> resolvers)
         {
             if (formatters is null)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 using MessagePack.Formatters;
 
@@ -16,18 +17,9 @@ namespace MessagePack.Resolvers
     /// <remarks>
     /// This class is not thread-safe for mutations. It is thread-safe when not being written to.
     /// </remarks>
-    public sealed class CompositeResolver : IFormatterResolver
+    public sealed class CompositeResolver
     {
-        private readonly Dictionary<Type, object> formattersByType;
-        private readonly List<IFormatterResolver> subResolvers;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CompositeResolver"/> class
-        /// with no formatters or resolvers.
-        /// </summary>
-        public CompositeResolver()
-        {
-        }
+        private static readonly ReadOnlyDictionary<Type, object> EmptyFormattersByType = new ReadOnlyDictionary<Type, object>(new Dictionary<Type, object>());
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositeResolver"/> class
@@ -38,124 +30,102 @@ namespace MessagePack.Resolvers
         /// The composite resolver that includes the AOT code generated resolver and several standard ones
         /// that the AOT code generator expects to be present.
         /// </returns>
-        public static CompositeResolver CreateForAot(IFormatterResolver aotResolver)
+        public static IFormatterResolver CreateForAot(IFormatterResolver aotResolver)
         {
-            var composite = new CompositeResolver();
-            composite.RegisterResolver(aotResolver);
-
-            composite.RegisterResolver(
-                BuiltinResolver.Instance,
-                AttributeFormatterResolver.Instance,
-                PrimitiveObjectResolver.Instance);
-
-            return composite;
-        }
-
-        /// <summary>
-        /// Adds a resolver to this composite resolver.
-        /// </summary>
-        /// <param name="resolver">The resolver to add.</param>
-        /// <remarks>
-        /// Each registered resolver is appended to the end of the list of resolvers to try for each requested type.
-        /// Registered formatters take precedence over all resolvers.
-        /// </remarks>
-        public void RegisterResolver(IFormatterResolver resolver)
-        {
-            if (resolver is null)
+            if (aotResolver is null)
             {
-                throw new ArgumentNullException(nameof(resolver));
+                throw new ArgumentNullException(nameof(aotResolver));
             }
 
-            this.subResolvers.Add(resolver);
+            return new CachingResolver(
+                EmptyFormattersByType,
+                new ReadOnlyCollection<IFormatterResolver>(
+                    new[]
+                    {
+                        aotResolver,
+                        BuiltinResolver.Instance,
+                        AttributeFormatterResolver.Instance,
+                        PrimitiveObjectResolver.Instance,
+                    }));
         }
 
-        /// <summary>
-        /// Adds resolvers to this composite resolver.
-        /// </summary>
-        /// <param name="resolvers">The resolvers to add.</param>
-        /// <remarks>
-        /// Each registered resolver is appended to the end of the list of resolvers to try for each requested type.
-        /// Registered formatters take precedence over all resolvers.
-        /// </remarks>
-        public void RegisterResolver(params IFormatterResolver[] resolvers)
+        public static IFormatterResolver Create(IReadOnlyList<object> formatters, IReadOnlyList<IFormatterResolver> resolvers)
         {
+            if (formatters is null)
+            {
+                throw new ArgumentNullException(nameof(formatters));
+            }
+
             if (resolvers is null)
             {
                 throw new ArgumentNullException(nameof(resolvers));
             }
 
-            this.subResolvers.AddRange(resolvers);
-        }
-
-        /// <summary>
-        /// Adds a formatter to this composite resolver.
-        /// </summary>
-        /// <param name="formatter">An object that implements <see cref="IMessagePackFormatter{T}"/> one or more times.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formatter"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="formatter"/> does not implement any <see cref="IMessagePackFormatter{T}"/> interfaces.</exception>
-        /// <remarks>
-        /// Registered formatters always take precedence over registered resolvers.
-        /// </remarks>
-        public void RegisterFormatter(object formatter)
-        {
-            if (formatter == null)
+            var formattersByType = new Dictionary<Type, object>();
+            foreach (var formatter in formatters)
             {
-                throw new ArgumentNullException(nameof(formatter));
-            }
-
-            bool foundAny = false;
-            foreach (Type implInterface in formatter.GetType().GetTypeInfo().ImplementedInterfaces)
-            {
-                TypeInfo ti = implInterface.GetTypeInfo();
-                if (ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(IMessagePackFormatter<>))
+                if (formatter == null)
                 {
-                    foundAny = true;
-                    if (!this.formattersByType.ContainsKey(ti.GenericTypeArguments[0]))
+                    throw new ArgumentException("An element in the array is null.", nameof(formatters));
+                }
+
+                bool foundAny = false;
+                foreach (Type implInterface in formatter.GetType().GetTypeInfo().ImplementedInterfaces)
+                {
+                    TypeInfo ti = implInterface.GetTypeInfo();
+                    if (ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(IMessagePackFormatter<>))
                     {
-                        this.formattersByType.Add(ti.GenericTypeArguments[0], formatter);
+                        foundAny = true;
+                        if (!formattersByType.ContainsKey(ti.GenericTypeArguments[0]))
+                        {
+                            formattersByType.Add(ti.GenericTypeArguments[0], formatter);
+                        }
                     }
                 }
+
+                if (!foundAny)
+                {
+                    throw new ArgumentException("No formatters found on this object: " + formatter.GetType().FullName, nameof(formatter));
+                }
             }
 
-            if (!foundAny)
-            {
-                throw new ArgumentException("No formatters found on this object.", nameof(formatter));
-            }
+            // Make a copy of the resolvers list provided by the caller to guard against them changing it later.
+            return new CachingResolver(
+                new ReadOnlyDictionary<Type, object>(formattersByType),
+                new ReadOnlyCollection<IFormatterResolver>(resolvers.ToArray()));
         }
 
-        /// <inheritdoc/>
-        public IMessagePackFormatter<T> GetFormatter<T>()
+        private class CachingResolver : CachingFormatterResolver
         {
-            // We use locks here because this resolver can be called by multiple threads concurrently
-            // and we may be mutating some of these collections as we cache formatters per type.
-            object formatter;
-            lock (this.formattersByType)
+            private readonly ReadOnlyDictionary<Type, object> formattersByType;
+            private readonly ReadOnlyCollection<IFormatterResolver> subResolvers;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CachingResolver"/> class.
+            /// </summary>
+            internal CachingResolver(ReadOnlyDictionary<Type, object> formattersByType, ReadOnlyCollection<IFormatterResolver> subResolvers)
             {
-                if (this.formattersByType.TryGetValue(typeof(T), out formatter))
-                {
-                    return (IMessagePackFormatter<T>)formatter;
-                }
+                this.formattersByType = formattersByType ?? throw new ArgumentNullException(nameof(formattersByType));
+                this.subResolvers = subResolvers ?? throw new ArgumentNullException(nameof(subResolvers));
             }
 
-            foreach (IFormatterResolver resolver in this.subResolvers)
+            /// <inheritdoc/>
+            protected override IMessagePackFormatter<T> GetFormatterCore<T>()
             {
-                formatter = resolver.GetFormatter<T>();
-                if (formatter != null)
+                if (!this.formattersByType.TryGetValue(typeof(T), out object formatter))
                 {
-                    break;
+                    foreach (IFormatterResolver resolver in this.subResolvers)
+                    {
+                        formatter = resolver.GetFormatter<T>();
+                        if (formatter != null)
+                        {
+                            break;
+                        }
+                    }
                 }
-            }
 
-            // Remember the answer for next time.
-            lock (this.formattersByType)
-            {
-                if (!this.formattersByType.ContainsKey(typeof(T)))
-                {
-                    this.formattersByType.Add(typeof(T), formatter);
-                }
+                return (IMessagePackFormatter<T>)formatter;
             }
-
-            return (IMessagePackFormatter<T>)formatter;
         }
     }
 }


### PR DESCRIPTION
Make it immutable and use the concurrent reading dictionary.
In the future we can create a dynamic type hard-coded for the inputs given to the static factory method.

Closes #502