### PR TITLE
Fix StandardResolverAllowPrivate exception

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -705,12 +705,13 @@ namespace MessagePack.Internal
                 il.EmitLdc_I4(len);
                 il.EmitCall(MessagePackWriterTypeInfo.WriteArrayHeader);
 
+                var index = 0;
                 for (int i = 0; i <= maxKey; i++)
                 {
                     ObjectSerializationInfo.EmittableMember member;
                     if (intKeyMap.TryGetValue(i, out member))
                     {
-                        EmitSerializeValue(il, type.GetTypeInfo(), member, i, tryEmitLoadCustomFormatter, argWriter, argValue, argOptions, localResolver);
+                        EmitSerializeValue(il, type.GetTypeInfo(), member, index++, tryEmitLoadCustomFormatter, argWriter, argValue, argOptions, localResolver);
                     }
                     else
                     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
@@ -9,11 +9,19 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MessagePack.Tests
 {
     public class DynamicObjectResolverOrderTest
     {
+        private readonly ITestOutputHelper logger;
+
+        public DynamicObjectResolverOrderTest(ITestOutputHelper logger)
+        {
+            this.logger = logger;
+        }
+
         private IEnumerable<string> IteratePropertyNames(ReadOnlyMemory<byte> bytes)
         {
             var reader = new MessagePackReader(bytes);
@@ -46,6 +54,25 @@ namespace MessagePack.Tests
             this.IteratePropertyNames(msgRawData).Is("Id", "Str");
         }
 
+        [Fact]
+        public void NonSequentialKeys_AllowPrivate()
+        {
+            var options = Resolvers.StandardResolverAllowPrivate.Options;
+            var c = new ClassWithMissingKeyPositions
+            {
+                Id = 2,
+                Year = 2017,
+                Memo = "some memo",
+            };
+
+            byte[] s = MessagePackSerializer.Serialize(c, options);
+            this.logger.WriteLine(MessagePackSerializer.ConvertToJson(s, options));
+
+            ClassWithMissingKeyPositions c2 = MessagePackSerializer.Deserialize<ClassWithMissingKeyPositions>(s, options);
+            Assert.Equal(c.Id, c2.Id);
+            Assert.Equal(c.Year, c2.Year);
+            Assert.Equal(c.Memo, c2.Memo);
+        }
 #endif
 
         [MessagePack.MessagePackObject(keyAsPropertyName: true)]
@@ -77,6 +104,27 @@ namespace MessagePack.Tests
 
             [DataMember(Order = 0)]
             public string Bar;
+        }
+
+        [MessagePackObject]
+        internal class ClassWithMissingKeyPositions
+        {
+            public ClassWithMissingKeyPositions()
+            {
+            }
+
+            [Key(0)]
+            internal int Id { get; set; }
+
+            // This position intentionally omitted for the test.
+            ////[Key(1)]
+            ////public string Name { get; set; }
+
+            [Key(2)]
+            internal int Year { get; set; } = 2019;
+
+            [Key(3)]
+            internal string Memo { get; set; }
         }
     }
 }


### PR DESCRIPTION
#### Bug description

StandardResolverAllowPrivate throws exception when serializing a class with non-sequential keys(like 0, 2, 3).

#### Repro steps

```CS
    [Fact]
    public void AllowPrivateFixTest()
    {
        var options = MessagePackSerializerOptions.Standard.WithResolver(MessagePack.Resolvers.StandardResolverAllowPrivate.Instance);
        // MessagePackSerializer.DefaultOptions = options; //affects other tests.

        var c = new AllowPrivateClass();
        var s = MessagePackSerializer.Serialize(c, options);
        var c2 = MessagePackSerializer.Deserialize<AllowPrivateClass>(s, options);
    }

    [MessagePackObject]
    public class AllowPrivateClass
    {
        [Key(0)]
        private int Id { get; set; }

        //[Key(1)]
        //public string Name { get; set; }

        [Key(2)]
        private int Year { get; set; } = 2019;

        [Key(3)]
        public string Memo { get; set; }

        public AllowPrivateClass()
        {
        }
    }

```

