### PR TITLE
Fix nuget package ID for mpc tool back to `MessagePack.Generator`

### DIFF
--- a/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>mpc</AssemblyName>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -9,10 +10,10 @@
     <ToolCommandName>dotnet-mpc</ToolCommandName>
 
     <!-- NuGet Info -->
+    <PackageId>MessagePack.Generator</PackageId>
     <Title>MessagePack Code Generator</Title>
     <Description>MessagePack standalone code generator.</Description>
     <PackageTags>MsgPack;MessagePack;Serialization;Formatter;Serializer;Unity;Xamarin</PackageTags>
-    <AssemblyName>mpc</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The recent rename of the assembly from MessagePack.Generator.exe to mpc.exe also changed the package ID in the same way.
But the package ID seems much more discoverable and descriptively unique if kept at `MessagePack.Generator`, leaving the dotnet tool name and executable name at the simpler `mpc`.