### PR TITLE
Fix-ups to get UWP test project building

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.33" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>

--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -116,7 +116,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.37" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Jil" version="2.15.4" />
     <PackageReference Include="MessagePack" version="1.4.3" />
     <PackageReference Include="MsgPack.Cli" version="0.9.0-rc1" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.37" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="protobuf-net" version="2.3.2" />
     <PackageReference Include="Sigil" version="4.7.0" />

--- a/sandbox/PerfNetFramework/PerfNetFramework.csproj
+++ b/sandbox/PerfNetFramework/PerfNetFramework.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" version="0.9.0-beta2" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.37" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="protobuf-net" version="2.1.0" />
     <PackageReference Include="ZeroFormatter" version="1.6.4" />

--- a/src/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/src/MessagePack.Internal/MessagePack.Internal.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.2.26" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MessagePack.UnityShims/Shims.cs
+++ b/src/MessagePack.UnityShims/Shims.cs
@@ -7,6 +7,7 @@ using MessagePack;
 #pragma warning disable SA1300 // Field should begin with upper-case letter
 #pragma warning disable IDE1006 // Field should begin with upper-case letter
 #pragma warning disable SA1649 // type name matches file name
+#pragma warning disable SA1401 // Fields should be private (we need fields rather than auto-properties for .NET Native compilation to work).
 
 namespace UnityEngine
 {
@@ -125,10 +126,10 @@ namespace UnityEngine
     public struct Bounds
     {
         [Key(0)]
-        public Vector3 center { get; set; }
+        public Vector3 center;
 
         [IgnoreMember]
-        public Vector3 extents { get; set; }
+        public Vector3 extents;
 
         [Key(1)]
         public Vector3 size
@@ -156,16 +157,16 @@ namespace UnityEngine
     public struct Rect
     {
         [Key(0)]
-        public float x { get; set; }
+        public float x;
 
         [Key(1)]
-        public float y { get; set; }
+        public float y;
 
         [Key(2)]
-        public float width { get; set; }
+        public float width;
 
         [Key(3)]
-        public float height { get; set; }
+        public float height;
 
         [SerializationConstructor]
         public Rect(float x, float y, float width, float height)
@@ -198,7 +199,7 @@ namespace UnityEngine
     public sealed class AnimationCurve
     {
         [Key(0)]
-        public Keyframe[] keys { get; set; }
+        public Keyframe[] keys;
 
         [IgnoreMember]
         public int length
@@ -207,26 +208,26 @@ namespace UnityEngine
         }
 
         [Key(1)]
-        public WrapMode postWrapMode { get; set; }
+        public WrapMode postWrapMode;
 
         [Key(2)]
-        public WrapMode preWrapMode { get; set; }
+        public WrapMode preWrapMode;
     }
 
     [MessagePackObject]
     public struct Keyframe
     {
         [Key(0)]
-        public float time { get; set; }
+        public float time;
 
         [Key(1)]
-        public float value { get; set; }
+        public float value;
 
         [Key(2)]
-        public float inTangent { get; set; }
+        public float inTangent;
 
         [Key(3)]
-        public float outTangent { get; set; }
+        public float outTangent;
 
         public Keyframe(float time, float value)
         {
@@ -297,13 +298,13 @@ namespace UnityEngine
     public sealed class Gradient
     {
         [Key(0)]
-        public GradientColorKey[] colorKeys { get; set; }
+        public GradientColorKey[] colorKeys;
 
         [Key(1)]
-        public GradientAlphaKey[] alphaKeys { get; set; }
+        public GradientAlphaKey[] alphaKeys;
 
         [Key(2)]
-        public GradientMode mode { get; set; }
+        public GradientMode mode;
     }
 
     [MessagePackObject]
@@ -367,16 +368,16 @@ namespace UnityEngine
     public sealed class RectOffset
     {
         [Key(0)]
-        public int left { get; set; }
+        public int left;
 
         [Key(1)]
-        public int right { get; set; }
+        public int right;
 
         [Key(2)]
-        public int top { get; set; }
+        public int top;
 
         [Key(3)]
-        public int bottom { get; set; }
+        public int bottom;
 
         public RectOffset()
         {
@@ -395,7 +396,7 @@ namespace UnityEngine
     public struct LayerMask
     {
         [Key(0)]
-        public int value { get; set; }
+        public int value;
     }
 
     // from Unity2017.2
@@ -458,16 +459,16 @@ namespace UnityEngine
     public struct RectInt
     {
         [Key(0)]
-        public int x { get; set; }
+        public int x;
 
         [Key(1)]
-        public int y { get; set; }
+        public int y;
 
         [Key(2)]
-        public int width { get; set; }
+        public int width;
 
         [Key(3)]
-        public int height { get; set; }
+        public int height;
 
         [SerializationConstructor]
         public RectInt(int x, int y, int width, int height)
@@ -499,10 +500,10 @@ namespace UnityEngine
     public struct BoundsInt
     {
         [Key(0)]
-        public Vector3Int position { get; set; }
+        public Vector3Int position;
 
         [Key(1)]
-        public Vector3Int size { get; set; }
+        public Vector3Int size;
 
         [SerializationConstructor]
         public BoundsInt(Vector3Int position, Vector3Int size)

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" version="0.9.0-beta2" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.37" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
     <PackageReference Include="ReactiveProperty" version="4.2.2" />
     <PackageReference Include="System.Collections.Immutable" version="1.6.0" />
     <PackageReference Include="xunit" version="2.4.1" />


### PR DESCRIPTION
This PR doesn't *add* the UWP test project, but it contains the changes necessary so that a local UWP project that referenced MessagePack (or more accurately, the test projects) could actually compile with the UWP .NET Native toolchain.

There are two key fixes here:
1. Switch from auto-properties to public fields in the unity shims. .NET Native doesn't like the C# compiler-generated field names.
1. Updated a nuget dependency chain that terminated with `Microsoft.VisualStudio.Threading`, which had one line of code that .NET Native couldn't handle. We update to a version of vs-threading that has [this fix](https://github.com/microsoft/vs-threading/pull/558/files).