### PR TITLE
Remove mutable fields/properties from TypelessFormatter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -93,7 +93,7 @@ namespace MessagePack
         }
 
         /// <summary>
-        /// From Json String to MessagePack binary.
+        /// Translates the given JSON to MessagePack.
         /// </summary>
         public static void ConvertFromJson(string str, ref MessagePackWriter writer, MessagePackSerializerOptions options = null)
         {
@@ -104,7 +104,25 @@ namespace MessagePack
         }
 
         /// <summary>
-        /// From Json String to MessagePack binary.
+        /// Translates the given JSON to MessagePack.
+        /// </summary>
+        public static byte[] ConvertFromJson(string str, MessagePackSerializerOptions options = null)
+        {
+            using (var seq = new Sequence<byte>())
+            {
+                var writer = new MessagePackWriter(seq);
+                using (var sr = new StringReader(str))
+                {
+                    ConvertFromJson(sr, ref writer, options);
+                }
+
+                writer.Flush();
+                return seq.AsReadOnlySequence.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Translates the given JSON to MessagePack.
         /// </summary>
         public static void ConvertFromJson(TextReader reader, ref MessagePackWriter writer, MessagePackSerializerOptions options = null)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace MessagePack
 {
@@ -12,6 +14,19 @@ namespace MessagePack
 #endif
     public class MessagePackSerializerOptions
     {
+        // see:http://msdn.microsoft.com/en-us/library/w3f99sx1.aspx
+        internal static readonly Regex AssemblyNameVersionSelectorRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=[\w-]+, PublicKeyToken=(?:null|[a-f0-9]{16})$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// A collection of known dangerous types that are not expected in a typical MessagePack stream,
+        /// and thus are rejected by the default implementation of <see cref="ThrowIfDeserializingTypeIsDisallowed(Type)"/>.
+        /// </summary>
+        private static readonly HashSet<string> BlacklistCheck = new HashSet<string>
+        {
+            "System.CodeDom.Compiler.TempFileCollection",
+            "System.Management.IWbemClassObjectFreeThreaded",
+        };
+
 #if !DYNAMICCODEDUMPER
         /// <summary>
         /// Gets a good default set of options that uses the <see cref="Resolvers.StandardResolver"/> and no compression.
@@ -27,11 +42,29 @@ namespace MessagePack
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackSerializerOptions"/> class.
         /// </summary>
-        internal MessagePackSerializerOptions(IFormatterResolver resolver, bool useLZ4Compression = false, bool? oldSpec = null)
+        protected internal MessagePackSerializerOptions(IFormatterResolver resolver, bool useLZ4Compression = false)
         {
             this.Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
             this.UseLZ4Compression = useLZ4Compression;
-            this.OldSpec = oldSpec;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializerOptions"/> class
+        /// with members initialized from an existing instance.
+        /// </summary>
+        /// <param name="copyFrom">The options to copy from.</param>
+        protected MessagePackSerializerOptions(MessagePackSerializerOptions copyFrom)
+        {
+            if (copyFrom == null)
+            {
+                throw new ArgumentNullException(nameof(copyFrom));
+            }
+
+            this.Resolver = copyFrom.Resolver;
+            this.UseLZ4Compression = copyFrom.UseLZ4Compression;
+            this.OldSpec = copyFrom.OldSpec;
+            this.OmitAssemblyVersion = copyFrom.OmitAssemblyVersion;
+            this.AllowAssemblyVersionMismatch = copyFrom.AllowAssemblyVersionMismatch;
         }
 
         /// <summary>
@@ -39,7 +72,7 @@ namespace MessagePack
         /// </summary>
         /// <value>An instance of <see cref="IFormatterResolver"/>. Never <c>null</c>.</value>
         /// <exception cref="ArgumentNullException">Thrown if an attempt is made to set this property to <c>null</c>.</exception>
-        public IFormatterResolver Resolver { get; }
+        public IFormatterResolver Resolver { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether to apply LZ4 to the MessagePack stream.
@@ -47,7 +80,7 @@ namespace MessagePack
         /// <remarks>
         /// When set to <c>true</c>, uncompressed MessagePack can still be deserialized and a small MessagePack stream may not be compressed.
         /// </remarks>
-        public bool UseLZ4Compression { get; }
+        public bool UseLZ4Compression { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether to serialize with <see cref="MessagePackWriter.OldSpec"/> set to some value
@@ -61,28 +94,158 @@ namespace MessagePack
         /// <remarks>
         /// Reading always supports both new and old spec.
         /// </remarks>
-        public bool? OldSpec { get; }
+        public bool? OldSpec { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether serialization should omit assembly version, culture and public key token metadata when using the typeless formatter.
+        /// </summary>
+        /// <value>The default value is <c>false</c>.</value>
+        public bool OmitAssemblyVersion { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether deserialization may instantiate types from an assembly with a different version if a matching version cannot be found.
+        /// </summary>
+        /// <value>The default value is <c>false</c>.</value>
+        public bool AllowAssemblyVersionMismatch { get; private set; }
+
+        /// <summary>
+        /// Gets a type given a string representation of the type.
+        /// </summary>
+        /// <param name="typeName">The name of the type to load. This is typically the <see cref="Type.AssemblyQualifiedName"/> but may use the assembly's simple name.</param>
+        /// <returns>The loaded type or <c>null</c> if no matching type could be found.</returns>
+        public virtual Type LoadType(string typeName)
+        {
+            Type result = Type.GetType(typeName, false);
+            if (result == null && this.AllowAssemblyVersionMismatch)
+            {
+                string shortenedName = AssemblyNameVersionSelectorRegex.Replace(typeName, string.Empty);
+                if (shortenedName != typeName)
+                {
+                    result = Type.GetType(shortenedName, false);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Checks whether a given type may be deserialized.
+        /// </summary>
+        /// <param name="type">The type to be instantiated.</param>
+        /// <exception cref="TypeAccessException">Thrown if the <paramref name="type"/> is not allowed to be deserialized.</exception>
+        /// <remarks>
+        /// This method provides a means for an important security mitigation when using the Typeless formatter to prevent untrusted messagepack from
+        /// deserializing objects that may be harmful if instantiated, disposed or finalized.
+        /// The default implementation throws for only a few known dangerous types.
+        /// Applications that deserialize from untrusted sources should override this method and throw if the type is not among the expected set.
+        /// </remarks>
+        public virtual void ThrowIfDeserializingTypeIsDisallowed(Type type)
+        {
+            if (BlacklistCheck.Contains(type.FullName))
+            {
+                throw new TypeAccessException();
+            }
+        }
 
         /// <summary>
         /// Gets a copy of these options with the <see cref="Resolver"/> property set to a new value.
         /// </summary>
         /// <param name="resolver">The new value for the <see cref="Resolver"/>.</param>
         /// <returns>The new instance; or the original if the value is unchanged.</returns>
-        public MessagePackSerializerOptions WithResolver(IFormatterResolver resolver) => this.Resolver != resolver ? new MessagePackSerializerOptions(resolver, this.UseLZ4Compression, this.OldSpec) : this;
+        public MessagePackSerializerOptions WithResolver(IFormatterResolver resolver)
+        {
+            if (this.Resolver == resolver)
+            {
+                return this;
+            }
+
+            var result = this.Clone();
+            result.Resolver = resolver;
+            return result;
+        }
 
         /// <summary>
         /// Gets a copy of these options with the <see cref="UseLZ4Compression"/> property set to a new value.
         /// </summary>
         /// <param name="useLZ4Compression">The new value for the <see cref="UseLZ4Compression"/>.</param>
         /// <returns>The new instance; or the original if the value is unchanged.</returns>
-        public MessagePackSerializerOptions WithLZ4Compression(bool useLZ4Compression = true) => this.UseLZ4Compression != useLZ4Compression ? new MessagePackSerializerOptions(this.Resolver, useLZ4Compression, this.OldSpec) : this;
+        public MessagePackSerializerOptions WithLZ4Compression(bool useLZ4Compression = true)
+        {
+            if (this.UseLZ4Compression == useLZ4Compression)
+            {
+                return this;
+            }
+
+            var result = this.Clone();
+            result.UseLZ4Compression = useLZ4Compression;
+            return result;
+        }
 
         /// <summary>
         /// Gets a copy of these options with the <see cref="OldSpec"/> property set to a new value.
         /// </summary>
         /// <param name="oldSpec">The new value for the <see cref="OldSpec"/>.</param>
         /// <returns>The new instance; or the original if the value is unchanged.</returns>
-        public MessagePackSerializerOptions WithOldSpec(bool? oldSpec = true) => this.OldSpec != oldSpec ? new MessagePackSerializerOptions(this.Resolver, this.UseLZ4Compression, oldSpec) : this;
+        public MessagePackSerializerOptions WithOldSpec(bool? oldSpec = true)
+        {
+            if (this.OldSpec == oldSpec)
+            {
+                return this;
+            }
+
+            var result = this.Clone();
+            result.OldSpec = oldSpec;
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a copy of these options with the <see cref="OmitAssemblyVersion"/> property set to a new value.
+        /// </summary>
+        /// <param name="omitAssemblyVersion">The new value for the <see cref="OmitAssemblyVersion"/> property.</param>
+        /// <returns>The new instance; or the original if the value is unchanged.</returns>
+        public MessagePackSerializerOptions WithOmitAssemblyVersion(bool omitAssemblyVersion)
+        {
+            if (this.OmitAssemblyVersion == omitAssemblyVersion)
+            {
+                return this;
+            }
+
+            var result = this.Clone();
+            result.OmitAssemblyVersion = omitAssemblyVersion;
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a copy of these options with the <see cref="AllowAssemblyVersionMismatch"/> property set to a new value.
+        /// </summary>
+        /// <param name="allowAssemblyVersionMismatch">The new value for the <see cref="AllowAssemblyVersionMismatch"/> property.</param>
+        /// <returns>The new instance; or the original if the value is unchanged.</returns>
+        public MessagePackSerializerOptions WithAllowAssemblyVersionMismatch(bool allowAssemblyVersionMismatch)
+        {
+            if (this.AllowAssemblyVersionMismatch == allowAssemblyVersionMismatch)
+            {
+                return this;
+            }
+
+            var result = this.Clone();
+            result.AllowAssemblyVersionMismatch = allowAssemblyVersionMismatch;
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a clone of this instance with the same properties set.
+        /// </summary>
+        /// <returns>The cloned instance. Guaranteed to be a new instance.</returns>
+        /// <exception cref="NotSupportedException">Thrown if this instance is a derived type that doesn't override this method.</exception>
+        protected virtual MessagePackSerializerOptions Clone()
+        {
+            if (this.GetType() != typeof(MessagePackSerializerOptions))
+            {
+                throw new NotSupportedException($"The derived type {this.GetType().FullName} did not override the {nameof(Clone)} method as required.");
+            }
+
+            return new MessagePackSerializerOptions(this);
+        }
 
 #if !DYNAMICCODEDUMPER
         private static class MessagePackSerializerOptionsDefaultSettingsLazyInitializationHelper

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1106,6 +1106,11 @@ namespace MessagePack
             }
             else
             {
+                if (this.writer.SequenceRental.Value == null)
+                {
+                    throw new NotSupportedException("This instance was not initialized to support this operation.");
+                }
+
                 this.Flush();
                 byte[] result = this.writer.SequenceRental.Value.AsReadOnlySequence.ToArray();
                 this.writer.SequenceRental.Dispose();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerOptionsTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerOptionsTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MessagePack;
+using MessagePack.Resolvers;
+using Xunit;
+
+public class MessagePackSerializerOptionsTests
+{
+    private static readonly MessagePackSerializerOptions NonDefaultOptions = MessagePackSerializerOptions.Standard
+        .WithLZ4Compression(true)
+        .WithAllowAssemblyVersionMismatch(true)
+        .WithOmitAssemblyVersion(true)
+        .WithResolver(BuiltinResolver.Instance)
+        .WithOldSpec(false);
+
+    [Fact]
+    public void AllowAssemblyVersionMismatch()
+    {
+        Assert.False(MessagePackSerializerOptions.Standard.AllowAssemblyVersionMismatch);
+        Assert.True(MessagePackSerializerOptions.Standard.WithAllowAssemblyVersionMismatch(true).AllowAssemblyVersionMismatch);
+    }
+
+    [Fact]
+    public void OmitAssemblyVersion()
+    {
+        Assert.False(MessagePackSerializerOptions.Standard.OmitAssemblyVersion);
+        Assert.True(MessagePackSerializerOptions.Standard.WithOmitAssemblyVersion(true).OmitAssemblyVersion);
+    }
+
+    [Fact]
+    public void UseLZ4Compression()
+    {
+        Assert.False(MessagePackSerializerOptions.Standard.UseLZ4Compression);
+        Assert.True(MessagePackSerializerOptions.Standard.WithLZ4Compression(true).UseLZ4Compression);
+    }
+
+    [Fact]
+    public void OldSpec()
+    {
+        Assert.Null(MessagePackSerializerOptions.Standard.OldSpec);
+        Assert.True(MessagePackSerializerOptions.Standard.WithOldSpec(true).OldSpec);
+    }
+
+    [Fact]
+    public void Resolver()
+    {
+        Assert.Same(StandardResolver.Instance, MessagePackSerializerOptions.Standard.Resolver);
+        Assert.Same(BuiltinResolver.Instance, MessagePackSerializerOptions.Standard.WithResolver(BuiltinResolver.Instance).Resolver);
+    }
+
+    [Fact]
+    public void WithOldSpec_PreservesOtherProperties()
+    {
+        var mutated = NonDefaultOptions.WithOldSpec(true);
+        Assert.True(mutated.OldSpec);
+        Assert.Equal(NonDefaultOptions.UseLZ4Compression, mutated.UseLZ4Compression);
+        Assert.Equal(NonDefaultOptions.AllowAssemblyVersionMismatch, mutated.AllowAssemblyVersionMismatch);
+        Assert.Equal(NonDefaultOptions.OmitAssemblyVersion, mutated.OmitAssemblyVersion);
+        Assert.Same(NonDefaultOptions.Resolver, mutated.Resolver);
+    }
+
+    [Fact]
+    public void WithLZ4Compression_PreservesOtherProperties()
+    {
+        var mutated = NonDefaultOptions.WithLZ4Compression(false);
+        Assert.False(mutated.UseLZ4Compression);
+        Assert.Equal(NonDefaultOptions.OldSpec, mutated.OldSpec);
+        Assert.Equal(NonDefaultOptions.AllowAssemblyVersionMismatch, mutated.AllowAssemblyVersionMismatch);
+        Assert.Equal(NonDefaultOptions.OmitAssemblyVersion, mutated.OmitAssemblyVersion);
+        Assert.Same(NonDefaultOptions.Resolver, mutated.Resolver);
+    }
+
+    [Fact]
+    public void WithAllowAssemblyVersionMismatch_PreservesOtherProperties()
+    {
+        var mutated = NonDefaultOptions.WithAllowAssemblyVersionMismatch(false);
+        Assert.False(mutated.AllowAssemblyVersionMismatch);
+        Assert.Equal(NonDefaultOptions.UseLZ4Compression, mutated.UseLZ4Compression);
+        Assert.Equal(NonDefaultOptions.OldSpec, mutated.OldSpec);
+        Assert.Equal(NonDefaultOptions.OmitAssemblyVersion, mutated.OmitAssemblyVersion);
+        Assert.Same(NonDefaultOptions.Resolver, mutated.Resolver);
+    }
+
+    [Fact]
+    public void WithOmitAssemblyVersion_PreservesOtherProperties()
+    {
+        var mutated = NonDefaultOptions.WithOmitAssemblyVersion(false);
+        Assert.False(mutated.OmitAssemblyVersion);
+        Assert.Equal(NonDefaultOptions.UseLZ4Compression, mutated.UseLZ4Compression);
+        Assert.Equal(NonDefaultOptions.OldSpec, mutated.OldSpec);
+        Assert.Equal(NonDefaultOptions.AllowAssemblyVersionMismatch, mutated.AllowAssemblyVersionMismatch);
+        Assert.Same(NonDefaultOptions.Resolver, mutated.Resolver);
+    }
+
+    [Fact]
+    public void WithResolver_PreservesOtherProperties()
+    {
+        var mutated = NonDefaultOptions.WithResolver(ContractlessStandardResolver.Instance);
+        Assert.Same(ContractlessStandardResolver.Instance, mutated.Resolver);
+        Assert.Equal(NonDefaultOptions.UseLZ4Compression, mutated.UseLZ4Compression);
+        Assert.Equal(NonDefaultOptions.OldSpec, mutated.OldSpec);
+        Assert.Equal(NonDefaultOptions.AllowAssemblyVersionMismatch, mutated.AllowAssemblyVersionMismatch);
+        Assert.Equal(NonDefaultOptions.OmitAssemblyVersion, mutated.OmitAssemblyVersion);
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using MessagePack;
+using MessagePack.Resolvers;
+using Xunit;
+using Xunit.Abstractions;
+
+public class MessagePackSerializerTypelessTests
+{
+    private readonly ITestOutputHelper logger;
+
+    public MessagePackSerializerTypelessTests(ITestOutputHelper logger)
+    {
+        this.logger = logger;
+    }
+
+    [Fact]
+    public void SerializationOfBuiltInType()
+    {
+        byte[] msgpack = MessagePackSerializer.Typeless.Serialize("hi");
+        this.logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack));
+        Assert.Equal("hi", MessagePackSerializer.Typeless.Deserialize(msgpack));
+    }
+
+    [Fact]
+    public void SerializationOfDisallowedType()
+    {
+        var myOptions = new MyTypelessOptions();
+        byte[] msgpack = MessagePackSerializer.Typeless.Serialize(new MyObject { SomeValue = 5 }, myOptions);
+        this.logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack, myOptions));
+        Assert.Throws<TypeAccessException>(() => MessagePackSerializer.Typeless.Deserialize(msgpack, myOptions));
+    }
+
+    [Fact]
+    public void OmitAssemblyVersion()
+    {
+        string json = MessagePackSerializer.ConvertToJson(MessagePackSerializer.Typeless.Serialize(new MyObject { SomeValue = 5 }));
+        this.logger.WriteLine(json);
+        Assert.Contains(ThisAssembly.AssemblyVersion, json);
+        json = MessagePackSerializer.ConvertToJson(MessagePackSerializer.Typeless.Serialize(new MyObject { SomeValue = 5 }, MessagePackSerializer.Typeless.DefaultOptions.WithOmitAssemblyVersion(true)));
+        this.logger.WriteLine(json);
+        Assert.DoesNotContain(ThisAssembly.AssemblyVersion, json);
+    }
+
+    public class MyObject
+    {
+        public object SomeValue { get; set; }
+    }
+
+    private class MyTypelessOptions : MessagePackSerializerOptions
+    {
+        internal MyTypelessOptions()
+            : base(TypelessContractlessStandardResolver.Options)
+        {
+        }
+
+        internal MyTypelessOptions(MyTypelessOptions copyFrom)
+            : base(copyFrom)
+        {
+        }
+
+        public override void ThrowIfDeserializingTypeIsDisallowed(Type type)
+        {
+            if (type == typeof(MyObject))
+            {
+                throw new TypeAccessException();
+            }
+        }
+
+        protected override MessagePackSerializerOptions Clone() => new MyTypelessOptions(this);
+    }
+}


### PR DESCRIPTION
This change makes MessagePackSerializerOptions support subclassing while maintaining its immutable nature.

Also move the blacklist in TypelessFormatter to MessagePackSerializerOptions where it is now extensible/replaceable with a whitelist.
Also fix the short-name switch to store the cache in two different fields based on the switch to avoid cache corruption when the switch is changed after serializing some types.

Fixes #444
Fixes #567