### PR TITLE
Stream deserialization fixes

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -128,93 +128,100 @@ namespace MessagePack
         /// </remarks>
         public void Skip()
         {
-            byte code = this.NextCode;
-            switch (code)
+            try
             {
-                case MessagePackCode.Nil:
-                case MessagePackCode.True:
-                case MessagePackCode.False:
-                    this.reader.Advance(1);
-                    break;
-                case MessagePackCode.Int8:
-                case MessagePackCode.UInt8:
-                    this.reader.Advance(2);
-                    break;
-                case MessagePackCode.Int16:
-                case MessagePackCode.UInt16:
-                    this.reader.Advance(3);
-                    break;
-                case MessagePackCode.Int32:
-                case MessagePackCode.UInt32:
-                case MessagePackCode.Float32:
-                    this.reader.Advance(5);
-                    break;
-                case MessagePackCode.Int64:
-                case MessagePackCode.UInt64:
-                case MessagePackCode.Float64:
-                    this.reader.Advance(9);
-                    break;
-                case MessagePackCode.Map16:
-                case MessagePackCode.Map32:
-                    this.ReadNextMap();
-                    break;
-                case MessagePackCode.Array16:
-                case MessagePackCode.Array32:
-                    this.ReadNextArray();
-                    break;
-                case MessagePackCode.Str8:
-                case MessagePackCode.Str16:
-                case MessagePackCode.Str32:
-                    int length = this.GetStringLengthInBytes();
-                    this.reader.Advance(length);
-                    break;
-                case MessagePackCode.Bin8:
-                case MessagePackCode.Bin16:
-                case MessagePackCode.Bin32:
-                    length = this.GetBytesLength();
-                    this.reader.Advance(length);
-                    break;
-                case MessagePackCode.FixExt1:
-                case MessagePackCode.FixExt2:
-                case MessagePackCode.FixExt4:
-                case MessagePackCode.FixExt8:
-                case MessagePackCode.FixExt16:
-                case MessagePackCode.Ext8:
-                case MessagePackCode.Ext16:
-                case MessagePackCode.Ext32:
-                    ExtensionHeader header = this.ReadExtensionFormatHeader();
-                    this.reader.Advance(header.Length);
-                    break;
-                default:
-                    if ((code >= MessagePackCode.MinNegativeFixInt && code <= MessagePackCode.MaxNegativeFixInt) ||
-                        (code >= MessagePackCode.MinFixInt && code <= MessagePackCode.MaxFixInt))
-                    {
+                byte code = this.NextCode;
+                switch (code)
+                {
+                    case MessagePackCode.Nil:
+                    case MessagePackCode.True:
+                    case MessagePackCode.False:
                         this.reader.Advance(1);
                         break;
-                    }
-
-                    if (code >= MessagePackCode.MinFixMap && code <= MessagePackCode.MaxFixMap)
-                    {
+                    case MessagePackCode.Int8:
+                    case MessagePackCode.UInt8:
+                        this.reader.Advance(2);
+                        break;
+                    case MessagePackCode.Int16:
+                    case MessagePackCode.UInt16:
+                        this.reader.Advance(3);
+                        break;
+                    case MessagePackCode.Int32:
+                    case MessagePackCode.UInt32:
+                    case MessagePackCode.Float32:
+                        this.reader.Advance(5);
+                        break;
+                    case MessagePackCode.Int64:
+                    case MessagePackCode.UInt64:
+                    case MessagePackCode.Float64:
+                        this.reader.Advance(9);
+                        break;
+                    case MessagePackCode.Map16:
+                    case MessagePackCode.Map32:
                         this.ReadNextMap();
                         break;
-                    }
-
-                    if (code >= MessagePackCode.MinFixArray && code <= MessagePackCode.MaxFixArray)
-                    {
+                    case MessagePackCode.Array16:
+                    case MessagePackCode.Array32:
                         this.ReadNextArray();
                         break;
-                    }
-
-                    if (code >= MessagePackCode.MinFixStr && code <= MessagePackCode.MaxFixStr)
-                    {
-                        length = this.GetStringLengthInBytes();
+                    case MessagePackCode.Str8:
+                    case MessagePackCode.Str16:
+                    case MessagePackCode.Str32:
+                        int length = this.GetStringLengthInBytes();
                         this.reader.Advance(length);
                         break;
-                    }
+                    case MessagePackCode.Bin8:
+                    case MessagePackCode.Bin16:
+                    case MessagePackCode.Bin32:
+                        length = this.GetBytesLength();
+                        this.reader.Advance(length);
+                        break;
+                    case MessagePackCode.FixExt1:
+                    case MessagePackCode.FixExt2:
+                    case MessagePackCode.FixExt4:
+                    case MessagePackCode.FixExt8:
+                    case MessagePackCode.FixExt16:
+                    case MessagePackCode.Ext8:
+                    case MessagePackCode.Ext16:
+                    case MessagePackCode.Ext32:
+                        ExtensionHeader header = this.ReadExtensionFormatHeader();
+                        this.reader.Advance(header.Length);
+                        break;
+                    default:
+                        if ((code >= MessagePackCode.MinNegativeFixInt && code <= MessagePackCode.MaxNegativeFixInt) ||
+                            (code >= MessagePackCode.MinFixInt && code <= MessagePackCode.MaxFixInt))
+                        {
+                            this.reader.Advance(1);
+                            break;
+                        }
 
-                    // We don't actually expect to ever hit this point, since every code is supported.
-                    Debug.Fail("Missing handler for code: " + code);
-                    throw ThrowInvalidCode(code);
+                        if (code >= MessagePackCode.MinFixMap && code <= MessagePackCode.MaxFixMap)
+                        {
+                            this.ReadNextMap();
+                            break;
+                        }
+
+                        if (code >= MessagePackCode.MinFixArray && code <= MessagePackCode.MaxFixArray)
+                        {
+                            this.ReadNextArray();
+                            break;
+                        }
+
+                        if (code >= MessagePackCode.MinFixStr && code <= MessagePackCode.MaxFixStr)
+                        {
+                            length = this.GetStringLengthInBytes();
+                            this.reader.Advance(length);
+                            break;
+                        }
+
+                        // We don't actually expect to ever hit this point, since every code is supported.
+                        Debug.Fail("Missing handler for code: " + code);
+                        throw ThrowInvalidCode(code);
+                }
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                ThrowNotEnoughBytesException(ex);
             }
         }
 
@@ -254,9 +261,16 @@ namespace MessagePack
         /// <returns>The sequence of bytes read.</returns>
         public ReadOnlySequence<byte> ReadRaw(long length)
         {
-            ReadOnlySequence<byte> result = this.reader.Sequence.Slice(this.reader.Position, length);
-            this.reader.Advance(length);
-            return result;
+            try
+            {
+                ReadOnlySequence<byte> result = this.reader.Sequence.Slice(this.reader.Position, length);
+                this.reader.Advance(length);
+                return result;
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                throw ThrowNotEnoughBytesException(ex);
+            }
         }
 
         /// <summary>
@@ -764,16 +778,29 @@ namespace MessagePack
         public ExtensionResult ReadExtensionFormat()
         {
             ExtensionHeader header = this.ReadExtensionFormatHeader();
-            ReadOnlySequence<byte> data = this.reader.Sequence.Slice(this.reader.Position, header.Length);
-            this.reader.Advance(header.Length);
-            return new ExtensionResult(header.TypeCode, data);
+            try
+            {
+                ReadOnlySequence<byte> data = this.reader.Sequence.Slice(this.reader.Position, header.Length);
+                this.reader.Advance(header.Length);
+                return new ExtensionResult(header.TypeCode, data);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                throw ThrowNotEnoughBytesException(ex);
+            }
         }
 
         /// <summary>
         /// Throws an exception indicating that there aren't enough bytes remaining in the buffer to store
         /// the promised data.
         /// </summary>
-        private static void ThrowNotEnoughBytesException() => throw new EndOfStreamException();
+        private static EndOfStreamException ThrowNotEnoughBytesException() => throw new EndOfStreamException();
+
+        /// <summary>
+        /// Throws an exception indicating that there aren't enough bytes remaining in the buffer to store
+        /// the promised data.
+        /// </summary>
+        private static EndOfStreamException ThrowNotEnoughBytesException(Exception innerException) => throw new EndOfStreamException(new EndOfStreamException().Message, innerException);
 
         private static Exception ThrowInvalidCode(byte code)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -17,6 +17,8 @@ namespace MessagePack
     /// <remarks>
     /// <see href="https://github.com/msgpack/msgpack/blob/master/spec.md">The MessagePack spec.</see>.
     /// </remarks>
+    /// <exception cref="MessagePackSerializationException">Thrown when reading methods fail due to invalid data.</exception>
+    /// <exception cref="EndOfStreamException">Thrown by reading methods when there are not enough bytes to read the required value.</exception>
 #if MESSAGEPACK_INTERNAL
     internal
 #else
@@ -771,7 +773,7 @@ namespace MessagePack
         /// Throws an exception indicating that there aren't enough bytes remaining in the buffer to store
         /// the promised data.
         /// </summary>
-        private static void ThrowNotEnoughBytesException() => throw new MessagePackSerializationException(null, new EndOfStreamException());
+        private static void ThrowNotEnoughBytesException() => throw new EndOfStreamException();
 
         private static Exception ThrowInvalidCode(byte code)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -624,6 +624,7 @@ namespace MessagePack
         /// Writes a <see cref="DateTime"/> using the message code <see cref="ReservedMessagePackExtensionTypeCode.DateTime"/>.
         /// </summary>
         /// <param name="dateTime">The value to write.</param>
+        /// <exception cref="NotSupportedException">Thrown when <see cref="OldSpec"/> is true because the old spec does not define a <see cref="DateTime"/> format.</exception>
         public void Write(DateTime dateTime)
         {
             if (this.OldSpec)

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.Text;
 using System.Threading;
 using Nerdbank.Streams;
 using Xunit;
@@ -171,7 +172,93 @@ namespace MessagePack.Tests
             Assert.True(reader.End);
         }
 
+        [Fact]
+        public void Read_CheckOperations_WithNoBytesLeft()
+        {
+            ReadOnlySequence<byte> partialMessage = default;
+
+            AssertThrowsEndOfStreamException(partialMessage, (ref MessagePackReader reader) => reader.NextCode);
+            AssertThrowsEndOfStreamException(partialMessage, (ref MessagePackReader reader) => reader.NextMessagePackType);
+
+            // These Try methods are meant to return false when it's not a matching code. End of stream when calling these methods is still unexpected.
+            AssertThrowsEndOfStreamException(partialMessage, (ref MessagePackReader reader) => reader.TryReadNil());
+            AssertThrowsEndOfStreamException(partialMessage, (ref MessagePackReader reader) => reader.TryReadStringSpan(out _));
+            AssertThrowsEndOfStreamException(partialMessage, (ref MessagePackReader reader) => reader.IsNil);
+        }
+
+        [Fact]
+        public void Read_WithInsufficientBytesLeft()
+        {
+            void AssertIncomplete<T>(WriterEncoder encoder, ReadOperation<T> decoder, bool validMsgPack = true)
+            {
+                var sequence = Encode(encoder);
+
+                // Test with every possible truncated length.
+                for (long len = sequence.Length - 1; len >= 0; len--)
+                {
+                    var truncated = sequence.Slice(0, len);
+                    AssertThrowsEndOfStreamException<T>(truncated, decoder);
+
+                    if (validMsgPack)
+                    {
+                        AssertThrowsEndOfStreamException(truncated, (ref MessagePackReader reader) => reader.Skip());
+                    }
+                }
+            }
+
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteArrayHeader(0xfffffff), (ref MessagePackReader reader) => reader.ReadArrayHeader());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(true), (ref MessagePackReader reader) => reader.ReadBoolean());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadByte());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteString(Encoding.UTF8.GetBytes("hi")), (ref MessagePackReader reader) => reader.ReadBytes());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write('c'), (ref MessagePackReader reader) => reader.ReadChar());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(DateTime.Now), (ref MessagePackReader reader) => reader.ReadDateTime());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(double.MaxValue), (ref MessagePackReader reader) => reader.ReadDouble());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteExtensionFormat(new ExtensionResult(5, new byte[3])), (ref MessagePackReader reader) => reader.ReadExtensionFormat());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteExtensionFormatHeader(new ExtensionHeader(5, 3)), (ref MessagePackReader reader) => reader.ReadExtensionFormatHeader());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadInt16());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadInt32());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadInt64());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteMapHeader(0xfffffff), (ref MessagePackReader reader) => reader.ReadMapHeader());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteNil(), (ref MessagePackReader reader) => reader.ReadNil());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write("hi"), (ref MessagePackReader reader) => reader.ReadRaw());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteRaw(new byte[10]), (ref MessagePackReader reader) => reader.ReadRaw(10), validMsgPack: false);
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadSByte());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadSingle());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write("hi"), (ref MessagePackReader reader) => reader.ReadString());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.WriteString(Encoding.UTF8.GetBytes("hi")), (ref MessagePackReader reader) => reader.ReadStringSequence());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadUInt16());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadUInt32());
+            AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadUInt64());
+        }
+
+        private delegate void ReaderOperation(ref MessagePackReader reader);
+
+        private delegate T ReadOperation<T>(ref MessagePackReader reader);
+
         private delegate void WriterEncoder(ref MessagePackWriter writer);
+
+        private static void AssertThrowsEndOfStreamException(ReadOnlySequence<byte> sequence, ReaderOperation readOperation)
+        {
+            Assert.Throws<EndOfStreamException>(() =>
+            {
+                var reader = new MessagePackReader(sequence);
+                readOperation(ref reader);
+            });
+        }
+
+        private static void AssertThrowsEndOfStreamException<T>(ReadOnlySequence<byte> sequence, ReadOperation<T> readOperation)
+        {
+            Assert.Throws<EndOfStreamException>(() =>
+            {
+                Decode(sequence, readOperation);
+            });
+        }
+
+        private static T Decode<T>(ReadOnlySequence<byte> sequence, ReadOperation<T> readOperation)
+        {
+            var reader = new MessagePackReader(sequence);
+            return readOperation(ref reader);
+        }
 
         private static ReadOnlySequence<byte> Encode(WriterEncoder cb)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
@@ -59,12 +59,11 @@ namespace MessagePack.Tests
             writer.WriteArrayHeader(9999);
             writer.Flush();
 
-            var ex = Assert.Throws<MessagePackSerializationException>(() =>
+            Assert.Throws<EndOfStreamException>(() =>
             {
                 var reader = new MessagePackReader(sequence);
                 reader.ReadArrayHeader();
             });
-            Assert.IsType<EndOfStreamException>(ex.InnerException);
         }
 
         [Fact]
@@ -75,12 +74,11 @@ namespace MessagePack.Tests
             writer.WriteMapHeader(9999);
             writer.Flush();
 
-            var ex = Assert.Throws<MessagePackSerializationException>(() =>
+            Assert.Throws<EndOfStreamException>(() =>
             {
                 var reader = new MessagePackReader(sequence);
                 reader.ReadMapHeader();
             });
-            Assert.IsType<EndOfStreamException>(ex.InnerException);
         }
 
         [Fact]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MessagePack.Resolvers;
+using Microsoft;
 using Nerdbank.Streams;
 using SharedData;
 using Xunit;
@@ -89,7 +90,7 @@ namespace MessagePack.Tests
             var decompress2 = MessagePackSerializer.Deserialize<FirstSimpleData[]>(normal);
             var decompress3 = MessagePackSerializer.Deserialize<FirstSimpleData[]>(ms);
             ms.Position = 0;
-            var onmore = new NonMemoryStream(ms);
+            var onmore = new StreamWrapper(ms);
             var decompress4 = MessagePackSerializer.Deserialize<FirstSimpleData[]>(onmore);
 
             decompress1.IsStructuralEqual(originalData);
@@ -97,26 +98,123 @@ namespace MessagePack.Tests
             decompress3.IsStructuralEqual(originalData);
             decompress4.IsStructuralEqual(originalData);
         }
+
+        [Fact]
+        public void SerializeAndDeserialize_MultipleValues_NonSeekableStream()
+        {
+            var ms = new MemoryStream();
+            Stream stream = new StreamWrapper(ms, canSeek: false);
+
+            MessagePackSerializer.Serialize(stream, 1);
+            MessagePackSerializer.Serialize(stream, 2);
+
+            ms.Position = 0;
+            Assert.Equal(1, MessagePackSerializer.Deserialize<int>(stream));
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<int>(stream));
+            Assert.IsType<EndOfStreamException>(ex.InnerException);
+        }
+
+        [Fact]
+        public async Task SerializeAndDeserializeAsync_MultipleValues_NonSeekableStream()
+        {
+            var ms = new MemoryStream();
+            Stream stream = new StreamWrapper(ms, canSeek: false);
+
+            await MessagePackSerializer.SerializeAsync(stream, 1);
+            await MessagePackSerializer.SerializeAsync(stream, 2);
+
+            ms.Position = 0;
+            Assert.Equal(1, await MessagePackSerializer.DeserializeAsync<int>(stream));
+            var ex = await Assert.ThrowsAsync<MessagePackSerializationException>(async () => await MessagePackSerializer.DeserializeAsync<int>(stream));
+            Assert.IsType<EndOfStreamException>(ex.InnerException);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SerializeAndDeserialize_MultipleValues_SeekableStream(bool useMemoryStream)
+        {
+            Stream stream = new MemoryStream();
+            if (!useMemoryStream)
+            {
+                // Hide the MemoryStream so MessagePack doesn't treat it specially.
+                stream = new StreamWrapper(stream);
+            }
+
+            MessagePackSerializer.Serialize(stream, 1);
+            MessagePackSerializer.Serialize(stream, 2);
+            MessagePackSerializer.Serialize(stream, 3);
+
+            stream.Position = 0;
+            Assert.Equal(1, MessagePackSerializer.Deserialize<int>(stream));
+            Assert.Equal(2, MessagePackSerializer.Deserialize<int>(stream));
+            Assert.Equal(3, MessagePackSerializer.Deserialize<int>(stream));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SerializeAndDeserializeAsync_MultipleValues_SeekableStream(bool useMemoryStream)
+        {
+            Stream stream = new MemoryStream();
+            if (!useMemoryStream)
+            {
+                // Hide the MemoryStream so MessagePack doesn't treat it specially.
+                stream = new StreamWrapper(stream);
+            }
+
+            await MessagePackSerializer.SerializeAsync(stream, 1);
+            await MessagePackSerializer.SerializeAsync(stream, 2);
+            await MessagePackSerializer.SerializeAsync(stream, 3);
+
+            stream.Position = 0;
+            Assert.Equal(1, await MessagePackSerializer.DeserializeAsync<int>(stream));
+            Assert.Equal(2, await MessagePackSerializer.DeserializeAsync<int>(stream));
+            Assert.Equal(3, await MessagePackSerializer.DeserializeAsync<int>(stream));
+        }
     }
 
-    internal class NonMemoryStream : Stream
+    internal class StreamWrapper : Stream
     {
-        private readonly MemoryStream stream;
+        private readonly Stream stream;
+        private readonly bool canSeek;
 
-        public NonMemoryStream(MemoryStream stream)
+        internal StreamWrapper(Stream stream)
         {
+            Requires.NotNull(stream, nameof(stream));
             this.stream = stream;
+            this.canSeek = stream.CanSeek;
+        }
+
+        internal StreamWrapper(Stream stream, bool canSeek)
+        {
+            Requires.NotNull(stream, nameof(stream));
+            Requires.Argument(stream.CanSeek || !CanSeek, nameof(canSeek), "Cannot emulate seek on a non-seekable underlying stream.");
+            this.stream = stream;
+            this.canSeek = canSeek;
         }
 
         public override bool CanRead => this.stream.CanRead;
 
-        public override bool CanSeek => this.stream.CanSeek;
+        public override bool CanSeek => this.canSeek;
 
         public override bool CanWrite => this.stream.CanWrite;
 
         public override long Length => this.stream.Length;
 
-        public override long Position { get => this.stream.Position; set => this.stream.Position = value; }
+        public override long Position
+        {
+            get => this.stream.Position;
+            set
+            {
+                if (!this.canSeek)
+                {
+                    throw new NotSupportedException();
+                }
+
+                this.stream.Position = value;
+            }
+        }
 
         public override void Flush()
         {
@@ -130,6 +228,11 @@ namespace MessagePack.Tests
 
         public override long Seek(long offset, SeekOrigin origin)
         {
+            if (!this.canSeek)
+            {
+                throw new NotSupportedException();
+            }
+
             return this.stream.Seek(offset, origin);
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 
 namespace Xunit
 {
@@ -40,6 +41,11 @@ namespace Xunit
         public static T Throws<T>(Action action) where T : Exception
         {
             return NUnit.Framework.Assert.Throws<T>(new TestDelegate(action));
+        }
+
+        public static Task<T> ThrowsAsync<T>(Func<Task> action) where T : Exception
+        {
+            return Task.FromResult(Throws<T>(() => action().GetAwaiter().GetResult()));
         }
 
         public static T Throws<T>(Func<object> action) where T : Exception


### PR DESCRIPTION
## Throw more precise exceptions from MessagePackReader/Writer

Now that MessagePackSerializer always wraps exceptions in MessagePackSerializationException, the formatters, readers and writers can generally throw whatever precise exception is most appropriate. The unnatural wrapping of EndOfStreamException was leading to double-wrapping when it goes through MessagePackSerializer.

## Fix MessagePackSerializer.Deserialize(Stream) to fix-up stream position

This fixes the bug that the Stream deserializing methods would advance the stream position unless it was a `MemoryStream` in which case it left the position alone. That was an observable side effect of the `MemoryStream` optimization, which wasn't documented.

This also enhances the stream deserializing methods to not just advance them all alike but to advance them only to the end of the deserialized msgpack token. Since we don't know in advance how far to read, I kept the behavior of draining the stream, but then if the stream is seekable, we "rewind" the stream back to the position of the first byte that was not deserialized. This enables an intuitive use case as shown in the tests I added of writing several values to a stream then reading several values from the stream and it actually works.

Fixes #662