### PR TITLE
Add CancellationToken parameters to synchronous Stream (de)serialize methods

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -122,13 +122,16 @@ namespace MessagePack
         /// <param name="stream">The stream to serialize to.</param>
         /// <param name="value">The value to serialize.</param>
         /// <param name="options">The options. Use <c>null</c> to use default options.</param>
-        public static void Serialize<T>(Stream stream, T value, MessagePackSerializerOptions options = null)
+        /// <param name="cancellationToken">A cancellation token.</param>
+        public static void Serialize<T>(Stream stream, T value, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             using (SequencePool.Rental sequenceRental = ReusableSequenceWithMinSize.Rent())
             {
                 Serialize<T>(sequenceRental.Value, value, options);
                 foreach (ReadOnlyMemory<byte> segment in sequenceRental.Value.AsReadOnlySequence)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     stream.Write(segment.Span);
                 }
             }
@@ -237,9 +240,11 @@ namespace MessagePack
         /// <typeparam name="T">The type of value to deserialize.</typeparam>
         /// <param name="stream">The stream to deserialize from.</param>
         /// <param name="options">The options. Use <c>null</c> to use default options.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The deserialized value.</returns>
-        public static T Deserialize<T>(Stream stream, MessagePackSerializerOptions options = null)
+        public static T Deserialize<T>(Stream stream, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (stream is MemoryStream ms && ms.TryGetBuffer(out ArraySegment<byte> streamBuffer))
             {
                 return Deserialize<T>(streamBuffer, options);
@@ -250,6 +255,7 @@ namespace MessagePack
                 int bytesRead;
                 do
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     Span<byte> span = sequence.GetSpan(stream.CanSeek ? (int)(stream.Length - stream.Position) : 0);
                     bytesRead = stream.Read(span);
                     sequence.Advance(bytesRead);


### PR DESCRIPTION
Since Stream is the only API that MessagePackSerializer takes which may take some time including I/O, accepting a CancellationToken can be very useful for cancelling such operations.