### PR TITLE
Fix duplicate relative path syntax trees

### DIFF
--- a/src/MessagePack.GeneratorCore/MessagePackCompilation.cs
+++ b/src/MessagePack.GeneratorCore/MessagePackCompilation.cs
@@ -47,7 +47,7 @@ namespace MessagePackCompiler
             }
 
             var hasAnnotations = false;
-            foreach (var file in sources.Distinct())
+            foreach (var file in sources.Select(Path.GetFullPath).Distinct())
             {
                 var text = File.ReadAllText(file.Replace('\\', Path.DirectorySeparatorChar), Encoding.UTF8);
                 var syntax = CSharpSyntaxTree.ParseText(text, parseOption);


### PR DESCRIPTION
Fixes #629 
After a simple setup didn't reproduce the issue, I debugged further and noticed that the error type being used listed two possible actual types. Looking further it turned out to be caused by two references to the same project. One that was a direct relationship and one that was through another project. This resulted in two different relative paths to the same file.
Could try to detect the duplication earlier, but resolving to absolute paths at the end is simple.