### PR TITLE
Allow private constructors when using ctor attribute

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1389,6 +1389,7 @@ namespace MessagePack.Internal
         {
             TypeInfo ti = type.GetTypeInfo();
             var isClass = ti.IsClass || ti.IsInterface || ti.IsAbstract;
+            var isStruct = ti.IsValueType;
 
             MessagePackObjectAttribute contractAttr = ti.GetCustomAttributes<MessagePackObjectAttribute>().FirstOrDefault();
             DataContractAttribute dataContractAttr = ti.GetCustomAttribute<DataContractAttribute>();
@@ -1722,7 +1723,7 @@ namespace MessagePack.Internal
 
             // GetConstructor
             IEnumerator<ConstructorInfo> ctorEnumerator = null;
-            ConstructorInfo ctor = ti.DeclaredConstructors.Where(x => x.IsPublic).SingleOrDefault(x => x.GetCustomAttribute<SerializationConstructorAttribute>(false) != null);
+            ConstructorInfo ctor = ti.DeclaredConstructors.SingleOrDefault(x => x.GetCustomAttribute<SerializationConstructorAttribute>(false) != null);
             if (ctor == null)
             {
                 ctorEnumerator =
@@ -1736,7 +1737,7 @@ namespace MessagePack.Internal
             }
 
             // struct allows null ctor
-            if (ctor == null && isClass)
+            if (ctor == null && !isStruct)
             {
                 throw new MessagePackDynamicObjectResolverException("can't find public constructor. type:" + type.FullName);
             }

--- a/tests/MessagePack.Tests/AllowPrivateTest.cs
+++ b/tests/MessagePack.Tests/AllowPrivateTest.cs
@@ -141,6 +141,40 @@ namespace MessagePack.Tests
             public int X;
         }
 
+        [MessagePackObject]
+        public class ImmutablePrivateClass 
+        {
+            [Key(0)]
+            private int _x;
+
+            [Key(1)]
+            private int _y;
+
+            [SerializationConstructor]
+            ImmutablePrivateClass(int x, int y)
+            {
+                _x = x;
+                _y = y;
+                CreatedUsingPrivateCtor = true;
+            }
+
+            public ImmutablePrivateClass(int x, int y, bool _dummy)
+            {
+                _x = x;
+                _y = y;
+                CreatedUsingPrivateCtor = false;
+            }
+
+            [IgnoreMember]
+            public int X => _x;
+
+            [IgnoreMember]
+            public int Y => _y;
+
+            [IgnoreMember]
+            public bool CreatedUsingPrivateCtor { get; }
+        }
+
         [Fact]
         public void AllowPrivate()
         {
@@ -214,6 +248,19 @@ namespace MessagePack.Tests
         {
             var x = MessagePackSerializer.Serialize(new EmptyConstructorStruct { X = 99 }, StandardResolverAllowPrivate.Options);
             MessagePackSerializer.Deserialize<EmptyConstructorStruct>(x, StandardResolverAllowPrivate.Options).X.Is(99);
+        }
+
+        [Fact]
+        public void PrivateConstructor()
+        {
+            var p1 = new ImmutablePrivateClass(10, 20, _dummy: false);
+            var bin = MessagePackSerializer.Serialize(p1, StandardResolverAllowPrivate.Options);
+            var p2 = MessagePackSerializer.Deserialize<ImmutablePrivateClass>(bin, StandardResolverAllowPrivate.Options);
+
+            Assert.Equal(p1.X, p2.X);
+            Assert.Equal(p1.Y, p2.Y);
+            Assert.Equal(false, p1.CreatedUsingPrivateCtor);
+            Assert.Equal(true, p2.CreatedUsingPrivateCtor);
         }
     }
 }

--- a/tests/MessagePack.Tests/AllowPrivateTest.cs
+++ b/tests/MessagePack.Tests/AllowPrivateTest.cs
@@ -142,34 +142,34 @@ namespace MessagePack.Tests
         }
 
         [MessagePackObject]
-        public class ImmutablePrivateClass 
+        public class ImmutablePrivateClass
         {
             [Key(0)]
-            private int _x;
+            private int x;
 
             [Key(1)]
-            private int _y;
+            private int y;
 
             [SerializationConstructor]
-            ImmutablePrivateClass(int x, int y)
+            private ImmutablePrivateClass(int x, int y)
             {
-                _x = x;
-                _y = y;
-                CreatedUsingPrivateCtor = true;
+                this.x = x;
+                this.y = y;
+                this.CreatedUsingPrivateCtor = true;
             }
 
-            public ImmutablePrivateClass(int x, int y, bool _dummy)
+            public ImmutablePrivateClass(int x, int y, bool dummy)
             {
-                _x = x;
-                _y = y;
-                CreatedUsingPrivateCtor = false;
+                this.x = x;
+                this.y = y;
+                this.CreatedUsingPrivateCtor = false;
             }
 
             [IgnoreMember]
-            public int X => _x;
+            public int X => this.x;
 
             [IgnoreMember]
-            public int Y => _y;
+            public int Y => this.y;
 
             [IgnoreMember]
             public bool CreatedUsingPrivateCtor { get; }
@@ -253,14 +253,14 @@ namespace MessagePack.Tests
         [Fact]
         public void PrivateConstructor()
         {
-            var p1 = new ImmutablePrivateClass(10, 20, _dummy: false);
+            var p1 = new ImmutablePrivateClass(10, 20, dummy: false);
             var bin = MessagePackSerializer.Serialize(p1, StandardResolverAllowPrivate.Options);
             var p2 = MessagePackSerializer.Deserialize<ImmutablePrivateClass>(bin, StandardResolverAllowPrivate.Options);
 
             Assert.Equal(p1.X, p2.X);
             Assert.Equal(p1.Y, p2.Y);
-            Assert.Equal(false, p1.CreatedUsingPrivateCtor);
-            Assert.Equal(true, p2.CreatedUsingPrivateCtor);
+            Assert.False(p1.CreatedUsingPrivateCtor);
+            Assert.True(p2.CreatedUsingPrivateCtor);
         }
     }
 }


### PR DESCRIPTION
The idea here is that adding `SerializationConstructor` attribute to a constructor is such an explicit action/flag, that it should override any priv/nonpriv solver constraint. I would argue that the same should be the case for `Key` attribute and similar as well, because adding `[Key(0)]` to something and having it ignored because it's private is confusing. But regardless, that you can at least work around. Private constructors don't work at all as is.

I would also really like a `[MessagePackObject(IgnoreByDefault = true)]`, so I don't have to keep doing `[IgnoreMember]` on all the public API. Thoughts?

Closes #40 