### PR TITLE
Reduce number of build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,6 @@ TestResult.xml
 [Rr]eleasePS/
 dlldata.c
 
-# DNX
-project.lock.json
-project.fragment.lock.json
-artifacts/
-
 *_i.c
 *_p.c
 *_i.h

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,26 @@
 # Contributing
 
+## Dependencies
+
+* [Visual Studio 2019](https://visualstudio.microsoft.com/)
+* [Unity Editor](https://unity3d.com/unity/editor) (optional)
+* .NET Core SDK and runtimes (run `init` to install)
+
+This repo uses the .NET Core SDK and runtimes to build and test the projects.
+You can install the right versions of the SDK and runtimes by running the `init.ps1` script at the root of the repo.
+
+By default no elevation is required as these toolsets are installed in a per-user directory. Launching `devenv` from the same PowerShell window that you ran the script will lead VS to discover these per-user toolsets.
+To get VS to find the toolsets when launched from the Start Menu, run `init -InstallLocality machine`, which requires elevation for each SDK or runtime installed.
+
 ## How to Build
 
 Open `MessagePack.sln` on Visual Studio 2019.
+
+Alternatively you may build from the command line using `msbuild.exe` or:
+
+    dotnet build /p:platform=NoVSIX
+
+## Unity
 
 Unity Project requires several dependency DLL's. At first, run `copy_assets.bat` under `src\MessagePack.UnityClient`.
 Then open that directory in the Unity Editor.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,13 @@ jobs:
   pool:
     vmImage: windows-2019
   steps:
+  - checkout: self
+    clean: true
+  - template: azure-pipelines/install-dependencies.yml
+
+  - powershell: '& (./azure-pipelines/Get-nbgv.ps1) cloud'
+    displayName: Set build number
+
   - template: azure-pipelines/build.yml
 
 - job: Unity
@@ -22,6 +29,9 @@ jobs:
     name: CustomAgents
     demands: UNITYHUB_EDITORS_FOLDER_LOCATION
   steps:
+  - checkout: self
+    clean: true
+  - template: azure-pipelines/install-dependencies.yml
   - template: azure-pipelines/build_unity.yml
 
 - job: Linux
@@ -30,6 +40,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
+  - template: azure-pipelines/install-dependencies.yml
   - template: azure-pipelines/build_nonWindows.yml
 
 - job: macOS
@@ -38,4 +49,5 @@ jobs:
   steps:
   - checkout: self
     clean: true
+  - template: azure-pipelines/install-dependencies.yml
   - template: azure-pipelines/build_nonWindows.yml

--- a/azure-pipelines/Get-TempToolsPath.ps1
+++ b/azure-pipelines/Get-TempToolsPath.ps1
@@ -1,0 +1,13 @@
+if ($env:AGENT_TOOLSDIRECTORY) {
+    $path = "$env:AGENT_TOOLSDIRECTORY\vs-platform\tools"
+} elseif ($env:localappdata) {
+    $path = "$env:localappdata\vs-platform\tools"
+} else {
+    $path = "$PSScriptRoot\..\obj\tools"
+}
+
+if (!(Test-Path $path)) {
+    New-Item -ItemType Directory -Path $Path | Out-Null
+}
+
+(Resolve-Path $path).Path

--- a/azure-pipelines/Get-nbgv.ps1
+++ b/azure-pipelines/Get-nbgv.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+    Gets the path to the nbgv CLI tool, installing it if necessary.
+#>
+Param(
+)
+
+$existingTool = Get-Command "nbgv" -ErrorAction SilentlyContinue
+if ($existingTool) {
+    return $existingTool.Path
+}
+
+if ($env:AGENT_TEMPDIRECTORY) {
+    $toolInstallDir = "$env:AGENT_TEMPDIRECTORY/$env:BUILD_BUILDID"
+} else {
+    $toolInstallDir = "$PSScriptRoot/../obj/tools"
+}
+
+$toolPath = "$toolInstallDir/nbgv"
+if (!(Test-Path $toolInstallDir)) { New-Item -Path $toolInstallDir -ItemType Directory | Out-Null }
+
+if (!(Get-Command $toolPath -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing nbgv to $toolInstallDir"
+    dotnet tool install --tool-path "$toolInstallDir" nbgv --configfile "$PSScriptRoot/justnugetorg.nuget.config" | Out-Null
+}
+
+# Normalize the path on the way out.
+return (Get-Command $toolPath).Path

--- a/azure-pipelines/Set-EnvVars.ps1
+++ b/azure-pipelines/Set-EnvVars.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+    Set environment variables in the environment.
+    Azure Pipeline and CMD environments are considered.
+.PARAMETER Variables
+    A hashtable of variables to be set.
+.OUTPUTS
+    A boolean indicating whether the environment variables can be expected to propagate to the caller's environment.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+Param(
+    [Parameter(Mandatory=$true, Position=1)]
+    $Variables
+)
+
+if ($Variables.Count -eq 0) {
+    return $true
+}
+
+$cmdInstructions = !$env:TF_BUILD -and $env:PS1UnderCmd -eq '1'
+if ($cmdInstructions) {
+    Write-Warning "Environment variables have been set that will be lost because you're running under cmd.exe"
+    Write-Host "Environment variables that must be set manually:" -ForegroundColor Blue
+}
+
+$Variables.GetEnumerator() |% {
+    Set-Item -Path env:$($_.Key) -Value $_.Value
+
+    # If we're running in Azure Pipelines, set these environment variables
+    if ($env:TF_BUILD) {
+        Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
+    }
+
+    if ($cmdInstructions) {
+        Write-Host "SET $($_.Key)=$($_.Value)"
+    }
+}
+
+return !$cmdInstructions

--- a/azure-pipelines/artifacts/Variables.ps1
+++ b/azure-pipelines/artifacts/Variables.ps1
@@ -1,0 +1,40 @@
+# This artifact captures all variables defined in the ..\variables folder.
+# It "snaps" the values of these variables where we can compute them during the build,
+# and otherwise captures the scripts to run later during an Azure Pipelines environment release.
+
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$ArtifactBasePath = "$RepoRoot\obj\_artifacts"
+$VariablesArtifactPath = "$ArtifactBasePath\variables"
+if (-not (Test-Path $VariablesArtifactPath)) { New-Item -ItemType Directory -Path $VariablesArtifactPath | Out-Null }
+
+# Copy variables, either by value if the value is calculable now, or by script
+Get-ChildItem -Path "$PSScriptRoot\..\variables" |% {
+    $value = $null
+    if (-not $_.BaseName.StartsWith('_')) { # Skip trying to interpret special scripts
+        # First check the environment variables in case the variable was set in a queued build
+        if (Test-Path env:$($_.BaseName)) {
+            $value = Get-Content "env:$($_.BaseName)"
+        }
+
+        # If that didn't give us anything, try executing the script right now from its original position
+        if (-not $value) {
+            $value = & $_.FullName
+        }
+
+        if ($value) {
+            # We got something, so wrap it with quotes so it's treated like a literal value.
+            $value = "'$value'"
+        }
+    }
+
+    # If that didn't get us anything, just copy the script itself
+    if (-not $value) {
+        $value = Get-Content -Path $_.FullName
+    }
+
+    Set-Content -Path "$VariablesArtifactPath\$($_.Name)" -Value $value
+}
+
+@{
+    "$VariablesArtifactPath" = (Get-ChildItem $VariablesArtifactPath -Recurse);
+}

--- a/azure-pipelines/artifacts/_all.ps1
+++ b/azure-pipelines/artifacts/_all.ps1
@@ -1,0 +1,50 @@
+# This script returns all the artifacts that should be collected after a build.
+#
+# Each powershell artifact is expressed as an object with these properties:
+#  Source          - the full path to the source file
+#  ArtifactName    - the name of the artifact to upload to
+#  ContainerFolder - the relative path within the artifact in which the file should appear
+#
+# Each artifact aggregating .ps1 script should return a hashtable:
+#   Key = path to the directory from which relative paths within the artifact should be calculated
+#   Value = an array of paths (absolute or relative to the BaseDirectory) to files to include in the artifact.
+#           FileInfo objects are also allowed.
+
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+
+Function EnsureTrailingSlash($path) {
+    if ($path.length -gt 0 -and !$path.EndsWith('\') -and !$path.EndsWith('/')) {
+        $path = $path + [IO.Path]::DirectorySeparatorChar
+    }
+
+    $path.Replace('\', [IO.Path]::DirectorySeparatorChar)
+}
+
+Get-ChildItem "$PSScriptRoot\*.ps1" -Exclude "_*" -Recurse |% {
+    $ArtifactName = $_.BaseName
+
+    $fileGroups = & $_
+    if (!$fileGroups -or $fileGroups.Count -eq 0) {
+        Write-Warning "No files found for the `"$ArtifactName`" artifact."
+    } else {
+        $fileGroups.GetEnumerator() | % {
+            $BaseDirectory = New-Object Uri ((EnsureTrailingSlash $_.Key), [UriKind]::Absolute)
+            $_.Value | % {
+                if ($_.GetType() -eq [IO.FileInfo] -or $_.GetType() -eq [IO.DirectoryInfo]) {
+                    $_ = $_.FullName
+                }
+
+                $artifact = New-Object -TypeName PSObject
+                Add-Member -InputObject $artifact -MemberType NoteProperty -Name ArtifactName -Value $ArtifactName
+
+                $SourceFullPath = New-Object Uri ($BaseDirectory, $_)
+                Add-Member -InputObject $artifact -MemberType NoteProperty -Name Source -Value $SourceFullPath.LocalPath
+
+                $RelativePath = [Uri]::UnescapeDataString($BaseDirectory.MakeRelative($SourceFullPath))
+                Add-Member -InputObject $artifact -MemberType NoteProperty -Name ContainerFolder -Value (Split-Path $RelativePath)
+
+                Write-Output $artifact
+            }
+        }
+    }
+}

--- a/azure-pipelines/artifacts/_pipelines.ps1
+++ b/azure-pipelines/artifacts/_pipelines.ps1
@@ -1,0 +1,55 @@
+# This script translates all the artifacts described by _all.ps1
+# into commands that instruct Azure Pipelines to actually collect those artifacts.
+
+param (
+    [string]$ArtifactNameSuffix
+)
+
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+if ($env:BUILD_ARTIFACTSTAGINGDIRECTORY) {
+    $ArtifactStagingFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+} else {
+    $ArtifactStagingFolder = "$RepoRoot\obj\_artifacts"
+    if (Test-Path $ArtifactStagingFolder) {
+        Remove-Item $ArtifactStagingFolder -Recurse -Force
+    }
+}
+
+function Create-SymbolicLink {
+    param (
+        $Link,
+        $Target
+    )
+
+    if ($Link -eq $Target) {
+        return
+    }
+
+    if (Test-Path $Link) { Remove-Item $Link }
+    $LinkContainer = Split-Path $Link -Parent
+    if (!(Test-Path $LinkContainer)) { mkdir $LinkContainer }
+    Write-Verbose "Linking $Link to $Target"
+    if ($IsMacOS -or $IsLinux) {
+        ln $Target $Link
+    } else {
+        cmd /c mklink $Link $Target
+    }
+}
+
+# Stage all artifacts
+$Artifacts = & "$PSScriptRoot\_all.ps1"
+$Artifacts |% {
+    $DestinationFolder = (Join-Path (Join-Path $ArtifactStagingFolder "$($_.ArtifactName)$ArtifactNameSuffix") $_.ContainerFolder).TrimEnd('\')
+    $Name = "$(Split-Path $_.Source -Leaf)"
+
+    #Write-Host "$($_.Source) -> $($_.ArtifactName)\$($_.ContainerFolder)" -ForegroundColor Yellow
+
+    if (-not (Test-Path $DestinationFolder)) { New-Item -ItemType Directory -Path $DestinationFolder | Out-Null }
+    if (Test-Path -PathType Leaf $_.Source) { # skip folders
+        Create-SymbolicLink -Link "$DestinationFolder\$Name" -Target $_.Source
+    }
+}
+
+$Artifacts |% { $_.ArtifactName } | Get-Unique |% {
+    Write-Host "##vso[artifact.upload containerfolder=$_$ArtifactNameSuffix;artifactname=$_$ArtifactNameSuffix;]$ArtifactStagingFolder/$_$ArtifactNameSuffix"
+}

--- a/azure-pipelines/artifacts/build_logs.ps1
+++ b/azure-pipelines/artifacts/build_logs.ps1
@@ -1,0 +1,12 @@
+if ($env:BUILD_ARTIFACTSTAGINGDIRECTORY) {
+    $artifactsRoot = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+} else {
+    $RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+    $artifactsRoot = "$RepoRoot\bin"
+}
+
+if (!(Test-Path $artifactsRoot/build_logs)) { return }
+
+@{
+    "$artifactsRoot/build_logs" = (Get-ChildItem -Recurse "$artifactsRoot/build_logs")
+}

--- a/azure-pipelines/artifacts/mpc-linux.ps1
+++ b/azure-pipelines/artifacts/mpc-linux.ps1
@@ -1,0 +1,13 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$MpcBin = "$RepoRoot/bin/MessagePack.Generator/$BuildConfiguration/netcoreapp3.0/linux-x64/publish"
+
+if (!(Test-Path $MpcBin))  { return }
+
+@{
+    "$MpcBin" = (Get-ChildItem $MpcBin)
+}

--- a/azure-pipelines/artifacts/mpc-osx.ps1
+++ b/azure-pipelines/artifacts/mpc-osx.ps1
@@ -1,0 +1,13 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$MpcBin = "$RepoRoot/bin/MessagePack.Generator/$BuildConfiguration/netcoreapp3.0/osx-x64/publish"
+
+if (!(Test-Path $MpcBin))  { return }
+
+@{
+    "$MpcBin" = (Get-ChildItem $MpcBin)
+}

--- a/azure-pipelines/artifacts/mpc-win.ps1
+++ b/azure-pipelines/artifacts/mpc-win.ps1
@@ -1,0 +1,13 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$MpcBin = "$RepoRoot/bin/MessagePack.Generator/$BuildConfiguration/netcoreapp3.0/win-x64/publish"
+
+if (!(Test-Path $MpcBin))  { return }
+
+@{
+    "$MpcBin" = (Get-ChildItem $MpcBin)
+}

--- a/azure-pipelines/artifacts/nuget.ps1
+++ b/azure-pipelines/artifacts/nuget.ps1
@@ -1,0 +1,14 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$result = @{}
+
+$PackagesRoot = "$RepoRoot/bin/Packages/$BuildConfiguration/NuGet"
+if (Test-Path $PackagesRoot) {
+    $result[$PackagesRoot] = (Get-ChildItem $PackagesRoot -Recurse)
+}
+
+return $result

--- a/azure-pipelines/artifacts/projectAssetsJson.ps1
+++ b/azure-pipelines/artifacts/projectAssetsJson.ps1
@@ -1,0 +1,9 @@
+$ObjRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..\obj")
+
+if (!(Test-Path $ObjRoot)) { return }
+
+@{
+    "$ObjRoot" = (
+        (Get-ChildItem "$ObjRoot\project.assets.json" -Recurse)
+    );
+}

--- a/azure-pipelines/artifacts/unity.ps1
+++ b/azure-pipelines/artifacts/unity.ps1
@@ -1,0 +1,14 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$result = @{}
+
+$UnityPackRoot = "$RepoRoot/bin"
+if (Test-Path $UnityPackRoot) {
+    $result[$UnityPackRoot] = (Get-ChildItem $UnityPackRoot/*.unitypackage)
+}
+
+return $result

--- a/azure-pipelines/artifacts/vsix.ps1
+++ b/azure-pipelines/artifacts/vsix.ps1
@@ -1,0 +1,14 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$result = @{}
+
+$VsixRoot = "$RepoRoot/bin/MessagePackAnalyzer.Vsix/$BuildConfiguration"
+if (Test-Path $VsixRoot) {
+    $result[$VsixRoot] = (Get-ChildItem "$VsixRoot/*vsix")
+}
+
+return $result

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -1,63 +1,4 @@
 steps:
-- checkout: self
-  clean: true
-
-- task: UseDotNet@2
-  displayName: Install .NET Core SDK 3.0.100
-  inputs:
-    packageType: sdk
-    version: 3.0.100
-- task: UseDotNet@2
-  displayName: Install .NET Core runtime 2.1.x
-  inputs:
-    packageType: runtime
-    version: 2.1.x
-- task: UseDotNet@2
-  displayName: Install .NET Core runtime 2.2.x
-  inputs:
-    packageType: runtime
-    version: 2.2.x
-- script: dotnet --info
-  displayName: Show dotnet SDK info
-
-- script: |
-    dotnet tool install --tool-path . nbgv
-    .\nbgv cloud -p src
-  displayName: Set build number
-
-- task: PowerShell@2
-  displayName: Set VSTS variables
-  inputs:
-    targetType: inline
-    script: |
-      if ($env:SignType -eq 'Real') {
-        $feedGuid = '09d8d03c-1ac8-456e-9274-4d2364527d99'
-      } else {
-        $feedGuid = 'da484c78-f942-44ef-b197-99e2a1bef53c'
-      }
-
-      Write-Host "##vso[task.setvariable variable=feedGuid]$feedGuid"
-
-      if ($env:ComputerName.StartsWith('factoryvm', [StringComparison]::OrdinalIgnoreCase)) {
-        Write-Host "Running on hosted queue"
-        Write-Host "##vso[task.setvariable variable=Hosted]true"
-      }
-
-      if ($env:SYSTEM_COLLECTIONID -eq '011b8bdf-6d56-4f87-be0d-0092136884d9') {
-        Write-Host "Running on official devdiv account: $env:System_TeamFoundationCollectionUri"
-      } else {
-        Write-Host "Running under OSS account: $env:System_TeamFoundationCollectionUri"
-      }
-
-- task: DotNetCoreCLI@2
-  displayName: Restore
-  inputs:
-    command: restore
-    verbosityRestore: normal # detailed, normal, minimal
-    projects: '**\*.sln'
-    feedsToUse: config
-    nugetConfigPath: nuget.config
-
 # Use VSBuild to pack because `dotnet pack` can't build VSIX projects.
 - task: VSBuild@1
   inputs:
@@ -81,59 +22,18 @@ steps:
     dotnet publish src/MessagePack.Generator -r linux-x64 -c $(BuildConfiguration) /p:PublishSingleFile=true,PublishTrimmed=true,IncludeSymbolsInSingleFile=true
   displayName: Building standalone mpc tool for all OSs
 
-- task: CopyFiles@1
-  inputs:
-    Contents: |
-      obj/**/project.assets.json
-    TargetFolder: $(Build.ArtifactStagingDirectory)/projectAssetsJson
-  displayName: Collecting project.assets.json artifacts
-  condition: succeededOrFailed()
-
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)/projectAssetsJson
-    ArtifactName: projectAssetsJson
-    ArtifactType: Container
-  displayName: Publish projectAssetsJson artifacts
-  condition: succeededOrFailed()
-
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)/build_logs
-    ArtifactName: build_logs
-    ArtifactType: Container
-  displayName: Publish build_logs artifacts
-  condition: succeededOrFailed()
-
 ## The rest of these steps are for deployment and skipped for PR builds
 
-- task: CopyFiles@1
+- task: PowerShell@2
   inputs:
-    Contents: |
-      bin/Packages/$(BuildConfiguration)/**/*.nupkg
-      bin/Packages/$(BuildConfiguration)/**/*.snupkg
-      bin/MessagePackAnalyzer.Vsix/$(BuildConfiguration)/**/*.vsix
-      bin/*.unitypackage
-    TargetFolder: $(Build.ArtifactStagingDirectory)/deployables
-    flattenFolders: true
-  displayName: Collecting deployables
-
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)/deployables
-    ArtifactName: deployables
-    ArtifactType: Container
-  displayName: Publish deployables artifacts
+    filePath: azure-pipelines/variables/_pipelines.ps1
+    failOnStderr: true
+  displayName: Update pipeline variables based on build outputs
   condition: succeededOrFailed()
 
-- publish: bin/MessagePack.Generator/$(BuildConfiguration)/netcoreapp3.0/win-x64/publish
-  artifact: mpc-win
-  displayName: Publish mpc for Windows
-
-- publish: bin/MessagePack.Generator/$(BuildConfiguration)/netcoreapp3.0/osx-x64/publish
-  artifact: mpc-osx
-  displayName: Publish mpc for OSX
-
-- publish: bin/MessagePack.Generator/$(BuildConfiguration)/netcoreapp3.0/linux-x64/publish
-  artifact: mpc-linux
-  displayName: Publish mpc for Linux
+- task: PowerShell@2
+  inputs:
+    filePath: azure-pipelines/artifacts/_pipelines.ps1
+    # arguments: -ArtifactNameSuffix "-$(Agent.JobName)"
+  displayName: Publish artifacts
+  condition: succeededOrFailed()

--- a/azure-pipelines/build_nonWindows.yml
+++ b/azure-pipelines/build_nonWindows.yml
@@ -1,30 +1,4 @@
 steps:
-- task: UseDotNet@2
-  displayName: Install .NET Core SDK 3.0.100
-  inputs:
-    packageType: sdk
-    version: 3.0.100
-- task: UseDotNet@2
-  displayName: Install .NET Core runtime 2.1.x
-  inputs:
-    packageType: runtime
-    version: 2.1.x
-- task: UseDotNet@2
-  displayName: Install .NET Core runtime 2.2.x
-  inputs:
-    packageType: runtime
-    version: 2.2.x
-- script: dotnet --info
-  displayName: Show dotnet SDK info
-
-- task: DotNetCoreCLI@2
-  displayName: Restore
-  inputs:
-    command: restore
-    verbosityRestore: normal # detailed, normal, minimal
-    feedsToUse: config
-    nugetConfigPath: nuget.config
-
 - task: DotNetCoreCLI@2
   displayName: Build MessagePack.sln
   inputs:

--- a/azure-pipelines/build_unity.yml
+++ b/azure-pipelines/build_unity.yml
@@ -1,15 +1,4 @@
 steps:
-- checkout: self
-  clean: true
-
-- task: UseDotNet@2
-  displayName: Install .NET Core SDK 3.0.100
-  inputs:
-    packageType: sdk
-    version: 3.0.100
-- script: dotnet --info
-  displayName: Show dotnet SDK info
-
 - script: dotnet publish src/MessagePack -c $(BuildConfiguration) -f netstandard2.0
   displayName: Build MessagePack
 
@@ -28,15 +17,15 @@ steps:
   inputs:
     Contents: |
       bin/*.unitypackage
-    TargetFolder: $(Build.ArtifactStagingDirectory)/deployables
+    TargetFolder: $(Build.ArtifactStagingDirectory)/unity
     flattenFolders: true
   displayName: Collecting deployables
   condition: succeededOrFailed()
 
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)/deployables
-    ArtifactName: deployables
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/unity
+    ArtifactName: unity
     ArtifactType: Container
   displayName: Publish deployables artifacts
   condition: succeededOrFailed()

--- a/azure-pipelines/install-dependencies.yml
+++ b/azure-pipelines/install-dependencies.yml
@@ -1,0 +1,15 @@
+parameters:
+  initArgs:
+
+steps:
+
+- powershell: |
+    .\init.ps1 -AccessToken '$(System.AccessToken)' ${{ parameters['initArgs'] }}
+    dotnet --info
+  displayName: Install prerequisites
+
+- task: PowerShell@2
+  inputs:
+    filePath: azure-pipelines/variables/_pipelines.ps1
+    failOnStderr: true
+  displayName: Set pipeline variables based on source

--- a/azure-pipelines/justnugetorg.nuget.config
+++ b/azure-pipelines/justnugetorg.nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines/variables/DotNetSdkVersion.ps1
+++ b/azure-pipelines/variables/DotNetSdkVersion.ps1
@@ -1,0 +1,2 @@
+$globalJson = Get-Content -Path "$PSScriptRoot\..\..\global.json" | ConvertFrom-Json
+$globalJson.sdk.version

--- a/azure-pipelines/variables/_all.ps1
+++ b/azure-pipelines/variables/_all.ps1
@@ -1,0 +1,11 @@
+# This script returns a hashtable of build variables that should be set
+# at the start of a build or release definition's execution.
+
+$vars = @{}
+
+Get-ChildItem "$PSScriptRoot\*.ps1" -Exclude "_*" |% {
+    Write-Host "Computing $($_.BaseName) variable"
+    $vars[$_.BaseName] = & $_
+}
+
+$vars

--- a/azure-pipelines/variables/_pipelines.ps1
+++ b/azure-pipelines/variables/_pipelines.ps1
@@ -1,0 +1,15 @@
+# This script translates the variables returned by the _all.ps1 script
+# into commands that instruct Azure Pipelines to actually set those variables for other pipeline tasks to consume.
+
+# The build or release definition may have set these variables to override
+# what the build would do. So only set them if they have not already been set.
+
+(& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
+    if (Test-Path -Path "env:$($_.Key.ToUpper())") {
+        Write-Host "Skipping setting $($_.Key) because variable is already set." -ForegroundColor Cyan
+    } else {
+        Write-Host "$($_.Key)=$($_.Value)" -ForegroundColor Yellow
+        Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
+        Set-Item -Path "env:$($_.Key)" -Value $_.Value
+    }
+}

--- a/init.cmd
+++ b/init.cmd
@@ -1,0 +1,4 @@
+@echo off
+SETLOCAL
+set PS1UnderCmd=1
+powershell.exe -NoProfile -NoLogo -ExecutionPolicy bypass -Command "try { & '%~dpn0.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+Installs dependencies required to build and test the projects in this repository.
+.DESCRIPTION
+This MAY not require elevation, as the SDK and runtimes are installed locally to this repo location,
+unless `-InstallLocality machine` is specified.
+.PARAMETER InstallLocality
+A value indicating whether dependencies should be installed locally to the repo or at a per-user location.
+Per-user allows sharing the installed dependencies across repositories and allows use of a shared expanded package cache.
+Visual Studio will only notice and use these SDKs/runtimes if VS is launched from the environment that runs this script.
+Per-repo allows for high isolation, allowing for a more precise recreation of the environment within an Azure Pipelines build.
+When using 'repo', environment variables are set to cause the locally installed dotnet SDK to be used.
+Per-repo can lead to file locking issues when dotnet.exe is left running as a build server and can be mitigated by running `dotnet build-server shutdown`.
+Per-machine requires elevation and will download and install all SDKs and runtimes to machine-wide locations so all applications can find it.
+.PARAMETER NoPrerequisites
+Skips the installation of prerequisite software (e.g. SDKs, tools).
+.PARAMETER NoRestore
+Skips the package restore step.
+.PARAMETER AccessToken
+An optional access token for authenticating to Azure Artifacts authenticated feeds.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+Param (
+    [ValidateSet('repo','user','machine')]
+    [string]$InstallLocality='user',
+    [Parameter()]
+    [switch]$NoPrerequisites,
+    [Parameter()]
+    [switch]$NoRestore,
+    [Parameter()]
+    [string]$AccessToken
+)
+
+if (!$NoPrerequisites) {
+    & "$PSScriptRoot\tools\Install-NuGetCredProvider.ps1" -AccessToken $AccessToken
+    & "$PSScriptRoot\tools\Install-DotNetSdk.ps1" -InstallLocality $InstallLocality
+}
+
+# Workaround nuget credential provider bug that causes very unreliable package restores on Azure Pipelines
+$env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
+$env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
+
+Push-Location $PSScriptRoot
+try {
+    $HeaderColor = 'Green'
+
+    if (!$NoRestore) {
+        Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
+        dotnet restore
+        if ($lastexitcode -ne 0) {
+            throw "Failure while restoring packages."
+        }
+    }
+}
+catch {
+    Write-Error $error[0]
+    exit $lastexitcode
+}
+finally {
+    Pop-Location
+}

--- a/installcredprovider.ps1
+++ b/installcredprovider.ps1
@@ -1,0 +1,140 @@
+# A PowerShell script that adds the latest version of the Azure Artifacts credential provider
+# plugin for Dotnet and/or NuGet to ~/.nuget/plugins directory
+# To install netcore, run installcredprovider.ps1
+# To install netcore and netfx, run installcredprovider.ps1 -AddNetfx
+# To overwrite existing plugin with the latest version, run installcredprovider.ps1 -Force
+# To use a specific version of a credential provider, run installcredprovider.ps1 -Version "0.1.17" or installcredprovider.ps1 -Version "0.1.17" -Force
+# More: https://github.com/Microsoft/artifacts-credprovider/blob/master/README.md
+
+param(
+    # whether or not to install netfx folder for nuget
+    [switch]$AddNetfx,
+    # override existing cred provider with the latest version
+    [switch]$Force,
+    # install the version specified
+    [string]$Version
+)
+
+$script:ErrorActionPreference='Stop'
+
+# Without this, System.Net.WebClient.DownloadFile will fail on a client with TLS 1.0/1.1 disabled
+if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -notcontains 'Tls12') {
+    [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+}
+
+$profilePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
+$tempPath = [System.IO.Path]::GetTempPath()
+
+$pluginLocation = [System.IO.Path]::Combine($profilePath, ".nuget", "plugins");
+$tempZipLocation = [System.IO.Path]::Combine($tempPath, "CredProviderZip");
+
+$localNetcoreCredProviderPath = [System.IO.Path]::Combine("netcore", "CredentialProvider.Microsoft");
+$localNetfxCredProviderPath = [System.IO.Path]::Combine("netfx", "CredentialProvider.Microsoft");
+
+$fullNetfxCredProviderPath = [System.IO.Path]::Combine($pluginLocation, $localNetfxCredProviderPath)
+$fullNetcoreCredProviderPath = [System.IO.Path]::Combine($pluginLocation, $localNetcoreCredProviderPath)
+
+$netfxExists = Test-Path -Path ($fullNetfxCredProviderPath)
+$netcoreExists = Test-Path -Path ($fullNetcoreCredProviderPath)
+
+# Check if plugin already exists if -Force swich is not set
+if (!$Force) {
+    if ($AddNetfx -eq $True -and $netfxExists -eq $True -and $netcoreExists -eq $True) {
+        Write-Host "The netcore and netfx Credential Providers are already in $pluginLocation"
+        return
+    }
+
+    if ($AddNetfx -eq $False -and $netcoreExists -eq $True) {
+        Write-Host "The netcore Credential Provider is already in $pluginLocation"
+        return
+    }
+}
+
+# Get the zip file from the GitHub release
+$releaseUrlBase = "https://api.github.com/repos/Microsoft/artifacts-credprovider/releases"
+$versionError = "Unable to find the release version $Version from $releaseUrlBase"
+$releaseId = "latest"
+if (![string]::IsNullOrEmpty($Version)) {
+    try {
+        $releases = Invoke-WebRequest -UseBasicParsing $releaseUrlBase
+        $releaseJson = $releases | ConvertFrom-Json
+        $correctReleaseVersion = $releaseJson | ? { $_.name -eq $Version }
+        $releaseId = $correctReleaseVersion.id
+    } catch {
+        Write-Error $versionError
+        return
+    }
+}
+
+if (!$releaseId) {
+    Write-Error $versionError
+    return
+}
+
+$releaseUrl = [System.IO.Path]::Combine($releaseUrlBase, $releaseId)
+$releaseUrl = $releaseUrl.Replace("\","/")
+
+$zipErrorString = "Unable to resolve the Credential Provider zip file from $releaseUrl"
+try {
+    Write-Host "Fetching release $releaseUrl"
+    $release = Invoke-WebRequest -UseBasicParsing $releaseUrl
+    $releaseJson = $release.Content | ConvertFrom-Json
+    if ($AddNetfx -eq $True) {
+        Write-Host "Using Microsoft.NuGet.CredentialProvider.zip"
+        $zipAsset = $releaseJson.assets | ? { $_.name -eq "Microsoft.NuGet.CredentialProvider.zip" }
+    } else {
+        Write-Host "Using Microsoft.NetCore2.NuGet.CredentialProvider.zip"
+        $zipAsset = $releaseJson.assets | ? { $_.name -eq "Microsoft.NetCore2.NuGet.CredentialProvider.zip" }
+    }
+    
+    $packageSourceUrl = $zipAsset.browser_download_url
+} catch {
+    Write-Error $zipErrorString
+    return
+}
+
+if (!$packageSourceUrl) {
+    Write-Error $zipErrorString
+    return
+}
+
+# Create temporary location for the zip file handling
+Write-Host "Creating temp directory for the Credential Provider zip: $tempZipLocation"
+if (Test-Path -Path $tempZipLocation) {
+    Remove-Item $tempZipLocation -Force -Recurse
+}
+New-Item -ItemType Directory -Force -Path $tempZipLocation
+
+# Download credential provider zip to the temp location
+$pluginZip = ([System.IO.Path]::Combine($tempZipLocation, "Microsoft.NuGet.CredentialProvider.zip"))
+Write-Host "Downloading $packageSourceUrl to $pluginZip"
+try {
+    $client = New-Object System.Net.WebClient
+    $client.DownloadFile($packageSourceUrl, $pluginZip)
+} catch {
+    Write-Error "Unable to download $packageSourceUrl to the location $pluginZip"
+}
+
+# Extract zip to temp directory
+Write-Host "Extracting zip to the Credential Provider temp directory"
+Add-Type -AssemblyName System.IO.Compression.FileSystem 
+[System.IO.Compression.ZipFile]::ExtractToDirectory($pluginZip, $tempZipLocation)
+
+# Remove existing content and copy netcore (and netfx) directories to plugins directory
+Write-Host "Copying Credential Provider to $pluginLocation"
+if ($netcoreExists) {
+    Remove-Item $fullNetcoreCredProviderPath -Force -Recurse
+}
+Copy-Item ([System.IO.Path]::Combine($tempZipLocation, "plugins", $localNetcoreCredProviderPath)) -Destination $fullNetcoreCredProviderPath -Force -Recurse
+if ($AddNetfx -eq $True) {
+    if ($netfxExists) {
+        Remove-Item $fullNetfxCredProviderPath -Force -Recurse
+    }
+    Copy-Item ([System.IO.Path]::Combine($tempZipLocation, "plugins", $localNetfxCredProviderPath)) -Destination $fullNetfxCredProviderPath -Force -Recurse
+}
+
+# Remove $tempZipLocation directory
+Write-Host "Removing the Credential Provider temp directory $tempZipLocation"
+Remove-Item $tempZipLocation -Force -Recurse
+
+Write-Host "Credential Provider installed successfully"

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -1,0 +1,196 @@
+<#
+.SYNOPSIS
+Installs the .NET SDK specified in the global.json file at the root of this repository,
+along with supporting .NET Core runtimes used for testing.
+.DESCRIPTION
+This MAY not require elevation, as the SDK and runtimes are installed locally to this repo location,
+unless `-InstallLocality machine` is specified.
+.PARAMETER InstallLocality
+A value indicating whether dependencies should be installed locally to the repo or at a per-user location.
+Per-user allows sharing the installed dependencies across repositories and allows use of a shared expanded package cache.
+Visual Studio will only notice and use these SDKs/runtimes if VS is launched from the environment that runs this script.
+Per-repo allows for high isolation, allowing for a more precise recreation of the environment within an Azure Pipelines build.
+When using 'repo', environment variables are set to cause the locally installed dotnet SDK to be used.
+Per-repo can lead to file locking issues when dotnet.exe is left running as a build server and can be mitigated by running `dotnet build-server shutdown`.
+Per-machine requires elevation and will download and install all SDKs and runtimes to machine-wide locations so all applications can find it.
+#>
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='Medium')]
+Param (
+    [ValidateSet('repo','user','machine')]
+    [string]$InstallLocality='user'
+)
+
+$DotNetInstallScriptRoot = "$PSScriptRoot/../obj/tools"
+if (!(Test-Path $DotNetInstallScriptRoot)) { New-Item -ItemType Directory -Path $DotNetInstallScriptRoot | Out-Null }
+$DotNetInstallScriptRoot = Resolve-Path $DotNetInstallScriptRoot
+
+# Look up actual required .NET Core SDK version from global.json
+$sdkVersion = & "$PSScriptRoot/../azure-pipelines/variables/DotNetSdkVersion.ps1"
+
+# Search for all .NET Core runtime versions referenced from MSBuild projects and arrange to install them.
+$runtimeVersions = @()
+Get-ChildItem "$PSScriptRoot\..\src\*.*proj","$PSScriptRoot\..\sandbox\*.*proj" -Recurse |% {
+    $projXml = [xml](Get-Content -Path $_)
+    $targetFrameworks = $projXml.Project.PropertyGroup.TargetFramework
+    if (!$targetFrameworks) {
+        $targetFrameworks = $projXml.Project.PropertyGroup.TargetFrameworks
+        if ($targetFrameworks) {
+            $targetFrameworks = $targetFrameworks -Split ';'
+        }
+    }
+    $targetFrameworks |? { $_ -match 'netcoreapp(\d+\.\d+)' } |% {
+        $runtimeVersions += $Matches[1]
+    }
+}
+
+Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
+    $OutFile = Join-Path $OutDir $Uri.Segments[-1]
+    if (!(Test-Path $OutFile)) {
+        Write-Verbose "Downloading $Uri..."
+        try {
+            (New-Object System.Net.WebClient).DownloadFile($Uri, $OutFile)
+        } finally {
+            # This try/finally causes the script to abort
+        }
+    }
+
+    $OutFile
+}
+
+Function Get-InstallerExe($Version, [switch]$Runtime) {
+    $sdkOrRuntime = 'Sdk'
+    if ($Runtime) { $sdkOrRuntime = 'Runtime' }
+
+    # Get the latest/actual version for the specified one
+    if (([Version]$Version).Build -eq -1) {
+        $versionInfo = -Split (Invoke-WebRequest -Uri "https://dotnetcli.blob.core.windows.net/dotnet/$sdkOrRuntime/$Version/latest.version" -UseBasicParsing)
+        $Version = $versionInfo[-1]
+    }
+
+    Get-FileFromWeb -Uri "https://dotnetcli.blob.core.windows.net/dotnet/$sdkOrRuntime/$Version/dotnet-$($sdkOrRuntime.ToLowerInvariant())-$Version-win-x64.exe" -OutDir "$DotNetInstallScriptRoot"
+}
+
+Function Install-DotNet($Version, [switch]$Runtime) {
+    if ($Runtime) { $sdkSubstring = '' } else { $sdkSubstring = 'SDK ' }
+    Write-Host "Downloading .NET Core $sdkSubstring$Version..."
+    $Installer = Get-InstallerExe -Version $Version -Runtime:$Runtime
+    Write-Host "Installing .NET Core $sdkSubstring$Version..."
+    cmd /c start /wait $Installer /install /quiet
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failure to install .NET Core SDK"
+    }
+}
+
+if ($InstallLocality -eq 'machine') {
+    if ($IsMacOS -or $IsLinux) {
+        Write-Error "Installing the .NET Core SDK or runtime at a machine-wide location is only supported by this script on Windows."
+        exit 1
+    }
+
+    if ($PSCmdlet.ShouldProcess(".NET Core SDK $sdkVersion", "Install")) {
+        Install-DotNet -Version $sdkVersion
+    }
+
+    $runtimeVersions |% {
+        if ($PSCmdlet.ShouldProcess(".NET Core runtime $_", "Install")) {
+            Install-DotNet -Version $_ -Runtime
+        }
+    }
+
+    return
+}
+
+$switches = @(
+    '-Architecture','x64'
+)
+$envVars = @{
+    # For locally installed dotnet, skip first time experience which takes a long time
+    'DOTNET_SKIP_FIRST_TIME_EXPERIENCE' = 'true';
+}
+
+if ($InstallLocality -eq 'repo') {
+    $DotNetInstallDir = "$DotNetInstallScriptRoot/.dotnet"
+} elseif ($env:AGENT_TOOLSDIRECTORY) {
+    $DotNetInstallDir = "$env:AGENT_TOOLSDIRECTORY/dotnet"
+} else {
+    $DotNetInstallDir = Join-Path $HOME .dotnet
+}
+
+Write-Host "Installing .NET Core SDK and runtimes to $DotNetInstallDir" -ForegroundColor Blue
+
+if ($DotNetInstallDir) {
+    $switches += '-InstallDir',$DotNetInstallDir
+    $envVars['DOTNET_MULTILEVEL_LOOKUP'] = '0'
+    $envVars['DOTNET_ROOT'] = $DotNetInstallDir
+}
+
+if ($IsMacOS -or $IsLinux) {
+    $DownloadUri = "https://dot.net/v1/dotnet-install.sh"
+    $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.sh"
+} else {
+    $DownloadUri = "https://dot.net/v1/dotnet-install.ps1"
+    $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.ps1"
+}
+
+if (-not (Test-Path $DotNetInstallScriptPath)) {
+    Invoke-WebRequest -Uri $DownloadUri -OutFile $DotNetInstallScriptPath -UseBasicParsing
+    if ($IsMacOS -or $IsLinux) {
+        chmod +x $DotNetInstallScriptPath
+    }
+}
+
+if ($PSCmdlet.ShouldProcess(".NET Core SDK $sdkVersion", "Install")) {
+    Invoke-Expression -Command "$DotNetInstallScriptPath -Version $sdkVersion $switches"
+} else {
+    Invoke-Expression -Command "$DotNetInstallScriptPath -Version $sdkVersion $switches -DryRun"
+}
+
+$switches += '-Runtime','dotnet'
+
+$runtimeVersions | Get-Unique |% {
+    if ($PSCmdlet.ShouldProcess(".NET Core runtime $_", "Install")) {
+        Invoke-Expression -Command "$DotNetInstallScriptPath -Channel $_ $switches"
+    } else {
+        Invoke-Expression -Command "$DotNetInstallScriptPath -Channel $_ $switches -DryRun"
+    }
+}
+
+if ($PSCmdlet.ShouldProcess("Set DOTNET environment variables to discover these installed runtimes?")) {
+    if ($env:TF_BUILD) {
+        Write-Host "Azure Pipelines detected. Logging commands will be used to propagate environment variables and prepend path."
+    }
+
+    if ($IsMacOS -or $IsLinux) {
+        $envVars['PATH'] = "${DotNetInstallDir}:$env:PATH"
+    } else {
+        $envVars['PATH'] = "$DotNetInstallDir;$env:PATH"
+    }
+
+    $envVars.GetEnumerator() |% {
+        Set-Item -Path env:$($_.Key) -Value $_.Value
+
+        # If we're running in Azure Pipelines, set these environment variables
+        if ($env:TF_BUILD) {
+            Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
+        }
+    }
+
+    if ($env:TF_BUILD) {
+        Write-Host "##vso[task.prependpath]$DotNetInstallDir"
+    }
+}
+
+if ($env:PS1UnderCmd -eq '1') {
+    Write-Warning "Environment variable changes will be lost because you're running under cmd.exe. Run these commands manually:"
+    $envVars.GetEnumerator() |% {
+        if ($_.Key -eq 'PATH') {
+            # Special case this one for readability
+            Write-Host "SET PATH=$DotNetInstallDir;%PATH%"
+        } else {
+            Write-Host "SET $($_.Key)=$($_.Value)"
+        }
+    }
+} else {
+    Write-Host "Environment variables set:" -ForegroundColor Blue
+    $envVars
+}

--- a/tools/Install-NuGetCredProvider.ps1
+++ b/tools/Install-NuGetCredProvider.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Downloads and installs the Microsoft Artifacts Credential Provider
+    from https://github.com/microsoft/artifacts-credprovider
+    to assist in authenticating to Azure Artifact feeds in interactive development
+    or unattended build agents.
+.PARAMETER AccessToken
+    An optional access token for authenticating to Azure Artifacts authenticated feeds.
+#>
+[CmdletBinding()]
+Param (
+    [Parameter()]
+    [string]$AccessToken
+)
+
+$toolsPath = & "$PSScriptRoot\..\azure-pipelines\Get-TempToolsPath.ps1"
+
+if ($IsMacOS -or $IsLinux) {
+    $installerScript = "installcredprovider.sh"
+    $sourceUrl = "https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh"
+} else {
+    $installerScript = "installcredprovider.ps1"
+    $sourceUrl = "https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1"
+}
+
+$installerScript = Join-Path $toolsPath $installerScript
+
+if (!(Test-Path $installerScript)) {
+    Invoke-WebRequest $sourceUrl -OutFile $installerScript
+}
+
+$installerScript = (Resolve-Path $installerScript).Path
+
+if ($IsMacOS -or $IsLinux) {
+    chmod u+x $installerScript
+}
+
+& $installerScript
+
+if ($AccessToken) {
+    $endpoints = @()
+
+    $nugetConfig = [xml](Get-Content -Path "$PSScriptRoot\..\nuget.config")
+
+    $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {
+        $endpoint = New-Object -TypeName PSObject
+        Add-Member -InputObject $endpoint -MemberType NoteProperty -Name endpoint -Value $_.value
+        Add-Member -InputObject $endpoint -MemberType NoteProperty -Name username -Value ado
+        Add-Member -InputObject $endpoint -MemberType NoteProperty -Name password -Value $AccessToken
+        $endpoints += $endpoint
+    }
+
+    $auth = New-Object -TypeName PSObject
+    Add-Member -InputObject $auth -MemberType NoteProperty -Name endpointCredentials -Value $endpoints
+
+    $authJson = ConvertTo-Json -InputObject $auth
+    $envVars = @{
+        'VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'=$authJson;
+    }
+
+    & "$PSScriptRoot\..\azure-pipelines\Set-EnvVars.ps1" -Variables $envVars | Out-Null
+}


### PR DESCRIPTION
This moves some of the logic from YML to ps1 scripts where it can be reproduced locally and therefore is more diagnosable and maintainable.

It also adds an init script to the repo root which installs whatever .NET Core SDK and runtimes are required to build and run tests in this repo.