### PR TITLE
Build .snupkg archives for nuget.org publishing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,8 @@
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="" />

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -117,6 +117,7 @@ steps:
   inputs:
     Contents: |
       bin/**/$(BuildConfiguration)/**/*.nupkg
+      bin/**/$(BuildConfiguration)/**/*.snupkg
       bin/**/$(BuildConfiguration)/**/*.vsix
     TargetFolder: $(Build.ArtifactStagingDirectory)/deployables
     flattenFolders: true

--- a/src/MessagePackAnalyzer/MessagePackAnalyzer.csproj
+++ b/src/MessagePackAnalyzer/MessagePackAnalyzer.csproj
@@ -7,6 +7,7 @@
     <PackageTags>MsgPack;MessagePack;Serialization;Formatter;Analyzer</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="tools\*.ps1" Pack="true" PackagePath="tools\" />


### PR DESCRIPTION
This allows the VS debugger to automatically find the pdb files and allow stepping into MessagePack code from a consuming application.