### PR TITLE
Stop building assembly version with revision precision

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.8",
-  "assemblyVersion": {
-    "precision": "revision"
-  },
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:.\\d+)?$"


### PR DESCRIPTION
This came from the master branch, which is unstable so revision-level precision is useful.
But in a stable v1.8 branch we really want major.minor precision only.
Doing so now makes the assembly version go *backwards* from 1.8.74.32478 (the last released package) to 1.8.0.0.
This is odd, but at this point we only have a small handful of downloads of the 1.8.74 package, so best to fix it now.