### PR TITLE
Add MessagePackReader.ReadRaw()

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -122,6 +122,7 @@ namespace MessagePack
         /// </summary>
         /// <remarks>
         /// The entire primitive is skipped, including content of maps or arrays, or any other type with payloads.
+        /// To get the raw MessagePack sequence that was skipped, use <see cref="ReadRaw()"/> instead.
         /// </remarks>
         public void Skip()
         {
@@ -254,6 +255,20 @@ namespace MessagePack
             ReadOnlySequence<byte> result = this.reader.Sequence.Slice(this.reader.Position, length);
             this.reader.Advance(length);
             return result;
+        }
+
+        /// <summary>
+        /// Reads the next MessagePack primitive.
+        /// </summary>
+        /// <returns>The raw MessagePack sequence.</returns>
+        /// <remarks>
+        /// The entire primitive is read, including content of maps or arrays, or any other type with payloads.
+        /// </remarks>
+        public ReadOnlySequence<byte> ReadRaw()
+        {
+            SequencePosition initialPosition = this.Position;
+            this.Skip();
+            return this.Sequence.Slice(initialPosition, this.Position);
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
@@ -146,6 +146,33 @@ namespace MessagePack.Tests
             Assert.Equal(cts.Token, reader.CancellationToken);
         }
 
+        [Fact]
+        public void ReadRaw()
+        {
+            var sequence = new Sequence<byte>();
+            var writer = new MessagePackWriter(sequence);
+            writer.Write(3);
+            writer.WriteArrayHeader(2);
+            writer.Write(1);
+            writer.Write("Hi");
+            writer.Write(5);
+            writer.Flush();
+
+            var reader = new MessagePackReader(sequence.AsReadOnlySequence);
+
+            var first = reader.ReadRaw();
+            Assert.Equal(1, first.Length);
+            Assert.Equal(3, new MessagePackReader(first).ReadInt32());
+
+            var second = reader.ReadRaw();
+            Assert.Equal(5, second.Length);
+
+            var third = reader.ReadRaw();
+            Assert.Equal(1, third.Length);
+
+            Assert.True(reader.End);
+        }
+
         private delegate void WriterEncoder(ref MessagePackWriter writer);
 
         private static ReadOnlySequence<byte> Encode(WriterEncoder cb)

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -528,6 +528,7 @@ MessagePack.MessagePackReader.ReadInt32() -> int
 MessagePack.MessagePackReader.ReadInt64() -> long
 MessagePack.MessagePackReader.ReadMapHeader() -> int
 MessagePack.MessagePackReader.ReadNil() -> MessagePack.Nil
+MessagePack.MessagePackReader.ReadRaw() -> System.Buffers.ReadOnlySequence<byte>
 MessagePack.MessagePackReader.ReadRaw(long length) -> System.Buffers.ReadOnlySequence<byte>
 MessagePack.MessagePackReader.ReadSByte() -> sbyte
 MessagePack.MessagePackReader.ReadSingle() -> float


### PR DESCRIPTION
We already had ReadRaw(long) where the caller had to know the number of bytes to skip. But if the caller just wants to skip a token (regardless of its length) then they had to call Skip(), which didn't return the token as well. To gain access to the sequence that was skipped, there was no public API to make that simple. ReadRaw() (no length argument) made the most sense to add since it's just like its preexisting ReadRaw(long) counterpart, but figures out the length itself.

Alternative considered:
1. Since this behaves more like Skip(), except that it returns the slice that was skipped, I considered simply changing the Skip() method to always return the slice. However since slicing has shown up as a perf bottleneck in some contexts, and skipping is supposed to be as fast as possible, I didn't want to add a mandatory slice to every skip operation that many callers would ignore.
2. Calling the new method SkipAndRead(). I think this suggests "skipping then reading" which is not what happens.