### PR TITLE
Introduce SerializationState struct and CancellationToken parameter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IMessagePackFormatter`1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IMessagePackFormatter`1.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.ComponentModel;
+using System.Threading;
 
 namespace MessagePack.Formatters
 {
@@ -28,15 +29,17 @@ namespace MessagePack.Formatters
         /// </summary>
         /// <param name="writer">The writer to use when serializing the value.</param>
         /// <param name="value">The value to be serialized.</param>
-        /// <param name="options">The serialization settings to use, including the resolver to use to obtain formatters for types that make up the composite type <typeparamref name="T"/>.</param>
-        void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
+        /// <param name="state">State relevant to this serialization operation.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        void Serialize(ref MessagePackWriter writer, T value, ref SerializationState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deserializes a value.
         /// </summary>
         /// <param name="reader">The reader to deserialize from.</param>
-        /// <param name="options">The serialization settings to use, including the resolver to use to obtain formatters for types that make up the composite type <typeparamref name="T"/>.</param>
+        /// <param name="state">State relevant to this specific serialization operation.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The deserialized value.</returns>
-        T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
+        T Deserialize(ref MessagePackReader reader, ref SerializationState state, CancellationToken cancellationToken);
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/SerializationState.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/SerializationState.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MessagePack.Formatters
+{
+    /// <summary>
+    /// Carries state specific to a particular serialization operation.
+    /// </summary>
+    /// <remarks>
+    /// This struct is propagated from the top-level serialization or deserialization request
+    /// down through all formatters that participate in it.
+    /// </remarks>
+    public ref struct SerializationState
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerializationState"/> struct.
+        /// </summary>
+        /// <param name="options">The serialization settings to use.</param>
+        public SerializationState(MessagePackSerializerOptions options)
+        {
+            this.Options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        /// <summary>
+        /// Gets the serialization settings to use, including the resolver to use to obtain <see cref="IMessagePackFormatter{T}" /> instances.
+        /// </summary>
+        public MessagePackSerializerOptions Options { get; }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
@@ -12,18 +12,30 @@ namespace MessagePack
 {
     public interface IFormatterResolver
     {
-        IMessagePackFormatter<T> GetFormatter<T>();
+        /// <summary>
+        /// Gets an <see cref="IMessagePackFormatter{T}"/> instance that can serialize or deserialize some type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value to be serialized or deserialized.</typeparam>
+        /// <param name="state">State associated with this particular serialization or deserialization operation.</param>
+        /// <returns>A formatter, if this resolver supplies one for type <typeparamref name="T"/>; otherwise <c>null</c>.</returns>
+        IMessagePackFormatter<T> GetFormatter<T>(ref SerializationState state);
     }
 
     public static class FormatterResolverExtensions
     {
+        private static readonly Type[] DelegateCacheTypeArray = new Type[1];
+
+        private static readonly Type[] GetFormatterParameterTypes = new Type[] { typeof(IFormatterResolver), typeof(SerializationState).MakeByRefType() };
+
+        private delegate object GetFormatterDelegate(IFormatterResolver resolver, ref SerializationState state);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IMessagePackFormatter<T> GetFormatterWithVerify<T>(this IFormatterResolver resolver)
+        public static IMessagePackFormatter<T> GetFormatterWithVerify<T>(this IFormatterResolver resolver, ref SerializationState state)
         {
             IMessagePackFormatter<T> formatter;
             try
             {
-                formatter = resolver.GetFormatter<T>();
+                formatter = resolver.GetFormatter<T>(ref state);
             }
             catch (TypeInitializationException ex)
             {
@@ -52,12 +64,25 @@ namespace MessagePack
             throw new FormatterNotRegisteredException(t.FullName + " is not registered in this resolver. resolver:" + resolver.GetType().Name);
         }
 
-        public static object GetFormatterDynamic(this IFormatterResolver resolver, Type type)
+        public static object GetFormatterDynamic(this IFormatterResolver resolver, Type type, ref SerializationState state)
         {
-            MethodInfo methodInfo = typeof(IFormatterResolver).GetRuntimeMethod(nameof(IFormatterResolver.GetFormatter), Type.EmptyTypes);
-
-            var formatter = methodInfo.MakeGenericMethod(type).Invoke(resolver, null);
+            var cache = typeof(DelegateCache<>).MakeGenericType(type);
+            var del = (GetFormatterDelegate)cache.GetField(nameof(DelegateCache<int>.MyDelegate)).GetValue(null);
+            var formatter = del(resolver, ref state);
             return formatter;
+        }
+
+        private static class DelegateCache<T>
+        {
+            internal static readonly GetFormatterDelegate MyDelegate;
+
+            static DelegateCache()
+            {
+                MethodInfo methodInfo = typeof(DelegateCache<T>).GetRuntimeMethod(nameof(GetFormatterDynamic), GetFormatterParameterTypes);
+                MyDelegate = (GetFormatterDelegate)methodInfo.CreateDelegate(typeof(GetFormatterDelegate));
+            }
+
+            private static object GetFormatterDynamic(IFormatterResolver resolver, ref SerializationState state) => resolver.GetFormatter<T>(ref state);
         }
     }
 


### PR DESCRIPTION
This simply updates the public API for `IMessagePackFormatter<T>` to propagate the new type.

This is a start on #597 and #598