### PR TITLE
Throw msg exception before build nonpublic formatter.

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,6 +5,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\opensource.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <!-- ignore compilation temp files and unity generated .meta files -->
     <None Remove="**/bin/**;**/obj/**;**/*.meta" />
   </ItemGroup>
   <Import Project="..\Directory.Build.targets" Condition="Exists('..\Directory.Build.targets')" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,5 +4,8 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\opensource.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="**/bin/**;**/obj/**;**/*.meta" />
+  </ItemGroup>
   <Import Project="..\Directory.Build.targets" Condition="Exists('..\Directory.Build.targets')" />
 </Project>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) All contributors. All rights reserved.
+// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !(UNITY_2018_3_OR_NEWER && NET_STANDARD_2_0)
@@ -345,6 +345,11 @@ namespace MessagePack.Internal
             if (serializationInfo == null)
             {
                 return null;
+            }
+
+            if (type.IsNotPublic)
+            {
+                throw new MessagePackSerializationException("Building dynamic formatter only allows public type. Type: " + type.FullName);
             }
 
             Type formatterType = typeof(IMessagePackFormatter<>).MakeGenericType(type);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -347,7 +347,7 @@ namespace MessagePack.Internal
                 return null;
             }
 
-            if (type.IsNotPublic)
+            if (!(type.IsPublic || type.IsNestedPublic))
             {
                 throw new MessagePackSerializationException("Building dynamic formatter only allows public type. Type: " + type.FullName);
             }


### PR DESCRIPTION
when serializing non-public type, throws an unfriendly exception.

```
System.TypeLoadException: Type 'MessagePack.Formatters.Sandbox_ClassWithMissingKeyPositionsFormatter1' from assembly 'MessagePack.Resolvers.DynamicObjectResolver, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' is attempting to implement an inaccessible interface.
   at System.Reflection.Emit.TypeBuilder.TermCreateClass(RuntimeModule module, Int32 tk, ObjectHandleOnStack type)
   at System.Reflection.Emit.TypeBuilder.CreateTypeNoLock()
   at System.Reflection.Emit.TypeBuilder.CreateTypeInfo()
```

so check the access modifier before build formatter and throws friendly msg.

```
MessagePack.MessagePackSerializationException: Building dynamic formatter only allows public type. Type: Sandbox.ClassWithMissingKeyPositions
```

---

This PR includes modifications to `Directory.Build.targets` that have nothing to do with this title.
when edit code for Unity, I'm removing `Directory.Build.props` to prevent error msgs. related to #556
Then, bin and obj are generated under each project, and it is read, so it causes compile error.
Unnecessary .meta is also loaded into SolutionExplorer.
This modifies of `Directory.Build.Targets` is to remove the there unnecessary file.