### PR TITLE
Optimize for MemoryStream Deserialize

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -126,7 +126,7 @@ csharp_indent_labels = flush_left
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = false:warning
+csharp_style_var_elsewhere = true:suggestion
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -218,6 +218,11 @@ namespace MessagePack
         /// <returns>The deserialized value.</returns>
         public static T Deserialize<T>(Stream stream, MessagePackSerializerOptions options = null)
         {
+            if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> streamBuffer))
+            {
+                return Deserialize<T>(streamBuffer, options);
+            }
+
             using (var sequence = new Sequence<byte>())
             {
                 int bytesRead;
@@ -243,6 +248,11 @@ namespace MessagePack
         /// <returns>The deserialized value.</returns>
         public static async ValueTask<T> DeserializeAsync<T>(Stream stream, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
+            if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> streamBuffer))
+            {
+                return Deserialize<T>(streamBuffer, options);
+            }
+
             using (var sequence = new Sequence<byte>())
             {
                 int bytesRead;


### PR DESCRIPTION
Streams are often MemoryStreams.
v1 had optimizations for MemoryStream.