### PR TITLE
Build .snupkg archives for nuget.org publishing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,8 @@
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="" />

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -105,6 +105,7 @@ steps:
   inputs:
     Contents: |
       bin/Packages/$(BuildConfiguration)/**/*.nupkg
+      bin/Packages/$(BuildConfiguration)/**/*.snupkg
       bin/MessagePackAnalyzer.Vsix/$(BuildConfiguration)/**/*.vsix
       bin/*.unitypackage
     TargetFolder: $(Build.ArtifactStagingDirectory)/deployables

--- a/src/MessagePackAnalyzer/MessagePackAnalyzer.csproj
+++ b/src/MessagePackAnalyzer/MessagePackAnalyzer.csproj
@@ -8,6 +8,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="tools\*.ps1" Pack="true" PackagePath="tools\" />


### PR DESCRIPTION
This allows the VS debugger to automatically find the pdb files and allow stepping into MessagePack code from a consuming application.