### PR TITLE
Pack MPC tool as build artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,16 +1184,36 @@ Because strict-AOT environments such as Xamarin and Unity IL2CPP forbid runtime 
 
 > Note: When Unity targets the PC it allows dynamic code generation, so AOT is not required.
 
-If you want to avoid the upfront dynamic generation cost or you need to run on Xamarin or Unity, you need AOT code generation. `mpc.exe`(MessagePackCompiler) is the code generator of MessagePack for C#. You can download mpc from the [releases](https://github.com/neuecc/MessagePack-CSharp/releases/) page, `mpc.zip`. mpc uses [Roslyn](https://github.com/dotnet/roslyn) to analyze source code.
+If you want to avoid the upfront dynamic generation cost or you need to run on Xamarin or Unity, you need AOT code generation. `mpc` (MessagePackCompiler) is the code generator of MessagePack for C#. mpc uses [Roslyn](https://github.com/dotnet/roslyn) to analyze source code.
+
+The easiest way to acquire and run mpc is as a dotnet tool.
+It works as a global tool, but installing it as a local tool allows you to include the tools and versions that you use in your source control system. Run these commands in the root of your repo:
 
 ```
-mpc arguments help:
--i, --input              [required]Input path of analyze csproj
--o, --output             [required]Output file path
--c, --conditionalsymbol  [optional, default=empty]conditional compiler symbol
--r, --resolvername       [optional, default=GeneratedResolver]Set resolver name
--n, --namespace          [optional, default=MessagePack]Set namespace root name
--m, --usemapmode         [optional, default=false]Force use map mode serialization
+dotnet new tool-manifest
+dotnet tool install MessagePack.Generator
+```
+
+Check in your `.config\dotnet-tools.json` file.
+On another machine you can "restore" your tool using the `dotnet tool restore` command.
+
+Once you have the tool installed, simply invoke using `dotnet mpc` within your repo:
+
+```
+dotnet mpc -h
+```
+
+Alternatively, you can download mpc from the [releases](https://github.com/neuecc/MessagePack-CSharp/releases/) page.
+
+```
+argument list:
+-i, -input: Input path of analyze csproj or directory, if input multiple csproj split with ','.
+-o, -output: Output file path(.cs) or directory(multiple generate file).
+-c, -conditionalSymbol: [default=null]Conditional compiler symbols, split with ','.
+-r, -resolverName: [default=GeneratedResolver]Set resolver name.
+-n, -namespace: [default=MessagePack]Set namespace root name.
+-m, -useMapMode: [default=False]Force use map mode serialization.
+-ms, -multipleIfDirectiveOutputSymbols: [default=null]Generate #if-- files by symbols, split with ','.
 ```
 
 ```cmd

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -75,6 +75,12 @@ steps:
     projects: tests/**/*.Tests.csproj
     arguments: --configuration $(BuildConfiguration) --no-build -v n
 
+- script: |
+    dotnet publish src/MessagePack.Generator -r win-x64 -c $(BuildConfiguration) /p:PublishSingleFile=true,PublishTrimmed=true,IncludeSymbolsInSingleFile=true
+    dotnet publish src/MessagePack.Generator -r osx-x64 -c $(BuildConfiguration) /p:PublishSingleFile=true,PublishTrimmed=true,IncludeSymbolsInSingleFile=true
+    dotnet publish src/MessagePack.Generator -r linux-x64 -c $(BuildConfiguration) /p:PublishSingleFile=true,PublishTrimmed=true,IncludeSymbolsInSingleFile=true
+  displayName: Building standalone mpc tool for all OSs
+
 - task: CopyFiles@1
   inputs:
     Contents: |
@@ -119,3 +125,15 @@ steps:
     ArtifactType: Container
   displayName: Publish deployables artifacts
   condition: succeededOrFailed()
+
+- publish: bin/MessagePack.Generator/$(BuildConfiguration)/netcoreapp3.0/win-x64/publish
+  artifact: mpc-win
+  displayName: Publish mpc for Windows
+
+- publish: bin/MessagePack.Generator/$(BuildConfiguration)/netcoreapp3.0/osx-x64/publish
+  artifact: mpc-osx
+  displayName: Publish mpc for OSX
+
+- publish: bin/MessagePack.Generator/$(BuildConfiguration)/netcoreapp3.0/linux-x64/publish
+  artifact: mpc-linux
+  displayName: Publish mpc for Linux

--- a/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-mpc</ToolCommandName>
 

--- a/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/src/MessagePack.Generator/MessagepackCompiler.cs
+++ b/src/MessagePack.Generator/MessagepackCompiler.cs
@@ -22,7 +22,7 @@ namespace MessagePack.Generator
             [Option("r", "Set resolver name.")]string resolverName = "GeneratedResolver",
             [Option("n", "Set namespace root name.")]string @namespace = "MessagePack",
             [Option("m", "Force use map mode serialization.")]bool useMapMode = false,
-            [Option("ms", "Generate #if-- files by symbols, split with ','.")]string multipleIfDiretiveOutputSymbols = null)
+            [Option("ms", "Generate #if-- files by symbols, split with ','.")]string multipleIfDirectiveOutputSymbols = null)
         {
             await new MessagePackCompiler.CodeGenerator(x => Console.WriteLine(x), this.Context.CancellationToken)
                 .GenerateFileAsync(
@@ -32,7 +32,7 @@ namespace MessagePack.Generator
                     resolverName,
                     @namespace,
                     useMapMode,
-                    multipleIfDiretiveOutputSymbols).ConfigureAwait(false);
+                    multipleIfDirectiveOutputSymbols).ConfigureAwait(false);
         }
     }
 }

--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -33,11 +33,11 @@ namespace MessagePackCompiler
            string resolverName,
            string @namespace,
            bool useMapMode,
-           string multipleIfDiretiveOutputSymbols)
+           string multipleIfDirectiveOutputSymbols)
         {
             var namespaceDot = string.IsNullOrWhiteSpace(@namespace) ? string.Empty : @namespace + ".";
             var conditionalSymbols = conditionalSymbol?.Split(',') ?? Array.Empty<string>();
-            var multipleOutputSymbols = multipleIfDiretiveOutputSymbols?.Split(',') ?? Array.Empty<string>();
+            var multipleOutputSymbols = multipleIfDirectiveOutputSymbols?.Split(',') ?? Array.Empty<string>();
 
             var sw = Stopwatch.StartNew();
 


### PR DESCRIPTION
- fix a typo in an mpc parameter name
- packs the mpc as a dotnet tool and documents it as such
- also builds mpc as a standalone executable for all 3 OS's and captures as a build artifact

Closes #617