### PR TITLE
Move extension type codes

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -21,8 +21,6 @@ namespace MessagePack.Formatters
     /// </summary>
     public sealed class TypelessFormatter : IMessagePackFormatter<object>
     {
-        public const sbyte ExtensionTypeCode = 100;
-
         private delegate void SerializeMethod(object dynamicContractlessFormatter, ref MessagePackWriter writer, object value, MessagePackSerializerOptions options);
 
         private delegate object DeserializeMethod(object dynamicContractlessFormatter, ref MessagePackReader reader, MessagePackSerializerOptions options);
@@ -191,7 +189,7 @@ namespace MessagePack.Formatters
                 scratchWriter.Flush();
 
                 // mark as extension with code 100
-                writer.WriteExtensionFormat(new ExtensionResult((sbyte)TypelessFormatter.ExtensionTypeCode, scratch.AsReadOnlySequence));
+                writer.WriteExtensionFormat(new ExtensionResult((sbyte)ThisLibraryExtensionTypeCodes.TypelessFormatter, scratch.AsReadOnlySequence));
             }
         }
 
@@ -205,7 +203,7 @@ namespace MessagePack.Formatters
             if (reader.NextMessagePackType == MessagePackType.Extension)
             {
                 ExtensionHeader ext = reader.ReadExtensionFormatHeader();
-                if (ext.TypeCode == TypelessFormatter.ExtensionTypeCode)
+                if (ext.TypeCode == ThisLibraryExtensionTypeCodes.TypelessFormatter)
                 {
                     // it has type name serialized
                     ReadOnlySequence<byte> typeName = reader.ReadStringSequence().Value;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
@@ -31,8 +31,9 @@ namespace MessagePack
     }
 
     /// <summary>
-    /// https://github.com/msgpack/msgpack/blob/master/spec.md#overview.
+    /// The core type codes as defined by msgpack.
     /// </summary>
+    /// <seealso href="https://github.com/msgpack/msgpack/blob/master/spec.md#overview" />
 #if MESSAGEPACK_INTERNAL
     internal
 #else
@@ -216,6 +217,9 @@ namespace MessagePack
         }
     }
 
+    /// <summary>
+    /// The officially defined messagepack extension type codes.
+    /// </summary>
 #if MESSAGEPACK_INTERNAL
     internal
 #else
@@ -224,8 +228,6 @@ namespace MessagePack
     static class ReservedMessagePackExtensionTypeCode
     {
         public const sbyte DateTime = -1;
-
-        public const sbyte LZ4 = 99;
     }
 
 #if MESSAGEPACK_INTERNAL

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
@@ -201,7 +201,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="code">The messagepack code.</param>
         /// <returns>A boolean value.</returns>
-        public static bool IsSignedInteger(byte code)
+        internal static bool IsSignedInteger(byte code)
         {
             switch (code)
             {
@@ -224,6 +224,8 @@ namespace MessagePack
     static class ReservedMessagePackExtensionTypeCode
     {
         public const sbyte DateTime = -1;
+
+        public const sbyte LZ4 = 99;
     }
 
 #if MESSAGEPACK_INTERNAL

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -357,7 +357,7 @@ namespace MessagePack
                         writer.Write("\"");
                     }
 #if !UNITY_2018_3_OR_NEWER
-                    else if (extHeader.TypeCode == TypelessFormatter.ExtensionTypeCode)
+                    else if (extHeader.TypeCode == ThisLibraryExtensionTypeCodes.TypelessFormatter)
                     {
                         // prepare type name token
                         var privateBuilder = new StringBuilder();

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -420,7 +420,7 @@ namespace MessagePack
             {
                 MessagePackReader peekReader = reader.CreatePeekReader();
                 ExtensionHeader header = peekReader.ReadExtensionFormatHeader();
-                if (header.TypeCode == ReservedMessagePackExtensionTypeCode.LZ4)
+                if (header.TypeCode == ThisLibraryExtensionTypeCodes.LZ4)
                 {
                     // Read the extension using the original reader, so we "consume" it.
                     ExtensionResult extension = reader.ReadExtensionFormat();
@@ -459,7 +459,7 @@ namespace MessagePack
                     int lz4Length = LZ4Operation(msgpackUncompressedData, lz4Span, LZ4Codec.Encode);
 
                     const int LengthOfUncompressedDataSizeHeader = 5;
-                    writer.WriteExtensionFormatHeader(new ExtensionHeader(ReservedMessagePackExtensionTypeCode.LZ4, LengthOfUncompressedDataSizeHeader + (uint)lz4Length));
+                    writer.WriteExtensionFormatHeader(new ExtensionHeader(ThisLibraryExtensionTypeCodes.LZ4, LengthOfUncompressedDataSizeHeader + (uint)lz4Length));
                     writer.WriteInt32((int)msgpackUncompressedData.Length);
                     writer.WriteRaw(lz4Span.AsSpan(0, lz4Length));
                 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -18,8 +18,6 @@ namespace MessagePack
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Each overload has sufficiently unique required parameters.")]
     public static partial class MessagePackSerializer
     {
-        public const sbyte LZ4ExtensionTypeCode = 99;
-
         private const int LZ4NotCompressionSize = 64;
 
         /// <summary>
@@ -422,7 +420,7 @@ namespace MessagePack
             {
                 MessagePackReader peekReader = reader.CreatePeekReader();
                 ExtensionHeader header = peekReader.ReadExtensionFormatHeader();
-                if (header.TypeCode == LZ4ExtensionTypeCode)
+                if (header.TypeCode == ReservedMessagePackExtensionTypeCode.LZ4)
                 {
                     // Read the extension using the original reader, so we "consume" it.
                     ExtensionResult extension = reader.ReadExtensionFormat();
@@ -461,7 +459,7 @@ namespace MessagePack
                     int lz4Length = LZ4Operation(msgpackUncompressedData, lz4Span, LZ4Codec.Encode);
 
                     const int LengthOfUncompressedDataSizeHeader = 5;
-                    writer.WriteExtensionFormatHeader(new ExtensionHeader(LZ4ExtensionTypeCode, LengthOfUncompressedDataSizeHeader + (uint)lz4Length));
+                    writer.WriteExtensionFormatHeader(new ExtensionHeader(ReservedMessagePackExtensionTypeCode.LZ4, LengthOfUncompressedDataSizeHeader + (uint)lz4Length));
                     writer.WriteInt32((int)msgpackUncompressedData.Length);
                     writer.WriteRaw(lz4Span.AsSpan(0, lz4Length));
                 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MessagePack
+{
+    /// <summary>
+    /// The extension type codes that this library defines for just this library.
+    /// </summary>
+    internal static class ThisLibraryExtensionTypeCodes
+    {
+        /// <summary>
+        /// The LZ4 compression extension.
+        /// </summary>
+        public const sbyte LZ4 = 99;
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
@@ -9,8 +9,63 @@ namespace MessagePack
     internal static class ThisLibraryExtensionTypeCodes
     {
         /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityVector2 = 30;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityVector3 = 31;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityVector4 = 32;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityQuaternion = 33;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityColor = 34;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityBounds = 35;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityRect = 36;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityInt = 37;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityFloat = 38;
+
+        /// <summary>
+        /// For Unity's UnsafeBlitFormatter.
+        /// </summary>
+        internal const sbyte UnityDouble = 39;
+
+        /// <summary>
         /// The LZ4 compression extension.
         /// </summary>
-        public const sbyte LZ4 = 99;
+        internal const sbyte LZ4 = 99;
+
+        /// <summary>
+        /// For the <see cref="Formatters.TypelessFormatter"/>.
+        /// </summary>
+        internal const sbyte TypelessFormatter = 100;
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityShims/Extension/UnsafeBlitFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityShims/Extension/UnsafeBlitFormatter.cs
@@ -16,20 +16,6 @@ using UnityEngine;
 
 namespace MessagePack.Unity.Extension
 {
-    public static class ReservedUnityExtensionTypeCode
-    {
-        public const sbyte Vector2 = 30;
-        public const sbyte Vector3 = 31;
-        public const sbyte Vector4 = 32;
-        public const sbyte Quaternion = 33;
-        public const sbyte Color = 34;
-        public const sbyte Bounds = 35;
-        public const sbyte Rect = 36;
-        public const sbyte Int = 37;
-        public const sbyte Float = 38;
-        public const sbyte Double = 39;
-    }
-
     // use ext instead of ArrayFormatter to extremely boost up performance.
     // Layout: [extHeader, byteSize(integer), isLittleEndian(bool), bytes()]
     // Used Ext:30~36
@@ -98,7 +84,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Vector2;
+                return ThisLibraryExtensionTypeCodes.UnityVector2;
             }
         }
     }
@@ -109,7 +95,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Vector3;
+                return ThisLibraryExtensionTypeCodes.UnityVector3;
             }
         }
     }
@@ -120,7 +106,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Vector4;
+                return ThisLibraryExtensionTypeCodes.UnityVector4;
             }
         }
     }
@@ -131,7 +117,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Quaternion;
+                return ThisLibraryExtensionTypeCodes.UnityQuaternion;
             }
         }
     }
@@ -142,7 +128,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Color;
+                return ThisLibraryExtensionTypeCodes.UnityColor;
             }
         }
     }
@@ -153,7 +139,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Bounds;
+                return ThisLibraryExtensionTypeCodes.UnityBounds;
             }
         }
     }
@@ -164,7 +150,7 @@ namespace MessagePack.Unity.Extension
         {
             get
             {
-                return ReservedUnityExtensionTypeCode.Rect;
+                return ThisLibraryExtensionTypeCodes.UnityRect;
             }
         }
     }
@@ -173,7 +159,7 @@ namespace MessagePack.Unity.Extension
     {
         protected override sbyte TypeCode
         {
-            get { return ReservedUnityExtensionTypeCode.Int; }
+            get { return ThisLibraryExtensionTypeCodes.UnityInt; }
         }
     }
 
@@ -181,7 +167,7 @@ namespace MessagePack.Unity.Extension
     {
         protected override sbyte TypeCode
         {
-            get { return ReservedUnityExtensionTypeCode.Float; }
+            get { return ThisLibraryExtensionTypeCodes.UnityFloat; }
         }
     }
 
@@ -189,7 +175,7 @@ namespace MessagePack.Unity.Extension
     {
         protected override sbyte TypeCode
         {
-            get { return ReservedUnityExtensionTypeCode.Double; }
+            get { return ThisLibraryExtensionTypeCodes.UnityDouble; }
         }
     }
 }

--- a/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
+++ b/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\MessagePack.UnityClient\Assets\Scripts\MessagePack\ThisLibraryExtensionTypeCodes.cs" Link="ThisLibraryExtensionTypeCodes.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MessagePack\MessagePack.csproj" />
     <ProjectReference Include="..\MessagePack.Annotations\MessagePack.Annotations.csproj" />
   </ItemGroup>

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -729,8 +729,8 @@ const MessagePack.MessagePackRange.MaxFixPositiveInt = 127 -> int
 const MessagePack.MessagePackRange.MaxFixStringLength = 31 -> int
 const MessagePack.MessagePackRange.MinFixNegativeInt = -32 -> int
 const MessagePack.MessagePackRange.MinFixStringLength = 0 -> int
-const MessagePack.MessagePackSerializer.LZ4ExtensionTypeCode = 99 -> sbyte
 const MessagePack.ReservedMessagePackExtensionTypeCode.DateTime = -1 -> sbyte
+const MessagePack.ReservedMessagePackExtensionTypeCode.LZ4 = 99 -> sbyte
 override MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>.GetSourceEnumerator(TCollection source) -> System.Collections.Generic.IEnumerator<TElement>
 override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>.Complete(TDictionary intermediateCollection) -> TDictionary
 override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>.GetSourceEnumerator(TDictionary source) -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>
@@ -809,7 +809,6 @@ static MessagePack.Internal.UnsafeMemory64.WriteRaw6(ref MessagePack.MessagePack
 static MessagePack.Internal.UnsafeMemory64.WriteRaw7(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory64.WriteRaw8(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.Internal.UnsafeMemory64.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
-static MessagePack.MessagePackCode.IsSignedInteger(byte code) -> bool
 static MessagePack.MessagePackCode.ToFormatName(byte code) -> string
 static MessagePack.MessagePackCode.ToMessagePackType(byte code) -> MessagePack.MessagePackType
 static MessagePack.MessagePackSerializer.ConvertFromJson(System.IO.TextReader reader, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -679,7 +679,6 @@ abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermedi
 abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Complete(TIntermediate intermediateCollection) -> TDictionary
 abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> TIntermediate
 abstract MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TEnumerator, TDictionary>.GetSourceEnumerator(TDictionary source) -> TEnumerator
-const MessagePack.Formatters.TypelessFormatter.ExtensionTypeCode = 100 -> sbyte
 const MessagePack.MessagePackCode.Array16 = 220 -> byte
 const MessagePack.MessagePackCode.Array32 = 221 -> byte
 const MessagePack.MessagePackCode.Bin16 = 197 -> byte

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -730,7 +730,6 @@ const MessagePack.MessagePackRange.MaxFixStringLength = 31 -> int
 const MessagePack.MessagePackRange.MinFixNegativeInt = -32 -> int
 const MessagePack.MessagePackRange.MinFixStringLength = 0 -> int
 const MessagePack.ReservedMessagePackExtensionTypeCode.DateTime = -1 -> sbyte
-const MessagePack.ReservedMessagePackExtensionTypeCode.LZ4 = 99 -> sbyte
 override MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TCollection>.GetSourceEnumerator(TCollection source) -> System.Collections.Generic.IEnumerator<TElement>
 override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TDictionary>.Complete(TDictionary intermediateCollection) -> TDictionary
 override MessagePack.Formatters.DictionaryFormatterBase<TKey, TValue, TIntermediate, TDictionary>.GetSourceEnumerator(TDictionary source) -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>

--- a/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
+++ b/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
@@ -40,7 +40,7 @@ namespace MessagePack.Tests.ExtensionTests
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
             var lz4DataReader = new MessagePackReader(lz4Data);
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
-            header.TypeCode.Is(ReservedMessagePackExtensionTypeCode.LZ4);
+            header.TypeCode.Is(ThisLibraryExtensionTypeCodes.LZ4);
 
             var decompress = MessagePackSerializer.Deserialize<int[]>(lz4Data, MessagePackSerializerOptions.LZ4Standard);
 
@@ -57,7 +57,7 @@ namespace MessagePack.Tests.ExtensionTests
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
             var lz4DataReader = new MessagePackReader(lz4Data);
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
-            header.TypeCode.Is(ReservedMessagePackExtensionTypeCode.LZ4);
+            header.TypeCode.Is(ThisLibraryExtensionTypeCodes.LZ4);
 
             var decompress = MessagePackSerializer.Deserialize(typeof(FirstSimpleData[]), lz4Data, MessagePackSerializerOptions.LZ4Standard);
 

--- a/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
+++ b/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
@@ -40,7 +40,7 @@ namespace MessagePack.Tests.ExtensionTests
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
             var lz4DataReader = new MessagePackReader(lz4Data);
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
-            header.TypeCode.Is(MessagePackSerializer.LZ4ExtensionTypeCode);
+            header.TypeCode.Is(ReservedMessagePackExtensionTypeCode.LZ4);
 
             var decompress = MessagePackSerializer.Deserialize<int[]>(lz4Data, MessagePackSerializerOptions.LZ4Standard);
 
@@ -57,7 +57,7 @@ namespace MessagePack.Tests.ExtensionTests
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
             var lz4DataReader = new MessagePackReader(lz4Data);
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
-            header.TypeCode.Is(MessagePackSerializer.LZ4ExtensionTypeCode);
+            header.TypeCode.Is(ReservedMessagePackExtensionTypeCode.LZ4);
 
             var decompress = MessagePackSerializer.Deserialize(typeof(FirstSimpleData[]), lz4Data, MessagePackSerializerOptions.LZ4Standard);
 

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\FarmHash.cs" Link="Link\FarmHash.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\ILGeneratorExtensions.cs" Link="Link\ILGeneratorExtensions.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\StringEncoding.cs" Link="Link\StringEncoding.cs" />
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\ThisLibraryExtensionTypeCodes.cs" Link="ExtensionTests\ThisLibraryExtensionTypeCodes.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\Tests\ShareTests\**\*.cs" Exclude="..\..\src\MessagePack.UnityClient\Assets\Scripts\Tests\ShareTests\T4\**\*.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The LZ4 type code seemed out of place on `MessagePackSerializer` and almost no one using the class would care to use it directly anyway, so it felt too prominently placed. I moved it to a promising-looking class, but wonder if @neuecc agrees that it's the right place.

I found the `MessagePackCode` class had a member in v2.x that wasn't there in v1.x and since I see no reason why it needs to be public, I made it internal.