### PR TITLE
Add CancellationToken to reader/writer structs

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -30,6 +30,7 @@ namespace MessagePack.Formatters
 
                 for (int i = 0; i < value.Length; i++)
                 {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, value[i], options);
                 }
             }
@@ -49,6 +50,7 @@ namespace MessagePack.Formatters
                 var array = new T[len];
                 for (int i = 0; i < array.Length; i++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     array[i] = formatter.Deserialize(ref reader, options);
                 }
 
@@ -116,6 +118,7 @@ namespace MessagePack.Formatters
                 T[] array = value.Array;
                 for (int i = 0; i < value.Count; i++)
                 {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
                     T item = array[value.Offset + i];
                     formatter.Serialize(ref writer, item, options);
                 }
@@ -154,6 +157,7 @@ namespace MessagePack.Formatters
 
                 for (int i = 0; i < c; i++)
                 {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, value[i], options);
                 }
             }
@@ -173,6 +177,7 @@ namespace MessagePack.Formatters
                 var list = new List<T>((int)len);
                 for (int i = 0; i < len; i++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     list.Add(formatter.Deserialize(ref reader, options));
                 }
 
@@ -203,6 +208,7 @@ namespace MessagePack.Formatters
 
                     foreach (TElement item in array)
                     {
+                        writer.CancellationToken.ThrowIfCancellationRequested();
                         formatter.Serialize(ref writer, item, options);
                     }
 
@@ -224,6 +230,7 @@ namespace MessagePack.Formatters
                         {
                             while (e.MoveNext())
                             {
+                                writer.CancellationToken.ThrowIfCancellationRequested();
                                 formatter.Serialize(ref writer, e.Current, options);
                             }
                         }
@@ -245,6 +252,7 @@ namespace MessagePack.Formatters
                             {
                                 while (e.MoveNext())
                                 {
+                                    writer.CancellationToken.ThrowIfCancellationRequested();
                                     count++;
                                     formatter.Serialize(ref scratchWriter, e.Current, options);
                                 }
@@ -278,6 +286,7 @@ namespace MessagePack.Formatters
                 TIntermediate list = this.Create(len);
                 for (int i = 0; i < len; i++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     this.Add(list, i, formatter.Deserialize(ref reader, options));
                 }
 
@@ -675,6 +684,7 @@ namespace MessagePack.Formatters
             writer.WriteArrayHeader(value.Count);
             foreach (var item in value)
             {
+                writer.CancellationToken.ThrowIfCancellationRequested();
                 formatter.Serialize(ref writer, item, options);
             }
         }
@@ -693,6 +703,7 @@ namespace MessagePack.Formatters
             var list = new T();
             for (int i = 0; i < count; i++)
             {
+                reader.CancellationToken.ThrowIfCancellationRequested();
                 list.Add(formatter.Deserialize(ref reader, options));
             }
 
@@ -721,6 +732,7 @@ namespace MessagePack.Formatters
             writer.WriteArrayHeader(value.Count);
             foreach (var item in value)
             {
+                writer.CancellationToken.ThrowIfCancellationRequested();
                 formatter.Serialize(ref writer, item, options);
             }
         }
@@ -739,6 +751,7 @@ namespace MessagePack.Formatters
             var list = new object[count];
             for (int i = 0; i < count; i++)
             {
+                reader.CancellationToken.ThrowIfCancellationRequested();
                 list[i] = formatter.Deserialize(ref reader, options);
             }
 
@@ -762,6 +775,7 @@ namespace MessagePack.Formatters
             writer.WriteMapHeader(value.Count);
             foreach (DictionaryEntry item in value)
             {
+                writer.CancellationToken.ThrowIfCancellationRequested();
                 formatter.Serialize(ref writer, item.Key, options);
                 formatter.Serialize(ref writer, item.Value, options);
             }
@@ -781,6 +795,7 @@ namespace MessagePack.Formatters
             var dict = new T();
             for (int i = 0; i < count; i++)
             {
+                reader.CancellationToken.ThrowIfCancellationRequested();
                 var key = formatter.Deserialize(ref reader, options);
                 var value = formatter.Deserialize(ref reader, options);
                 dict.Add(key, value);
@@ -811,6 +826,7 @@ namespace MessagePack.Formatters
             writer.WriteMapHeader(value.Count);
             foreach (DictionaryEntry item in value)
             {
+                writer.CancellationToken.ThrowIfCancellationRequested();
                 formatter.Serialize(ref writer, item.Key, options);
                 formatter.Serialize(ref writer, item.Value, options);
             }
@@ -830,6 +846,7 @@ namespace MessagePack.Formatters
             var dict = new Dictionary<object, object>(count);
             for (int i = 0; i < count; i++)
             {
+                reader.CancellationToken.ThrowIfCancellationRequested();
                 var key = formatter.Deserialize(ref reader, options);
                 var value = formatter.Deserialize(ref reader, options);
                 dict.Add(key, value);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs
@@ -55,6 +55,7 @@ namespace MessagePack.Formatters
                 {
                     while (e.MoveNext())
                     {
+                        writer.CancellationToken.ThrowIfCancellationRequested();
                         KeyValuePair<TKey, TValue> item = e.Current;
                         keyFormatter.Serialize(ref writer, item.Key, options);
                         valueFormatter.Serialize(ref writer, item.Value, options);
@@ -84,6 +85,7 @@ namespace MessagePack.Formatters
                 TIntermediate dict = this.Create(len);
                 for (int i = 0; i < len; i++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     TKey key = keyFormatter.Deserialize(ref reader, options);
 
                     TValue value = valueFormatter.Deserialize(ref reader, options);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs
@@ -36,6 +36,7 @@ namespace MessagePack.Formatters
                 writer.WriteArrayHeader(value.Length);
                 foreach (T item in value)
                 {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, item, options);
                 }
             }
@@ -67,6 +68,7 @@ namespace MessagePack.Formatters
                 var j = -1;
                 for (int loop = 0; loop < maxLen; loop++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     if (j < jLength - 1)
                     {
                         j++;
@@ -111,6 +113,7 @@ namespace MessagePack.Formatters
                 writer.WriteArrayHeader(value.Length);
                 foreach (T item in value)
                 {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, item, options);
                 }
             }
@@ -144,6 +147,7 @@ namespace MessagePack.Formatters
                 var k = -1;
                 for (int loop = 0; loop < maxLen; loop++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     if (k < kLength - 1)
                     {
                         k++;
@@ -196,6 +200,7 @@ namespace MessagePack.Formatters
                 writer.WriteArrayHeader(value.Length);
                 foreach (T item in value)
                 {
+                    writer.CancellationToken.ThrowIfCancellationRequested();
                     formatter.Serialize(ref writer, item, options);
                 }
             }
@@ -230,6 +235,7 @@ namespace MessagePack.Formatters
                 var l = -1;
                 for (int loop = 0; loop < maxLen; loop++)
                 {
+                    reader.CancellationToken.ThrowIfCancellationRequested();
                     if (l < lLength - 1)
                     {
                         l++;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using MessagePack.Internal;
 
 namespace MessagePack
@@ -45,6 +46,11 @@ namespace MessagePack
         {
             this.reader = new SequenceReader<byte>(readOnlySequence);
         }
+
+        /// <summary>
+        /// Gets or sets the cancellation token for this deserialization operation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
 
         /// <summary>
         /// Gets the <see cref="ReadOnlySequence{T}"/> originally supplied to the constructor.
@@ -101,6 +107,7 @@ namespace MessagePack
         /// <returns>The new reader.</returns>
         public MessagePackReader Clone(in ReadOnlySequence<byte> readOnlySequence) => new MessagePackReader(readOnlySequence)
         {
+            CancellationToken = this.CancellationToken,
         };
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using MessagePack.Internal;
 using Microsoft;
 
@@ -52,6 +53,11 @@ namespace MessagePack
         }
 
         /// <summary>
+        /// Gets or sets the cancellation token for this serialization operation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to write in <see href="https://github.com/msgpack/msgpack/blob/master/spec-old.md">old spec</see> compatibility mode.
         /// </summary>
         public bool OldSpec { get; set; }
@@ -65,6 +71,7 @@ namespace MessagePack
         public MessagePackWriter Clone(IBufferWriter<byte> writer) => new MessagePackWriter(writer)
         {
             OldSpec = this.OldSpec,
+            CancellationToken = this.CancellationToken,
         };
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.Threading;
 using Nerdbank.Streams;
 using Xunit;
 using Xunit.Abstractions;
@@ -78,6 +79,17 @@ namespace MessagePack.Tests
                 var reader = new MessagePackReader(sequence);
                 reader.ReadMapHeader();
             });
+        }
+
+        [Fact]
+        public void CancellationToken()
+        {
+            var reader = new MessagePackReader(default);
+            Assert.False(reader.CancellationToken.CanBeCanceled);
+
+            var cts = new CancellationTokenSource();
+            reader.CancellationToken = cts.Token;
+            Assert.Equal(cts.Token, reader.CancellationToken);
         }
 
         private delegate void WriterEncoder(ref MessagePackWriter writer);

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Threading;
 using Nerdbank.Streams;
 using Xunit;
 
@@ -97,6 +98,18 @@ namespace MessagePack.Tests
 
             Assert.Equal(header.TypeCode, readHeader.TypeCode);
             Assert.Equal(header.Length, readHeader.Length);
+        }
+
+        [Fact]
+        public void CancellationToken()
+        {
+            var sequence = new Sequence<byte>();
+            var writer = new MessagePackWriter(sequence);
+            Assert.False(writer.CancellationToken.CanBeCanceled);
+
+            var cts = new CancellationTokenSource();
+            writer.CancellationToken = cts.Token;
+            Assert.Equal(cts.Token, writer.CancellationToken);
         }
     }
 }

--- a/src/MessagePack/MessagePackSerializer+Typeless.cs
+++ b/src/MessagePack/MessagePackSerializer+Typeless.cs
@@ -35,21 +35,21 @@ namespace MessagePack
 
             public static void Serialize(ref MessagePackWriter writer, object obj, MessagePackSerializerOptions options = null) => Serialize<object>(ref writer, obj, options ?? DefaultOptions);
 
-            public static void Serialize(IBufferWriter<byte> writer, object obj, MessagePackSerializerOptions options = null) => Serialize<object>(writer, obj, options ?? DefaultOptions);
+            public static void Serialize(IBufferWriter<byte> writer, object obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => Serialize<object>(writer, obj, options ?? DefaultOptions, cancellationToken);
 
-            public static byte[] Serialize(object obj, MessagePackSerializerOptions options = null) => Serialize<object>(obj, options ?? DefaultOptions);
+            public static byte[] Serialize(object obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => Serialize<object>(obj, options ?? DefaultOptions, cancellationToken);
 
-            public static void Serialize(Stream stream, object obj, MessagePackSerializerOptions options = null) => Serialize<object>(stream, obj, options ?? DefaultOptions);
+            public static void Serialize(Stream stream, object obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => Serialize<object>(stream, obj, options ?? DefaultOptions, cancellationToken);
 
             public static Task SerializeAsync(Stream stream, object obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => SerializeAsync<object>(stream, obj, options ?? DefaultOptions, cancellationToken);
 
             public static object Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options = null) => Deserialize<object>(ref reader, options ?? DefaultOptions);
 
-            public static object Deserialize(in ReadOnlySequence<byte> byteSequence, MessagePackSerializerOptions options = null) => Deserialize<object>(byteSequence, options ?? DefaultOptions);
+            public static object Deserialize(in ReadOnlySequence<byte> byteSequence, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => Deserialize<object>(byteSequence, options ?? DefaultOptions, cancellationToken);
 
-            public static object Deserialize(Stream stream, MessagePackSerializerOptions options = null) => Deserialize<object>(stream, options ?? DefaultOptions);
+            public static object Deserialize(Stream stream, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => Deserialize<object>(stream, options ?? DefaultOptions, cancellationToken);
 
-            public static object Deserialize(Memory<byte> bytes, MessagePackSerializerOptions options = null) => Deserialize<object>(bytes, options ?? DefaultOptions);
+            public static object Deserialize(Memory<byte> bytes, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => Deserialize<object>(bytes, options ?? DefaultOptions, cancellationToken);
 
             public static ValueTask<object> DeserializeAsync(Stream stream, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default) => DeserializeAsync<object>(stream, options ?? DefaultOptions, cancellationToken);
         }

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -502,6 +502,8 @@ MessagePack.Internal.UnsafeMemory64
 MessagePack.MessagePackCode
 MessagePack.MessagePackRange
 MessagePack.MessagePackReader
+MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
+MessagePack.MessagePackReader.CancellationToken.set -> void
 MessagePack.MessagePackReader.Clone(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> MessagePack.MessagePackReader
 MessagePack.MessagePackReader.Consumed.get -> long
 MessagePack.MessagePackReader.CreatePeekReader() -> MessagePack.MessagePackReader
@@ -564,6 +566,8 @@ MessagePack.MessagePackType.Nil = 2 -> MessagePack.MessagePackType
 MessagePack.MessagePackType.String = 5 -> MessagePack.MessagePackType
 MessagePack.MessagePackType.Unknown = 0 -> MessagePack.MessagePackType
 MessagePack.MessagePackWriter
+MessagePack.MessagePackWriter.CancellationToken.get -> System.Threading.CancellationToken
+MessagePack.MessagePackWriter.CancellationToken.set -> void
 MessagePack.MessagePackWriter.Clone(System.Buffers.IBufferWriter<byte> writer) -> MessagePack.MessagePackWriter
 MessagePack.MessagePackWriter.Flush() -> void
 MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte> writer) -> void
@@ -800,45 +804,45 @@ static MessagePack.MessagePackCode.IsSignedInteger(byte code) -> bool
 static MessagePack.MessagePackCode.ToFormatName(byte code) -> string
 static MessagePack.MessagePackCode.ToMessagePackType(byte code) -> MessagePack.MessagePackType
 static MessagePack.MessagePackSerializer.ConvertFromJson(System.IO.TextReader reader, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void
-static MessagePack.MessagePackSerializer.ConvertFromJson(string str, MessagePack.MessagePackSerializerOptions options = null) -> byte[]
+static MessagePack.MessagePackSerializer.ConvertFromJson(string str, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]
 static MessagePack.MessagePackSerializer.ConvertFromJson(string str, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void
-static MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions options = null) -> string
-static MessagePack.MessagePackSerializer.ConvertToJson(in System.Buffers.ReadOnlySequence<byte> bytes, MessagePack.MessagePackSerializerOptions options = null) -> string
+static MessagePack.MessagePackSerializer.ConvertToJson(System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
+static MessagePack.MessagePackSerializer.ConvertToJson(in System.Buffers.ReadOnlySequence<byte> bytes, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
 static MessagePack.MessagePackSerializer.ConvertToJson(ref MessagePack.MessagePackReader reader, System.IO.TextWriter jsonWriter, MessagePack.MessagePackSerializerOptions options = null) -> void
 static MessagePack.MessagePackSerializer.DefaultOptions.get -> MessagePack.MessagePackSerializerOptions
 static MessagePack.MessagePackSerializer.DefaultOptions.set -> void
 static MessagePack.MessagePackSerializer.Deserialize(System.Type type, System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object
-static MessagePack.MessagePackSerializer.Deserialize(System.Type type, System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions options = null) -> object
+static MessagePack.MessagePackSerializer.Deserialize(System.Type type, System.ReadOnlyMemory<byte> bytes, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object
 static MessagePack.MessagePackSerializer.Deserialize(System.Type type, ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options = null) -> object
 static MessagePack.MessagePackSerializer.Deserialize<T>(System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
-static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions options = null) -> T
-static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions options, out int bytesRead) -> T
-static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, out int bytesRead) -> T
-static MessagePack.MessagePackSerializer.Deserialize<T>(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions options = null) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, MessagePack.MessagePackSerializerOptions options, out int bytesRead, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(System.ReadOnlyMemory<byte> buffer, out int bytesRead, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+static MessagePack.MessagePackSerializer.Deserialize<T>(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
 static MessagePack.MessagePackSerializer.Deserialize<T>(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options = null) -> T
 static MessagePack.MessagePackSerializer.DeserializeAsync(System.Type type, System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object>
 static MessagePack.MessagePackSerializer.DeserializeAsync<T>(System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
 static MessagePack.MessagePackSerializer.Serialize(System.Type type, System.IO.Stream stream, object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
-static MessagePack.MessagePackSerializer.Serialize(System.Type type, object obj, MessagePack.MessagePackSerializerOptions options = null) -> byte[]
+static MessagePack.MessagePackSerializer.Serialize(System.Type type, object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]
 static MessagePack.MessagePackSerializer.Serialize(System.Type type, ref MessagePack.MessagePackWriter writer, object obj, MessagePack.MessagePackSerializerOptions options = null) -> void
-static MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte> writer, T value, MessagePack.MessagePackSerializerOptions options = null) -> void
+static MessagePack.MessagePackSerializer.Serialize<T>(System.Buffers.IBufferWriter<byte> writer, T value, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 static MessagePack.MessagePackSerializer.Serialize<T>(System.IO.Stream stream, T value, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
-static MessagePack.MessagePackSerializer.Serialize<T>(T value, MessagePack.MessagePackSerializerOptions options = null) -> byte[]
+static MessagePack.MessagePackSerializer.Serialize<T>(T value, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]
 static MessagePack.MessagePackSerializer.Serialize<T>(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions options = null) -> void
 static MessagePack.MessagePackSerializer.SerializeAsync(System.Type type, System.IO.Stream stream, object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 static MessagePack.MessagePackSerializer.SerializeAsync<T>(System.IO.Stream stream, T value, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
-static MessagePack.MessagePackSerializer.SerializeToJson<T>(System.IO.TextWriter textWriter, T obj, MessagePack.MessagePackSerializerOptions options = null) -> void
-static MessagePack.MessagePackSerializer.SerializeToJson<T>(T obj, MessagePack.MessagePackSerializerOptions options = null) -> string
+static MessagePack.MessagePackSerializer.SerializeToJson<T>(System.IO.TextWriter textWriter, T obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.SerializeToJson<T>(T obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
 static MessagePack.MessagePackSerializer.Typeless.DefaultOptions.get -> MessagePack.MessagePackSerializerOptions
 static MessagePack.MessagePackSerializer.Typeless.DefaultOptions.set -> void
-static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null) -> object
-static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.Memory<byte> bytes, MessagePack.MessagePackSerializerOptions options = null) -> object
-static MessagePack.MessagePackSerializer.Typeless.Deserialize(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions options = null) -> object
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(System.Memory<byte> bytes, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object
+static MessagePack.MessagePackSerializer.Typeless.Deserialize(in System.Buffers.ReadOnlySequence<byte> byteSequence, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> object
 static MessagePack.MessagePackSerializer.Typeless.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options = null) -> object
 static MessagePack.MessagePackSerializer.Typeless.DeserializeAsync(System.IO.Stream stream, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object>
-static MessagePack.MessagePackSerializer.Typeless.Serialize(System.Buffers.IBufferWriter<byte> writer, object obj, MessagePack.MessagePackSerializerOptions options = null) -> void
-static MessagePack.MessagePackSerializer.Typeless.Serialize(System.IO.Stream stream, object obj, MessagePack.MessagePackSerializerOptions options = null) -> void
-static MessagePack.MessagePackSerializer.Typeless.Serialize(object obj, MessagePack.MessagePackSerializerOptions options = null) -> byte[]
+static MessagePack.MessagePackSerializer.Typeless.Serialize(System.Buffers.IBufferWriter<byte> writer, object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Typeless.Serialize(System.IO.Stream stream, object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+static MessagePack.MessagePackSerializer.Typeless.Serialize(object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]
 static MessagePack.MessagePackSerializer.Typeless.Serialize(ref MessagePack.MessagePackWriter writer, object obj, MessagePack.MessagePackSerializerOptions options = null) -> void
 static MessagePack.MessagePackSerializer.Typeless.SerializeAsync(System.IO.Stream stream, object obj, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 static MessagePack.MessagePackSerializerOptions.LZ4Standard.get -> MessagePack.MessagePackSerializerOptions


### PR DESCRIPTION
This adds CancellationToken parameters to all serialize/deserialize methods except those that take `MessagePackWriter` or `MessagePackReader`. This is because those two structs store the `CancellationToken` so if the caller already created them, they also had a chance to specify the `CancellationToken`.

By tucking it into the existing structs used for reading/writing, this avoided a massive API change.

As part of this, I changed a few formatters to honor the `CancellationToken`. Most do not check it, but the collection based ones that have a loop (that presumably could do a lot of work) check the token within the loop.

Fixes #598