### PR TITLE
Ensure that only documented exceptions are thrown

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -858,7 +858,7 @@ namespace MessagePack.Internal
             else
             {
                 il.Emit(OpCodes.Ldstr, "typecode is null, struct not supported");
-                il.Emit(OpCodes.Newobj, invalidOperationExceptionConstructor);
+                il.Emit(OpCodes.Newobj, messagePackSerializationExceptionMessageOnlyConstructor);
                 il.Emit(OpCodes.Throw);
             }
 
@@ -1225,7 +1225,7 @@ namespace MessagePack.Internal
         //// static readonly ConstructorInfo dictionaryConstructor = typeof(ByteArrayStringHashTable).GetTypeInfo().DeclaredConstructors.First(x => { var p = x.GetParameters(); return p.Length == 1 && p[0].ParameterType == typeof(int); });
         //// static readonly MethodInfo dictionaryAdd = typeof(ByteArrayStringHashTable).GetRuntimeMethod("Add", new[] { typeof(string), typeof(int) });
         //// static readonly MethodInfo dictionaryTryGetValue = typeof(ByteArrayStringHashTable).GetRuntimeMethod("TryGetValue", new[] { typeof(ArraySegment<byte>), refInt });
-        private static readonly ConstructorInfo invalidOperationExceptionConstructor = typeof(System.InvalidOperationException).GetTypeInfo().DeclaredConstructors.First(x =>
+        private static readonly ConstructorInfo messagePackSerializationExceptionMessageOnlyConstructor = typeof(MessagePackSerializationException).GetTypeInfo().DeclaredConstructors.First(x =>
         {
             ParameterInfo[] p = x.GetParameters();
             return p.Length == 1 && p[0].ParameterType == typeof(string);

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
@@ -32,7 +32,8 @@ public class MessagePackSerializerTypelessTests
         var myOptions = new MyTypelessOptions();
         byte[] msgpack = MessagePackSerializer.Typeless.Serialize(new MyObject { SomeValue = 5 }, myOptions);
         this.logger.WriteLine(MessagePackSerializer.ConvertToJson(msgpack, myOptions));
-        Assert.Throws<TypeAccessException>(() => MessagePackSerializer.Typeless.Deserialize(msgpack, myOptions));
+        var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Typeless.Deserialize(msgpack, myOptions));
+        Assert.IsType<TypeAccessException>(ex.InnerException);
     }
 
     [Fact]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
@@ -63,7 +63,7 @@ namespace MessagePack.Tests
             MessagePackSerializer.Deserialize<SimpleIntKeyData>(bytes).IsNull();
 
             // deserialize from nil
-            Xunit.Assert.Throws<InvalidOperationException>(() =>
+            Xunit.Assert.Throws<MessagePackSerializationException>(() =>
             {
                 MessagePackSerializer.Deserialize<SimpleStructIntKeyData>(bytes);
             });

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs
@@ -20,10 +20,12 @@ namespace MessagePack.Tests
         [Fact]
         public void CanResolve()
         {
-            Assert.Throws<NotImplementedException>(() =>
+            var ex = Assert.Throws<MessagePackSerializationException>(() =>
             {
                 MessagePackSerializer.Serialize(new MyDateTimeResolverTest() { MyProperty1 = DateTime.Now }, PrimitivelikeResolver.Options);
             });
+
+            Assert.IsType<NotImplementedException>(ex.InnerException);
         }
 #endif
 


### PR DESCRIPTION
We catch and wrap all exceptions thrown from the MessagePackSerializer APIs.

This ensures that arbitrary formatters or resolvers can't throw exceptions outside the documented set and cause unexpected failures in applications that are prepared to only catch the documented exception. The pattern of wrapping exceptions in outer exceptions is quite common and conducive to progressively precise errors that aid investigations.

In doing this, a few tests failed that were still expecting different exception types, so I've updated these tests. One in particular revealed that the DynamicObjectResolver was generating code that still threw thew old InvalidOperationException type so I fixed that as well.