### PR TITLE
Remove explicit MessagePack.Annotations dependency from extension packages

### DIFF
--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MessagePack\MessagePack.csproj" />
-    <ProjectReference Include="..\MessagePack.Annotations\MessagePack.Annotations.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MessagePack.ImmutableCollection/MessagePack.ImmutableCollection.csproj
+++ b/src/MessagePack.ImmutableCollection/MessagePack.ImmutableCollection.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MessagePack\MessagePack.csproj" />
-    <ProjectReference Include="..\MessagePack.Annotations\MessagePack.Annotations.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MessagePack.ReactiveProperty/MessagePack.ReactiveProperty.csproj
+++ b/src/MessagePack.ReactiveProperty/MessagePack.ReactiveProperty.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MessagePack\MessagePack.csproj" />
-    <ProjectReference Include="..\MessagePack.Annotations\MessagePack.Annotations.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
+++ b/src/MessagePack.UnityShims/MessagePack.UnityShims.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MessagePack\MessagePack.csproj" />
-    <ProjectReference Include="..\MessagePack.Annotations\MessagePack.Annotations.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
These dependencies already exist transitively through MessagePack itself. So listing them explicitly just makes for a longer dependency list on nuget.org