### PR TITLE
Remove MessagePackWriter.WriteFixedArrayHeaderUnsafe

### DIFF
--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -329,7 +329,7 @@ namespace MessagePack.Formatters.SharedData
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {
@@ -426,7 +426,7 @@ namespace MessagePack.Formatters.SharedData
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {
@@ -517,7 +517,7 @@ namespace MessagePack.Formatters.SharedData
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {
@@ -592,7 +592,7 @@ namespace MessagePack.Formatters.SharedData
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {
@@ -673,7 +673,7 @@ namespace MessagePack.Formatters.SharedData
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {
@@ -784,7 +784,7 @@ namespace MessagePack.Formatters
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {
@@ -888,7 +888,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.Prop1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop2, options);
             writer.Write(value.Prop3);
@@ -1029,7 +1029,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.SimpleStructIntKeyData value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.X);
             writer.Write(value.Y);
             formatterResolver.GetFormatterWithVerify<byte[]>().Serialize(ref writer, value.BytesSpecial, options);
@@ -1161,7 +1161,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(7);
+            writer.WriteArrayHeader(7);
             writer.Write(value.Prop1);
             formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Serialize(ref writer, value.Prop2, options);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop3, options);
@@ -1238,7 +1238,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.Vector2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.X);
             writer.Write(value.Y);
         }
@@ -1289,7 +1289,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(0);
+            writer.WriteArrayHeader(0);
         }
 
         public global::SharedData.EmptyClass Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -1324,7 +1324,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.EmptyStruct value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(0);
+            writer.WriteArrayHeader(0);
         }
 
         public global::SharedData.EmptyStruct Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -1365,7 +1365,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(6);
+            writer.WriteArrayHeader(6);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -1427,7 +1427,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(8);
+            writer.WriteArrayHeader(8);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -1496,7 +1496,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -1546,7 +1546,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
         }
@@ -1599,7 +1599,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
         }
@@ -1652,7 +1652,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
         }
@@ -1706,7 +1706,7 @@ namespace MessagePack.Formatters.SharedData
 
             IFormatterResolver formatterResolver = options.Resolver;
             value.OnBeforeSerialize();
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.X);
         }
 
@@ -1755,7 +1755,7 @@ namespace MessagePack.Formatters.SharedData
 
             IFormatterResolver formatterResolver = options.Resolver;
             ((IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.X);
         }
 
@@ -1935,7 +1935,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.MyProperty);
             writer.Write(value.MyProperty1);
         }
@@ -1988,7 +1988,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.MyProperty);
             writer.Write(value.MyProperty2);
         }
@@ -2041,7 +2041,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -2085,7 +2085,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.MySubUnion2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(6);
+            writer.WriteArrayHeader(6);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -2137,7 +2137,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.WriteNil();
             writer.WriteNil();
             writer.Write(value.Three);
@@ -2180,7 +2180,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.MySubUnion4 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(8);
+            writer.WriteArrayHeader(8);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -2234,7 +2234,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(8);
+            writer.WriteArrayHeader(8);
             writer.WriteNil();
             writer.WriteNil();
             writer.WriteNil();
@@ -2288,7 +2288,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.MyProperty1);
             writer.Write(value.MyProperty2);
             writer.Write(value.MyProperty3);
@@ -2347,7 +2347,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.MyProperty);
             formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Serialize(ref writer, value.UnknownBlock, options);
             writer.Write(value.MyProperty2);
@@ -2406,7 +2406,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.MyProperty);
             writer.WriteNil();
             writer.Write(value.MyProperty2);
@@ -2460,7 +2460,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(0);
+            writer.WriteArrayHeader(0);
         }
 
         public global::SharedData.Empty1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -2562,7 +2562,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.MyProperty);
         }
 
@@ -2673,7 +2673,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.VectorLike2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.x);
             writer.Write(value.y);
         }
@@ -2720,7 +2720,7 @@ namespace MessagePack.Formatters.SharedData
         public void Serialize(ref MessagePackWriter writer, global::SharedData.Vector3Like value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.x);
             writer.Write(value.y);
             writer.Write(value.z);
@@ -2916,7 +2916,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.MyProperty);
         }
 
@@ -2963,7 +2963,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.XYZ);
         }
 
@@ -3010,7 +3010,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.OPQ, options);
         }
 
@@ -3057,7 +3057,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.Data1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Data2, options);
         }
@@ -3141,7 +3141,7 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.MyProperty);
         }
 
@@ -3219,7 +3219,7 @@ namespace MessagePack.Formatters
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.MyProperty);
         }
 
@@ -3266,7 +3266,7 @@ namespace MessagePack.Formatters
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.UserId);
             writer.Write(value.RoomId);
             formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Serialize(ref writer, value.PostTime, options);
@@ -3331,7 +3331,7 @@ namespace MessagePack.Formatters
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Text, options);
         }
 
@@ -3378,7 +3378,7 @@ namespace MessagePack.Formatters
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.StampId);
         }
 
@@ -3425,7 +3425,7 @@ namespace MessagePack.Formatters
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.QuestId);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Text, options);
         }
@@ -3478,7 +3478,7 @@ namespace MessagePack.Formatters
             }
 
             IFormatterResolver formatterResolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(7);
+            writer.WriteArrayHeader(7);
             formatterResolver.GetFormatterWithVerify<int[]>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<int[,]>().Serialize(ref writer, value.MyProperty1, options);
             formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[,]>().Serialize(ref writer, value.MyProperty2, options);

--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -170,7 +170,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 4);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 4);
 ////            offset += MessagePackBinary.WriteSingle(ref bytes, offset, value.time);
 ////            offset += MessagePackBinary.WriteSingle(ref bytes, offset, value.value);
 ////            offset += MessagePackBinary.WriteSingle(ref bytes, offset, value.inTangent);
@@ -242,7 +242,7 @@
 ////            }
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 3);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 3);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.Keyframe[]>().Serialize(ref bytes, offset, value.keys, formatterResolver);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.WrapMode>().Serialize(ref bytes, offset, value.postWrapMode, formatterResolver);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.WrapMode>().Serialize(ref bytes, offset, value.preWrapMode, formatterResolver);
@@ -445,7 +445,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 2);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 2);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.Color>().Serialize(ref bytes, offset, value.color, formatterResolver);
 ////            offset += MessagePackBinary.WriteSingle(ref bytes, offset, value.time);
 ////            return offset - startOffset;
@@ -501,7 +501,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 2);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 2);
 ////            offset += MessagePackBinary.WriteSingle(ref bytes, offset, value.alpha);
 ////            offset += MessagePackBinary.WriteSingle(ref bytes, offset, value.time);
 ////            return offset - startOffset;
@@ -561,7 +561,7 @@
 ////            }
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 3);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 3);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.GradientColorKey[]>().Serialize(ref bytes, offset, value.colorKeys, formatterResolver);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.GradientAlphaKey[]>().Serialize(ref bytes, offset, value.alphaKeys, formatterResolver);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.GradientMode>().Serialize(ref bytes, offset, value.mode, formatterResolver);
@@ -624,7 +624,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 4);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 4);
 ////            offset += MessagePackBinary.WriteByte(ref bytes, offset, value.r);
 ////            offset += MessagePackBinary.WriteByte(ref bytes, offset, value.g);
 ////            offset += MessagePackBinary.WriteByte(ref bytes, offset, value.b);
@@ -696,7 +696,7 @@
 ////            }
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 4);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 4);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.left);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.right);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.top);
@@ -765,7 +765,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 1);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 1);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.value);
 ////            return offset - startOffset;
 ////        }
@@ -815,7 +815,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 2);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 2);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.x);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.y);
 ////            return offset - startOffset;
@@ -871,7 +871,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 3);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 3);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.x);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.y);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.z);
@@ -933,7 +933,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 2);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 2);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.start);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.length);
 ////            return offset - startOffset;
@@ -989,7 +989,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 4);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 4);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.x);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.y);
 ////            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.width);
@@ -1057,7 +1057,7 @@
 ////        {
 
 ////            var startOffset = offset;
-////            offset += global::MessagePack.MessagePackBinary.WriteFixedArrayHeaderUnsafe(ref bytes, offset, 2);
+////            offset += global::MessagePack.MessagePackBinary.WriteArrayHeader(ref bytes, offset, 2);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.Vector3Int>().Serialize(ref bytes, offset, value.position, formatterResolver);
 ////            offset += formatterResolver.GetFormatterWithVerify<global::UnityEngine.Vector3Int>().Serialize(ref bytes, offset, value.size, formatterResolver);
 ////            return offset - startOffset;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -121,7 +121,9 @@ namespace MessagePack
         {
             if (count <= MessagePackRange.MaxFixArrayCount)
             {
-                this.WriteFixedArrayHeaderUnsafe(count);
+                Span<byte> span = this.writer.GetSpan(1);
+                span[0] = (byte)(MessagePackCode.MinFixArray | count);
+                this.writer.Advance(1);
             }
             else if (count <= ushort.MaxValue)
             {
@@ -137,22 +139,6 @@ namespace MessagePack
                 WriteBigEndian(count, span.Slice(1));
                 this.writer.Advance(5);
             }
-        }
-
-        /// <summary>
-        /// Write the length of the next array to be written as <see cref="MessagePackCode.MinFixArray"/>.
-        /// </summary>
-        /// <param name="count">
-        /// The number of elements that will be written in the array. This MUST be less than <see cref="MessagePackRange.MaxFixArrayCount"/>.
-        /// This condition is NOT checked within this method, and violating this rule will result in data corruption.
-        /// </param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteFixedArrayHeaderUnsafe(uint count)
-        {
-            Span<byte> span = this.writer.GetSpan(1);
-            span[0] = (byte)(MessagePackCode.MinFixArray | count);
-            this.writer.Advance(1);
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -703,14 +703,7 @@ namespace MessagePack.Internal
                 var len = maxKey + 1;
                 argWriter.EmitLoad();
                 il.EmitLdc_I4(len);
-                if (len <= MessagePackRange.MaxFixMapCount)
-                {
-                    il.EmitCall(MessagePackWriterTypeInfo.WriteFixedArrayHeaderUnsafe);
-                }
-                else
-                {
-                    il.EmitCall(MessagePackWriterTypeInfo.WriteArrayHeader);
-                }
+                il.EmitCall(MessagePackWriterTypeInfo.WriteArrayHeader);
 
                 for (int i = 0; i <= maxKey; i++)
                 {
@@ -1264,7 +1257,6 @@ namespace MessagePack.Internal
 
             internal static readonly MethodInfo WriteMapHeader = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.WriteMapHeader), new[] { typeof(int) });
             internal static readonly MethodInfo WriteArrayHeader = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.WriteArrayHeader), new[] { typeof(int) });
-            internal static readonly MethodInfo WriteFixedArrayHeaderUnsafe = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.WriteFixedArrayHeaderUnsafe), new[] { typeof(uint) });
             internal static readonly MethodInfo WriteBytes = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.Write), new[] { typeof(ReadOnlySpan<byte>) });
             internal static readonly MethodInfo WriteNil = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.WriteNil), Type.EmptyTypes);
             internal static readonly MethodInfo WriteRaw = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.WriteRaw), new[] { typeof(ReadOnlySpan<byte>) });

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityShims/Formatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityShims/Formatters.cs
@@ -16,7 +16,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Vector2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.x);
             writer.Write(value.y);
         }
@@ -57,7 +57,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Vector3 value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.Write(value.x);
             writer.Write(value.y);
             writer.Write(value.z);
@@ -103,7 +103,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Vector4 value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.x);
             writer.Write(value.y);
             writer.Write(value.z);
@@ -154,7 +154,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Quaternion value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.x);
             writer.Write(value.y);
             writer.Write(value.z);
@@ -205,7 +205,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Color value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.r);
             writer.Write(value.g);
             writer.Write(value.b);
@@ -257,7 +257,7 @@ namespace MessagePack.Unity
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Bounds value, global::MessagePack.MessagePackSerializerOptions options)
         {
             IFormatterResolver resolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             resolver.GetFormatterWithVerify<global::UnityEngine.Vector3>().Serialize(ref writer, value.center, options);
             resolver.GetFormatterWithVerify<global::UnityEngine.Vector3>().Serialize(ref writer, value.size, options);
         }
@@ -299,7 +299,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Rect value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.x);
             writer.Write(value.y);
             writer.Write(value.width);
@@ -377,7 +377,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Keyframe value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.time);
             writer.Write(value.value);
             writer.Write(value.inTangent);
@@ -439,7 +439,7 @@ namespace MessagePack.Unity
             }
 
             IFormatterResolver resolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             resolver.GetFormatterWithVerify<global::UnityEngine.Keyframe[]>().Serialize(ref writer, value.keys, options);
             resolver.GetFormatterWithVerify<global::UnityEngine.WrapMode>().Serialize(ref writer, value.postWrapMode, options);
             resolver.GetFormatterWithVerify<global::UnityEngine.WrapMode>().Serialize(ref writer, value.preWrapMode, options);
@@ -616,7 +616,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.GradientColorKey value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             options.Resolver.GetFormatterWithVerify<global::UnityEngine.Color>().Serialize(ref writer, value.color, options);
             writer.Write(value.time);
         }
@@ -660,7 +660,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.GradientAlphaKey value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.Write(value.alpha);
             writer.Write(value.time);
         }
@@ -710,7 +710,7 @@ namespace MessagePack.Unity
             }
 
             IFormatterResolver resolver = options.Resolver;
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             resolver.GetFormatterWithVerify<global::UnityEngine.GradientColorKey[]>().Serialize(ref writer, value.colorKeys, options);
             resolver.GetFormatterWithVerify<global::UnityEngine.GradientAlphaKey[]>().Serialize(ref writer, value.alphaKeys, options);
             resolver.GetFormatterWithVerify<global::UnityEngine.GradientMode>().Serialize(ref writer, value.mode, options);
@@ -760,7 +760,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Color32 value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.r);
             writer.Write(value.g);
             writer.Write(value.b);
@@ -821,7 +821,7 @@ namespace MessagePack.Unity
                 return;
             }
 
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.Write(value.left);
             writer.Write(value.right);
             writer.Write(value.top);
@@ -876,7 +876,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.LayerMask value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(1);
+            writer.WriteArrayHeader(1);
             writer.Write(value.value);
         }
 
@@ -913,7 +913,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Vector2Int value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.WriteInt32(value.x);
             writer.WriteInt32(value.y);
         }
@@ -954,7 +954,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.Vector3Int value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(3);
+            writer.WriteArrayHeader(3);
             writer.WriteInt32(value.x);
             writer.WriteInt32(value.y);
             writer.WriteInt32(value.z);
@@ -1001,7 +1001,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.RangeInt value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             writer.WriteInt32(value.start);
             writer.WriteInt32(value.length);
         }
@@ -1042,7 +1042,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.RectInt value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(4);
+            writer.WriteArrayHeader(4);
             writer.WriteInt32(value.x);
             writer.WriteInt32(value.y);
             writer.WriteInt32(value.width);
@@ -1095,7 +1095,7 @@ namespace MessagePack.Unity
     {
         public void Serialize(ref MessagePackWriter writer, global::UnityEngine.BoundsInt value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            writer.WriteFixedArrayHeaderUnsafe(2);
+            writer.WriteArrayHeader(2);
             options.Resolver.GetFormatterWithVerify<global::UnityEngine.Vector3Int>().Serialize(ref writer, value.position, options);
             options.Resolver.GetFormatterWithVerify<global::UnityEngine.Vector3Int>().Serialize(ref writer, value.size, options);
         }

--- a/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.cs
@@ -189,11 +189,11 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
             #line hidden
             
             #line 65 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
- if( objInfo.IsIntKey) { if( (objInfo.MaxKey + 1) <= 15) { 
+ if( objInfo.IsIntKey) { 
             
             #line default
             #line hidden
-            this.Write("            writer.WriteFixedArrayHeaderUnsafe(");
+            this.Write("            writer.WriteArrayHeader(");
             
             #line 66 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.MaxKey + 1));
@@ -207,103 +207,89 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
             
             #line default
             #line hidden
-            this.Write("            writer.WriteArrayHeader(");
-            
-            #line 68 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.MaxKey + 1));
-            
-            #line default
-            #line hidden
-            this.Write(");\r\n");
-            
-            #line 69 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
- } } else { 
-            
-            #line default
-            #line hidden
             this.Write("            writer.WriteMapHeader(");
             
-            #line 70 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 68 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.WriteCount));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 71 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 69 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 72 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 70 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  if(objInfo.IsIntKey) { 
             
             #line default
             #line hidden
             
-            #line 73 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 71 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  for(var i =0; i<= objInfo.MaxKey; i++) { var member = objInfo.GetMember(i); 
             
             #line default
             #line hidden
             
-            #line 74 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 72 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  if( member == null) { 
             
             #line default
             #line hidden
             this.Write("            writer.WriteNil();\r\n");
             
-            #line 76 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 74 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } else { 
             
             #line default
             #line hidden
             this.Write("            ");
             
-            #line 77 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 75 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetSerializeMethodString()));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 78 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 76 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } } } else { 
             
             #line default
             #line hidden
             
-            #line 79 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 77 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  var index = 0; foreach(var x in objInfo.Members) { 
             
             #line default
             #line hidden
             this.Write("            writer.WriteRaw(this.____stringByteKeys[");
             
-            #line 80 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 78 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(index++));
             
             #line default
             #line hidden
             this.Write("]);\r\n            ");
             
-            #line 81 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 79 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.GetSerializeMethodString()));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 82 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 80 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } } 
             
             #line default
             #line hidden
             this.Write("        }\r\n\r\n        public ");
             
-            #line 85 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 83 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             
             #line default
@@ -312,14 +298,14 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
                     "zerOptions options)\r\n        {\r\n            if (reader.TryReadNil())\r\n          " +
                     "  {\r\n");
             
-            #line 89 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 87 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  if( objInfo.IsClass) { 
             
             #line default
             #line hidden
             this.Write("                return null;\r\n");
             
-            #line 91 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 89 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } else { 
             
             #line default
@@ -327,7 +313,7 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
             this.Write("                throw new InvalidOperationException(\"typecode is null, struct not" +
                     " supported\");\r\n");
             
-            #line 93 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 91 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
@@ -335,55 +321,55 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
             this.Write("            }\r\n\r\n            IFormatterResolver formatterResolver = options.Resol" +
                     "ver;\r\n");
             
-            #line 97 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 95 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  if(objInfo.IsStringKey) { 
             
             #line default
             #line hidden
             this.Write("            var length = reader.ReadMapHeader();\r\n");
             
-            #line 99 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 97 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } else { 
             
             #line default
             #line hidden
             this.Write("            var length = reader.ReadArrayHeader();\r\n");
             
-            #line 101 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 99 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 102 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 100 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  foreach(var x in objInfo.Members) { 
             
             #line default
             #line hidden
             this.Write("            var __");
             
-            #line 103 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 101 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
             
             #line default
             #line hidden
             this.Write("__ = default(");
             
-            #line 103 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 101 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.Type));
             
             #line default
             #line hidden
             this.Write(");\r\n");
             
-            #line 104 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 102 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
             #line hidden
             this.Write("\r\n            for (int i = 0; i < length; i++)\r\n            {\r\n");
             
-            #line 108 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 106 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  if(objInfo.IsStringKey) { 
             
             #line default
@@ -397,49 +383,49 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
                 }
 ");
             
-            #line 116 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 114 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } else { 
             
             #line default
             #line hidden
             this.Write("                var key = i;\r\n");
             
-            #line 118 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 116 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
             #line hidden
             this.Write("\r\n                switch (key)\r\n                {\r\n");
             
-            #line 122 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 120 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  foreach(var x in objInfo.Members) { 
             
             #line default
             #line hidden
             this.Write("                    case ");
             
-            #line 123 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 121 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.IntKey));
             
             #line default
             #line hidden
             this.Write(":\r\n                        __");
             
-            #line 124 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 122 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
             
             #line default
             #line hidden
             this.Write("__ = ");
             
-            #line 124 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 122 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.GetDeserializeMethodString()));
             
             #line default
             #line hidden
             this.Write(";\r\n                        break;\r\n");
             
-            #line 126 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 124 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
@@ -448,41 +434,41 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBe
                     "             break;\r\n                }\r\n            }\r\n\r\n            var ____res" +
                     "ult = new ");
             
-            #line 133 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 131 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             
             #line default
             #line hidden
             this.Write(";\r\n");
             
-            #line 134 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 132 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  foreach(var x in objInfo.Members.Where(x => x.IsWritable)) { 
             
             #line default
             #line hidden
             this.Write("            ____result.");
             
-            #line 135 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 133 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
             
             #line default
             #line hidden
             this.Write(" = __");
             
-            #line 135 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 133 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
             
             #line default
             #line hidden
             this.Write("__;\r\n");
             
-            #line 136 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 134 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
             #line hidden
             
-            #line 137 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 135 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
 if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnAfter) { 
             
             #line default
@@ -490,21 +476,21 @@ if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnAf
             this.Write("            ((IMessagePackSerializationCallbackReceiver)____result).OnAfterDeseri" +
                     "alize();\r\n");
             
-            #line 139 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 137 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { 
             
             #line default
             #line hidden
             this.Write("            ____result.OnAfterDeserialize();\r\n");
             
-            #line 141 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 139 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default
             #line hidden
             this.Write("            return ____result;\r\n        }\r\n    }\r\n");
             
-            #line 145 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
+            #line 143 "D:\git\MessagePack-CSharp\src\MessagePack.UniversalCodeGenerator\Generator\FormatterTemplate.tt"
  } 
             
             #line default

--- a/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.UniversalCodeGenerator/Generator/FormatterTemplate.tt
@@ -62,11 +62,9 @@ namespace <#= Namespace #>
 <# } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { #>
             value.OnBeforeSerialize();
 <# } #>
-<# if( objInfo.IsIntKey) { if( (objInfo.MaxKey + 1) <= 15) { #>
-            writer.WriteFixedArrayHeaderUnsafe(<#= objInfo.MaxKey + 1 #>);
-<# } else { #>
+<# if( objInfo.IsIntKey) { #>
             writer.WriteArrayHeader(<#= objInfo.MaxKey + 1 #>);
-<# } } else { #>
+<# } else { #>
             writer.WriteMapHeader(<#= objInfo.WriteCount #>);
 <# } #>
 <# if(objInfo.IsIntKey) { #>

--- a/src/MessagePack.UniversalCodeGenerator/Generator/UnionTemplate.cs
+++ b/src/MessagePack.UniversalCodeGenerator/Generator/UnionTemplate.cs
@@ -167,7 +167,7 @@ namespace ");
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {

--- a/src/MessagePack.UniversalCodeGenerator/Generator/UnionTemplate.tt
+++ b/src/MessagePack.UniversalCodeGenerator/Generator/UnionTemplate.tt
@@ -46,7 +46,7 @@ namespace <#= Namespace #>
             KeyValuePair<int, int> keyValuePair;
             if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
             {
-                writer.WriteFixedArrayHeaderUnsafe(2);
+                writer.WriteArrayHeader(2);
                 writer.WriteInt32(keyValuePair.Key);
                 switch (keyValuePair.Value)
                 {


### PR DESCRIPTION
This "unsafe" API accomplished skipping a single branch instruction, so most likely was not a significant perf win, yet added complexity to callers and code generators, and brought the risk that folks would call it inappropriately, leading to data corruption.

Closes #506