### PR TITLE
Improve compatibility with existing types

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1421,9 +1421,7 @@ namespace MessagePack.Internal
                         }
 
                         EmittableMember member;
-                        var property = item as PropertyInfo;
-                        var field = item as FieldInfo;
-                        if (property != null)
+                        if (item is PropertyInfo property)
                         {
                             if (property.IsIndexer())
                             {
@@ -1441,7 +1439,7 @@ namespace MessagePack.Internal
                                 StringKey = memberGroup.Count() > 1 ? $"{item.DeclaringType.FullName}.{item.Name}" : item.Name,
                             };
                         }
-                        else if (field != null)
+                        else if (item is FieldInfo field)
                         {
                             if (item.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>(true) != null)
                             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1439,7 +1439,20 @@ namespace MessagePack.Internal
                     }
                     else
                     {
-                        stringMembers.Add(member.StringKey, member);
+                        if (stringMembers.TryGetValue(member.StringKey, out var existingMember))
+                        {
+                            // a member of the same name already exists
+                            var existingMemberInfo = existingMember.PropertyInfo ?? (MemberInfo)existingMember.FieldInfo;
+                            if (item.DeclaringType.IsSubclassOf(existingMemberInfo.DeclaringType))
+                            {
+                                // properties declared with the 'new' modifier override existing entries
+                                stringMembers[member.StringKey] = member;
+                            }
+                        }
+                        else
+                        {
+                            stringMembers.Add(member.StringKey, member);
+                        }
                     }
                 }
 
@@ -1484,7 +1497,20 @@ namespace MessagePack.Internal
                     }
                     else
                     {
-                        stringMembers.Add(member.StringKey, member);
+                        if (stringMembers.TryGetValue(member.StringKey, out var existingMember))
+                        {
+                            // a member of the same name already exists
+                            var existingMemberInfo = existingMember.PropertyInfo ?? (MemberInfo)existingMember.FieldInfo;
+                            if (item.DeclaringType.IsSubclassOf(existingMemberInfo.DeclaringType))
+                            {
+                                // fields declared with the 'new' modifier override existing entries
+                                stringMembers[member.StringKey] = member;
+                            }
+                        }
+                        else
+                        {
+                            stringMembers.Add(member.StringKey, member);
+                        }
                     }
                 }
             }
@@ -1871,7 +1897,7 @@ namespace MessagePack.Internal
                 BestmatchConstructor = ctor,
                 ConstructorParameters = constructorParameters.ToArray(),
                 IsIntKey = isIntKey,
-                Members = members,
+                Members = members.Where(m => constructorParameters.Contains(m) || m.IsWritable).ToArray(),
             };
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -257,26 +257,34 @@ namespace MessagePack.Tests
         public void NewFieldCheck()
         {
             var o = new NewField { X = "Foo", Y = "Bar" };
-            ((BaseField)o).X = 123;
+            BaseField b1 = o;
+            b1.X = 123;
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
             this.logger.WriteLine(MessagePackSerializer.ConvertToJson(bin));
-            NewField v =
-                MessagePackSerializer.Deserialize<NewField>(bin, Resolvers.ContractlessStandardResolver.Options);
-
+            var v = MessagePackSerializer.Deserialize<NewField>(bin, Resolvers.ContractlessStandardResolver.Options);
             v.IsStructuralEqual(o);
+
+            // Verify that we still maintain compatibility with deserializing the base type.
+            var b2 = MessagePackSerializer.Deserialize<BaseField>(bin, Resolvers.ContractlessStandardResolver.Options);
+            Assert.Equal(b1.X, b2.X);
+            Assert.Equal(b1.Y, b2.Y);
         }
 
         [Fact]
         public void NewPropertyCheck()
         {
             var o = new NewProperty { X = "Foo", Y = "Bar" };
-            ((BaseProperty)o).X = 123;
+            BaseProperty b1 = o;
+            b1.X = 123;
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
             this.logger.WriteLine(MessagePackSerializer.ConvertToJson(bin));
-            NewProperty v =
-                MessagePackSerializer.Deserialize<NewProperty>(bin, Resolvers.ContractlessStandardResolver.Options);
-
+            var v = MessagePackSerializer.Deserialize<NewProperty>(bin, Resolvers.ContractlessStandardResolver.Options);
             v.IsStructuralEqual(o);
+
+            // Verify that we still maintain compatibility with deserializing the base type.
+            var b2 = MessagePackSerializer.Deserialize<BaseProperty>(bin, Resolvers.ContractlessStandardResolver.Options);
+            Assert.Equal(b1.X, b2.X);
+            Assert.Equal(b1.Y, b2.Y);
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -249,6 +249,7 @@ namespace MessagePack.Tests
         public void NewFieldCheck()
         {
             var o = new NewField { X = "Foo", Y = "Bar" };
+            ((BaseField)o).X = 123;
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
             NewField v =
                 MessagePackSerializer.Deserialize<NewField>(bin, Resolvers.ContractlessStandardResolver.Options);
@@ -260,6 +261,7 @@ namespace MessagePack.Tests
         public void NewPropertyCheck()
         {
             var o = new NewProperty { X = "Foo", Y = "Bar" };
+            ((BaseProperty)o).X = 123;
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
             NewProperty v =
                 MessagePackSerializer.Deserialize<NewProperty>(bin, Resolvers.ContractlessStandardResolver.Options);

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace MessagePack.Tests
@@ -99,6 +95,34 @@ namespace MessagePack.Tests
             public int MyProperty1MyProperty1MyProperty1MyProperty1MyProperty1MyProperty1MyProperty1MyProperty1MyProperty1MyProperty1MyProperty2MyProperty { get; set; }
 
             public int OAFADFZEWFSDFSDFKSLJFWEFNWOZFUSEWWEFWEWFFFFFFFFFFFFFFZFEWBFOWUEGWHOUDGSOGUDSZNOFRWEUFWGOWHOGHWOG000000000000000000000000000000000000000HOGZ { get; set; }
+        }
+
+        public class BaseProperty
+        {
+            public int Y;
+
+            public int X { get; set; }
+        }
+
+        public class NewProperty : BaseProperty
+        {
+            public new string X { get; set; }
+
+            public new string Y { get; set; }
+        }
+
+        public class BaseField
+        {
+            public int X;
+
+            public int Y { get; set; }
+        }
+
+        public class NewField : BaseField
+        {
+            public new string X;
+
+            public new string Y;
         }
 
         [Fact]
@@ -217,6 +241,28 @@ namespace MessagePack.Tests
             };
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
             LongestString v = MessagePackSerializer.Deserialize<LongestString>(bin, Resolvers.ContractlessStandardResolver.Options);
+
+            v.IsStructuralEqual(o);
+        }
+
+        [Fact]
+        public void NewFieldCheck()
+        {
+            var o = new NewField { X = "Foo", Y = "Bar" };
+            var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
+            NewField v =
+                MessagePackSerializer.Deserialize<NewField>(bin, Resolvers.ContractlessStandardResolver.Options);
+
+            v.IsStructuralEqual(o);
+        }
+
+        [Fact]
+        public void NewPropertyCheck()
+        {
+            var o = new NewProperty { X = "Foo", Y = "Bar" };
+            var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
+            NewProperty v =
+                MessagePackSerializer.Deserialize<NewProperty>(bin, Resolvers.ContractlessStandardResolver.Options);
 
             v.IsStructuralEqual(o);
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -4,11 +4,19 @@
 using System;
 using System.Collections;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MessagePack.Tests
 {
     public class ContractlessStandardResolverTest
     {
+        private readonly ITestOutputHelper logger;
+
+        public ContractlessStandardResolverTest(ITestOutputHelper logger)
+        {
+            this.logger = logger;
+        }
+
         public class Address
         {
             public string Street { get; set; }
@@ -251,6 +259,7 @@ namespace MessagePack.Tests
             var o = new NewField { X = "Foo", Y = "Bar" };
             ((BaseField)o).X = 123;
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
+            this.logger.WriteLine(MessagePackSerializer.ConvertToJson(bin));
             NewField v =
                 MessagePackSerializer.Deserialize<NewField>(bin, Resolvers.ContractlessStandardResolver.Options);
 
@@ -263,6 +272,7 @@ namespace MessagePack.Tests
             var o = new NewProperty { X = "Foo", Y = "Bar" };
             ((BaseProperty)o).X = 123;
             var bin = MessagePackSerializer.Serialize(o, Resolvers.ContractlessStandardResolver.Options);
+            this.logger.WriteLine(MessagePackSerializer.ConvertToJson(bin));
             NewProperty v =
                 MessagePackSerializer.Deserialize<NewProperty>(bin, Resolvers.ContractlessStandardResolver.Options);
 

--- a/tests/MessagePack.Tests/ContractlessStandardResolverConstructorTests.cs
+++ b/tests/MessagePack.Tests/ContractlessStandardResolverConstructorTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using MessagePack.Resolvers;
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class ContractlessStandardResolverConstructorTests
+    {
+        public class TestConstructor1
+        {
+            public int X { get; }
+
+            public int Y { get; }
+
+            public int Z { get; }
+
+            public int CalledConstructorParameterCount { get; }
+
+            public TestConstructor1()
+            {
+                this.CalledConstructorParameterCount = 0;
+            }
+
+            public TestConstructor1(int x)
+            {
+                this.X = x;
+                this.CalledConstructorParameterCount = 1;
+            }
+
+            public TestConstructor1(int x, int y)
+            {
+                this.X = x;
+                this.Y = y;
+                this.CalledConstructorParameterCount = 2;
+            }
+
+            public TestConstructor1(int x, int y, int z)
+            {
+                this.X = x;
+                this.Y = y;
+                this.Z = z;
+                this.CalledConstructorParameterCount = 3;
+            }
+        }
+
+        public class TestConstructor2
+        {
+            public int X { get; }
+
+            public int Y { get; }
+
+            public int Z { get; }
+
+            public int CalledConstructorParameterCount { get; }
+
+            public int Bad => throw new InvalidOperationException();
+
+            public TestConstructor2()
+            {
+                this.CalledConstructorParameterCount = 0;
+            }
+
+            public TestConstructor2(int x)
+            {
+                this.X = x;
+                this.CalledConstructorParameterCount = 1;
+            }
+
+            public TestConstructor2(int x, int y)
+            {
+                this.X = x;
+                this.Y = y;
+                this.CalledConstructorParameterCount = 2;
+            }
+
+            public TestConstructor2(int x, int y, int z)
+            {
+                this.X = x;
+                this.Y = y;
+                this.Z = z;
+                this.CalledConstructorParameterCount = 3;
+            }
+        }
+
+        [Fact]
+        public void UseConstructor()
+        {
+            var ctor = new TestConstructor1(10, 20, 30);
+            var bin = MessagePackSerializer.Serialize(ctor, ContractlessStandardResolver.Options);
+            var r = MessagePackSerializer.Deserialize<TestConstructor1>(bin, ContractlessStandardResolver.Options);
+
+            r.CalledConstructorParameterCount.Is(3);
+        }
+
+        [Fact]
+        public void IgnorePropertiesWithoutConstructorArgument()
+        {
+            var ctor = new TestConstructor2(10, 20, 30);
+            var bin = MessagePackSerializer.Serialize(ctor, ContractlessStandardResolver.Options);
+            var r = MessagePackSerializer.Deserialize<TestConstructor2>(bin, ContractlessStandardResolver.Options);
+
+            r.CalledConstructorParameterCount.Is(3);
+        }
+    }
+}

--- a/tests/MessagePack.Tests/Utils/ChainingAssertion.Xunit.cs
+++ b/tests/MessagePack.Tests/Utils/ChainingAssertion.Xunit.cs
@@ -540,7 +540,7 @@ namespace Xunit
                 .Where(x => x.GetGetMethod(false) != null && x.GetIndexParameters().Length == 0);
             IEnumerable<MemberInfo> members = fields.Cast<MemberInfo>().Concat(properties);
 
-            foreach (dynamic mi in fields.Cast<MemberInfo>().Concat(properties))
+            foreach (dynamic mi in members)
             {
                 IEnumerable<string> concatNames = names.Concat(new[] { (string)mi.Name });
 


### PR DESCRIPTION
In a project we want to serialize contractless classes from [Units.NET](https://github.com/neuecc/MessagePack-CSharp) (e.g. Pressure) with MessagePack. Besides a minor [problem](https://github.com/angularsen/UnitsNet/pull/705) in Units.NET, I had to make a few changes to MessagePack to support (de)serialization of these types without exceptions. 

- Ignore members which are neither writable nor have an associated
  constructor argument of the same name (prevent exceptions while
  accessing members which cannot be deserialized anyway)
- Support members declared with the 'new' modifier in a subclass
  (prevent ArgumentException while adding an existing item to an
  dictionary)