### PR TITLE
Fix DynamicCodeDumper

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>exe</OutputType>
     <DefineConstants>$(DefineConstants);DYNAMICCODEDUMPER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -118,8 +119,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.Streams" Version="2.2.38" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.2.26" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/sandbox/DynamicCodeDumper/Program.cs
+++ b/sandbox/DynamicCodeDumper/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text;
@@ -66,7 +67,7 @@ namespace DynamicCodeDumper
                 using (var sequence = new Sequence<byte>())
                 {
                     var sequenceWriter = new MessagePackWriter(sequence);
-                    f.Serialize(ref sequenceWriter, new MyClass { MyProperty1 = 100, MyProperty2 = "foo" }, null);
+                    f.Serialize(ref sequenceWriter, new MyClass { MyProperty1 = 100, MyProperty2 = "foo" }, EmptyResolver.Options);
                     sequenceWriter.Flush();
                 }
             }
@@ -89,7 +90,7 @@ namespace DynamicCodeDumper
 
         private static void Verify(params AssemblyBuilder[] builders)
         {
-            var path = @"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\x64\PEVerify.exe";
+            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\x64\PEVerify.exe");
 
             foreach (AssemblyBuilder targetDll in builders)
             {
@@ -106,6 +107,13 @@ namespace DynamicCodeDumper
                 var data = p.StandardOutput.ReadToEnd();
                 Console.WriteLine(data);
             }
+        }
+
+        private class EmptyResolver : IFormatterResolver
+        {
+            internal static readonly MessagePackSerializerOptions Options = new MessagePackSerializerOptions(new EmptyResolver());
+
+            public IMessagePackFormatter<T> GetFormatter<T>() => null;
         }
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
@@ -31,7 +31,7 @@ namespace MessagePack.Internal
             AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.Run;
 #endif
             this.assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(moduleName), builderAccess);
-            this.moduleBuilder = this.assemblyBuilder.DefineDynamicModule(moduleName);
+            this.moduleBuilder = this.assemblyBuilder.DefineDynamicModule(moduleName + ".dll");
         }
 
         /* requires lock on mono environment. see: https://github.com/neuecc/MessagePack-CSharp/issues/161 */

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -649,12 +649,12 @@ namespace MessagePack.Internal
             return dict;
         }
 
-        // int Serialize([arg:1]MessagePackWriter writer, [arg:2]T value, [arg:3]MessagePackSerializerOptions options);
+        // void Serialize(ref [arg:1]MessagePackWriter writer, [arg:2]T value, [arg:3]MessagePackSerializerOptions options);
         private static void BuildSerialize(Type type, ObjectSerializationInfo info, ILGenerator il, Action emitStringByteKeys, Func<int, ObjectSerializationInfo.EmittableMember, Action> tryEmitLoadCustomFormatter, int firstArgIndex)
         {
             var argWriter = new ArgumentField(il, firstArgIndex);
             var argValue = new ArgumentField(il, firstArgIndex + 1, type);
-            var argResolver = new ArgumentField(il, firstArgIndex + 2);
+            var argOptions = new ArgumentField(il, firstArgIndex + 2);
 
             // if(value == null) return WriteNil
             if (type.GetTypeInfo().IsClass)
@@ -690,7 +690,7 @@ namespace MessagePack.Internal
 
             // IFormatterResolver resolver = options.Resolver;
             LocalBuilder localResolver = il.DeclareLocal(typeof(IFormatterResolver));
-            argResolver.EmitLoad();
+            argOptions.EmitLoad();
             il.EmitCall(getResolverFromOptions);
             il.EmitStloc(localResolver);
 
@@ -710,7 +710,7 @@ namespace MessagePack.Internal
                     ObjectSerializationInfo.EmittableMember member;
                     if (intKeyMap.TryGetValue(i, out member))
                     {
-                        EmitSerializeValue(il, type.GetTypeInfo(), member, i, tryEmitLoadCustomFormatter, argWriter, argValue, argResolver, localResolver);
+                        EmitSerializeValue(il, type.GetTypeInfo(), member, i, tryEmitLoadCustomFormatter, argWriter, argValue, argOptions, localResolver);
                     }
                     else
                     {
@@ -765,7 +765,7 @@ namespace MessagePack.Internal
                         il.EmitCall(MessagePackWriterTypeInfo.WriteRaw);
                     }
 
-                    EmitSerializeValue(il, type.GetTypeInfo(), item, index, tryEmitLoadCustomFormatter, argWriter, argValue, argResolver, localResolver);
+                    EmitSerializeValue(il, type.GetTypeInfo(), item, index, tryEmitLoadCustomFormatter, argWriter, argValue, argOptions, localResolver);
                     index++;
                 }
             }


### PR DESCRIPTION
There were several problems, including:
1. The `DynamicAssembly.Save()` method emitted empty assemblies (because the module name didn't include the file extension).
1. The `DynamicCodeDumper.Program` class was passing in `null` to the formatter for the options, which isn't supported.
1. The package references didn't match what was required and used by `MessagePack` itself.

I also fixed a local variable name to reflect what it actually represents.

Fixes #510