### PR TITLE
Allow negative extension headers in MessagePackWriter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1011,7 +1011,7 @@ namespace MessagePack
         public void WriteExtensionFormatHeader(ExtensionHeader extensionHeader)
         {
             int dataLength = (int)extensionHeader.Length;
-            byte typeCode = (byte)extensionHeader.TypeCode;
+            byte typeCode = unchecked((byte)extensionHeader.TypeCode);
             switch (dataLength)
             {
                 case 1:

--- a/tests/MessagePack.Tests/MessagePackWriterTests.cs
+++ b/tests/MessagePack.Tests/MessagePackWriterTests.cs
@@ -36,7 +36,7 @@ namespace MessagePack.Tests
         }
 
         [Fact]
-        public void WriteExtensionFormatHeader_NegativeExtension() 
+        public void WriteExtensionFormatHeader_NegativeExtension()
         {
             var sequence = new Sequence<byte>();
             var writer = new MessagePackWriter(sequence);
@@ -44,7 +44,7 @@ namespace MessagePack.Tests
             var header = new ExtensionHeader(-1, 10);
             writer.WriteExtensionFormatHeader(header);
             writer.Flush();
-            
+
             var written = sequence.AsReadOnlySequence;
             var reader = new MessagePackReader(written);
             var readHeader = reader.ReadExtensionFormatHeader();

--- a/tests/MessagePack.Tests/MessagePackWriterTests.cs
+++ b/tests/MessagePack.Tests/MessagePackWriterTests.cs
@@ -34,5 +34,23 @@ namespace MessagePack.Tests
             Assert.Equal(1, written[0]);
             Assert.Equal(2, written[7]);
         }
+
+        [Fact]
+        public void WriteExtensionFormatHeader_NegativeExtension() 
+        {
+            var sequence = new Sequence<byte>();
+            var writer = new MessagePackWriter(sequence);
+
+            var header = new ExtensionHeader(-1, 10);
+            writer.WriteExtensionFormatHeader(header);
+            writer.Flush();
+            
+            var written = sequence.AsReadOnlySequence;
+            var reader = new MessagePackReader(written);
+            var readHeader = reader.ReadExtensionFormatHeader();
+
+            Assert.Equal(header.TypeCode, readHeader.TypeCode);
+            Assert.Equal(header.Length, readHeader.Length);
+        }
     }
 }


### PR DESCRIPTION
This is already allowed in the MessagePackReader.

I can't run the tests on my computer. Hopefully the CI will run them on PRs.

Resolves #484 