### PR TITLE
Define MessagePackSerializationException base class

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -87,6 +87,9 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\MessagePackCode.cs">
       <Link>Code\MessagePackCode.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\MessagePackSerializationException.cs">
+      <Link>Code\MessagePackSerializationException.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\DateTimeConstants.cs">
       <Link>Code\Internal\DateTimeConstants.cs</Link>
     </Compile>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/UnsafeBinaryFormatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/UnsafeBinaryFormatters.cs
@@ -88,7 +88,7 @@ namespace MessagePack.Formatters
             ReadOnlySequence<byte> valueSequence = reader.ReadBytes().Value;
             if (valueSequence.Length != sizeof(decimal))
             {
-                throw new InvalidOperationException("Invalid decimal Size.");
+                throw new MessagePackSerializationException("Invalid decimal Size.");
             }
 
             decimal result;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs
@@ -69,7 +69,7 @@ namespace MessagePack
         }
     }
 
-    public class FormatterNotRegisteredException : Exception
+    public class FormatterNotRegisteredException : MessagePackSerializationException
     {
         public FormatterNotRegisteredException(string message)
             : base(message)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/TinyJsonReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/TinyJsonReader.cs
@@ -39,7 +39,7 @@ namespace MessagePack
         String,
     }
 
-    public class TinyJsonException : Exception
+    public class TinyJsonException : MessagePackSerializationException
     {
         public TinyJsonException(string message)
             : base(message)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MessagePack
+{
+    /// <summary>
+    /// An exception thrown during serializing an object graph or deserializing a messagepack sequence.
+    /// </summary>
+    [Serializable]
+    public class MessagePackSerializationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializationException"/> class.
+        /// </summary>
+        public MessagePackSerializationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializationException"/> class.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        public MessagePackSerializationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializationException"/> class.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        /// <param name="inner">The inner exception.</param>
+        public MessagePackSerializationException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackSerializationException"/> class.
+        /// </summary>
+        /// <param name="info">Serialization info.</param>
+        /// <param name="context">Serialization context.</param>
+        protected MessagePackSerializationException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -2029,7 +2029,7 @@ namespace MessagePack.Internal
         }
     }
 
-    internal class MessagePackDynamicObjectResolverException : Exception
+    internal class MessagePackDynamicObjectResolverException : MessagePackSerializationException
     {
         public MessagePackDynamicObjectResolverException(string message)
             : base(message)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -505,7 +505,7 @@ namespace MessagePack.Internal
         }
     }
 
-    internal class MessagePackDynamicUnionResolverException : Exception
+    internal class MessagePackDynamicUnionResolverException : MessagePackSerializationException
     {
         public MessagePackDynamicUnionResolverException(string message)
             : base(message)

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -539,6 +539,11 @@ MessagePack.MessagePackReader.ReadUInt64() -> ulong
 MessagePack.MessagePackReader.Sequence.get -> System.Buffers.ReadOnlySequence<byte>
 MessagePack.MessagePackReader.Skip() -> void
 MessagePack.MessagePackReader.TryReadNil() -> bool
+MessagePack.MessagePackSerializationException
+MessagePack.MessagePackSerializationException.MessagePackSerializationException() -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(string message) -> void
+MessagePack.MessagePackSerializationException.MessagePackSerializationException(string message, System.Exception inner) -> void
 MessagePack.MessagePackSerializer
 MessagePack.MessagePackSerializer.Typeless
 MessagePack.MessagePackSerializerOptions


### PR DESCRIPTION
Adjust all other exceptions we define to derive from this.

This allows callers to use messagepack and be prepared to catch just one base exception type and be able to recover when failures occur.