### PR TITLE
Add Compression.LZ4ContiguousBlock and implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ public class Sample3
 }
 
 // [10,20]
-Console.WriteLine(MessagePackSerializer.ToJson(new Sample1 { Foo = 10, Bar = 20 }));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(new Sample1 { Foo = 10, Bar = 20 }));
 
 // {"foo":10,"bar":20}
-Console.WriteLine(MessagePackSerializer.ToJson(new Sample2 { Foo = 10, Bar = 20 }));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(new Sample2 { Foo = 10, Bar = 20 }));
 
 // {"Foo":10}
-Console.WriteLine(MessagePackSerializer.ToJson(new Sample3 { Foo = 10, Bar = 20 }));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(new Sample3 { Foo = 10, Bar = 20 }));
 ```
 
 All patterns serialization target are public instance member(field or property). If you want to avoid serialization target, you can add `[IgnoreMember]` to target member.
@@ -195,7 +195,7 @@ public class IntKeySample
 }
 
 // [null,null,null,0,null,null,null,null,null,null,0]
-Console.WriteLine(MessagePackSerializer.ToJson(new IntKeySample()));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(new IntKeySample()));
 ```
 
 I want to use like JSON.NET! I don't want to put attribute! If you think that way, you can use a contractless resolver.
@@ -211,7 +211,7 @@ var data = new ContractlessSample { MyProperty1 = 99, MyProperty2 = 9999 };
 var bin = MessagePackSerializer.Serialize(data, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
 // {"MyProperty1":99,"MyProperty2":9999}
-Console.WriteLine(MessagePackSerializer.ToJson(bin));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(bin));
 
 // You can set ContractlessStandardResolver as default.
 MessagePackSerializer.SetDefaultResolver(MessagePack.Resolvers.ContractlessStandardResolver.Instance);
@@ -397,7 +397,7 @@ var bin = MessagePackSerializer.Serialize(data);
 
 // Union is serialized to two-length array, [key, object]
 // [1,["FooBar"]]
-Console.WriteLine(MessagePackSerializer.ToJson(bin));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(bin));
 ```
 
 Using Union in Abstract Class, you can use same of interface.
@@ -456,14 +456,14 @@ var objects = new object[] { 1, "aaa", new ObjectFieldType { Anything = 9999 } }
 var bin = MessagePackSerializer.Serialize(objects);
 
 // [1,"aaa",[9999]]
-Console.WriteLine(MessagePackSerializer.ToJson(bin));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(bin));
 
 // Support Anonymous Type Serialize
 var anonType = new { Foo = 100, Bar = "foobar" };
 var bin2 = MessagePackSerializer.Serialize(anonType, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
 // {"Foo":100,"Bar":"foobar"}
-Console.WriteLine(MessagePackSerializer.ToJson(bin2));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(bin2));
 ```
 
 > Unity supports is limited.
@@ -487,7 +487,7 @@ var bin = MessagePackSerializer.Typeless.Serialize(mc);
 
 // binary data is embeded type-assembly information.
 // ["Sandbox.MyClass, Sandbox",10,"hoge","huga"]
-Console.WriteLine(MessagePackSerializer.ToJson(bin));
+Console.WriteLine(MessagePackSerializer.SerializeToJson(bin));
 
 // can deserialize to MyClass with typeless
 var objModel = MessagePackSerializer.Typeless.Deserialize(bin) as MyClass;

--- a/sandbox/PerfBenchmarkDotNet/Lz4Benchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/Lz4Benchmark.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias newmsgpack;
+extern alias oldmsgpack;
+
+using BenchmarkDotNet.Attributes;
+using newmsgpack::MessagePack;
+
+#pragma warning disable SA1306 // Field names should begin with lower-case letter
+#pragma warning disable SA1312 // Variable names should begin with lower-case letter
+
+namespace PerfBenchmarkDotNet
+{
+    [Config(typeof(BenchmarkConfig))]
+    public class Lz4Benchmark
+    {
+        private StringKeySerializerTarget2[] data;
+        private MessagePackSerializerOptions lz4BlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4Block);
+        private MessagePackSerializerOptions lz4ContiguousBlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4ContiguousBlock);
+        private byte[] bin;
+        private byte[] binLz4Block;
+        private byte[] binLz4ContiguousBlock;
+
+        public Lz4Benchmark()
+        {
+            var length = 1000;
+            data = RandomFixtureKit.FixtureFactory.CreateMany<StringKeySerializerTarget2>(length);
+            bin = MessagePackSerializer.Serialize(data);
+            binLz4Block = MessagePackSerializer.Serialize(data, lz4BlockOptions);
+            binLz4ContiguousBlock = MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
+        }
+
+        [Benchmark]
+        public byte[] SerializeNone() => MessagePackSerializer.Serialize(data);
+
+        [Benchmark]
+        public byte[] SerializeLz4Block() => MessagePackSerializer.Serialize(data, lz4BlockOptions);
+
+        [Benchmark]
+        public byte[] SerializeLz4ContiguousBlock() => MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
+
+        [Benchmark]
+        public StringKeySerializerTarget2[] DeserializeNone() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(bin);
+
+        [Benchmark]
+        public StringKeySerializerTarget2[] DeserializeLz4Block() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4Block, lz4BlockOptions);
+
+        [Benchmark]
+        public StringKeySerializerTarget2[] DeserializeLz4ContiguousBlock() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
+    }
+}
+
+#pragma warning restore SA1200 // Using directives should be placed correctly
+#pragma warning restore SA1403 // File may only contain a single namespace
+

--- a/sandbox/PerfBenchmarkDotNet/Lz4Benchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/Lz4Benchmark.cs
@@ -20,7 +20,7 @@ namespace PerfBenchmarkDotNet
 
         private StringKeySerializerTarget2[] data;
         private MessagePackSerializerOptions lz4BlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4Block);
-        private MessagePackSerializerOptions lz4ContiguousBlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4ContiguousBlock);
+        private MessagePackSerializerOptions lz4ContiguousBlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4BlockArray);
         private byte[] bin;
         private byte[] binLz4Block;
         private byte[] binLz4ContiguousBlock;
@@ -41,7 +41,7 @@ namespace PerfBenchmarkDotNet
         public byte[] SerializeLz4Block() => MessagePackSerializer.Serialize(data, lz4BlockOptions);
 
         [Benchmark]
-        public byte[] SerializeLz4ContiguousBlock() => MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
+        public byte[] SerializeLz4BlockArray() => MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
 
         [Benchmark]
         public StringKeySerializerTarget2[] DeserializeNone() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(bin);
@@ -50,7 +50,7 @@ namespace PerfBenchmarkDotNet
         public StringKeySerializerTarget2[] DeserializeLz4Block() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4Block, lz4BlockOptions);
 
         [Benchmark]
-        public StringKeySerializerTarget2[] DeserializeLz4ContiguousBlock() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
+        public StringKeySerializerTarget2[] DeserializeLz4BlockArray() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
     }
 }
 

--- a/sandbox/PerfBenchmarkDotNet/Lz4PrimitiveBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/Lz4PrimitiveBenchmark.cs
@@ -13,12 +13,9 @@ using newmsgpack::MessagePack;
 namespace PerfBenchmarkDotNet
 {
     [Config(typeof(BenchmarkConfig))]
-    public class Lz4Benchmark
+    public class Lz4PrimitiveBenchmark
     {
-        [Params(1, 10, 100, 1000, 10000)]
-        public int Length { get; set; }
-
-        private StringKeySerializerTarget2[] data;
+        private int data;
         private MessagePackSerializerOptions lz4BlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4Block);
         private MessagePackSerializerOptions lz4ContiguousBlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4ContiguousBlock);
         private byte[] bin;
@@ -28,7 +25,7 @@ namespace PerfBenchmarkDotNet
         [GlobalSetup]
         public void Setup()
         {
-            data = RandomFixtureKit.FixtureFactory.CreateMany<StringKeySerializerTarget2>(Length);
+            data = 9999;
             bin = MessagePackSerializer.Serialize(data);
             binLz4Block = MessagePackSerializer.Serialize(data, lz4BlockOptions);
             binLz4ContiguousBlock = MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
@@ -44,13 +41,13 @@ namespace PerfBenchmarkDotNet
         public byte[] SerializeLz4ContiguousBlock() => MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
 
         [Benchmark]
-        public StringKeySerializerTarget2[] DeserializeNone() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(bin);
+        public int DeserializeNone() => MessagePackSerializer.Deserialize<int>(bin);
 
         [Benchmark]
-        public StringKeySerializerTarget2[] DeserializeLz4Block() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4Block, lz4BlockOptions);
+        public int DeserializeLz4Block() => MessagePackSerializer.Deserialize<int>(binLz4Block, lz4BlockOptions);
 
         [Benchmark]
-        public StringKeySerializerTarget2[] DeserializeLz4ContiguousBlock() => MessagePackSerializer.Deserialize<StringKeySerializerTarget2[]>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
+        public int DeserializeLz4ContiguousBlock() => MessagePackSerializer.Deserialize<int>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
     }
 }
 

--- a/sandbox/PerfBenchmarkDotNet/Lz4PrimitiveBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/Lz4PrimitiveBenchmark.cs
@@ -17,7 +17,7 @@ namespace PerfBenchmarkDotNet
     {
         private int data;
         private MessagePackSerializerOptions lz4BlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4Block);
-        private MessagePackSerializerOptions lz4ContiguousBlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4ContiguousBlock);
+        private MessagePackSerializerOptions lz4ContiguousBlockOptions = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4BlockArray);
         private byte[] bin;
         private byte[] binLz4Block;
         private byte[] binLz4ContiguousBlock;
@@ -38,7 +38,7 @@ namespace PerfBenchmarkDotNet
         public byte[] SerializeLz4Block() => MessagePackSerializer.Serialize(data, lz4BlockOptions);
 
         [Benchmark]
-        public byte[] SerializeLz4ContiguousBlock() => MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
+        public byte[] SerializeLz4BlockArray() => MessagePackSerializer.Serialize(data, lz4ContiguousBlockOptions);
 
         [Benchmark]
         public int DeserializeNone() => MessagePackSerializer.Deserialize<int>(bin);
@@ -47,7 +47,7 @@ namespace PerfBenchmarkDotNet
         public int DeserializeLz4Block() => MessagePackSerializer.Deserialize<int>(binLz4Block, lz4BlockOptions);
 
         [Benchmark]
-        public int DeserializeLz4ContiguousBlock() => MessagePackSerializer.Deserialize<int>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
+        public int DeserializeLz4BlockArray() => MessagePackSerializer.Deserialize<int>(binLz4ContiguousBlock, lz4ContiguousBlockOptions);
     }
 }
 

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="protobuf-net" version="2.3.2" />
+    <PackageReference Include="RandomFixtureKit" Version="1.0.0" />
     <PackageReference Include="Sigil" version="4.7.0" />
     <PackageReference Include="ZeroFormatter" version="1.6.4" />
   </ItemGroup>

--- a/sandbox/PerfBenchmarkDotNet/Program.cs
+++ b/sandbox/PerfBenchmarkDotNet/Program.cs
@@ -28,6 +28,7 @@ namespace PerfBenchmarkDotNet
                 typeof(MessagePackWriterBenchmark),
                 typeof(SpanBenchmarks),
                 typeof(Lz4Benchmark),
+                typeof(Lz4PrimitiveBenchmark),
             });
 
             // args = new[] { "0" };

--- a/sandbox/PerfBenchmarkDotNet/Program.cs
+++ b/sandbox/PerfBenchmarkDotNet/Program.cs
@@ -27,6 +27,7 @@ namespace PerfBenchmarkDotNet
                 typeof(MessagePackReaderBenchmark),
                 typeof(MessagePackWriterBenchmark),
                 typeof(SpanBenchmarks),
+                typeof(Lz4Benchmark),
             });
 
             // args = new[] { "0" };

--- a/sandbox/PerfBenchmarkDotNet/StringKeySerializerTarget2.cs
+++ b/sandbox/PerfBenchmarkDotNet/StringKeySerializerTarget2.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+extern alias newmsgpack;
+extern alias oldmsgpack;
+
+#pragma warning disable SA1306 // Field names should begin with lower-case letter
+#pragma warning disable SA1312 // Variable names should begin with lower-case letter
+
+namespace PerfBenchmarkDotNet
+{
+    [oldmsgpack::MessagePack.MessagePackObject(true)]
+    [newmsgpack::MessagePack.MessagePackObject(true)]
+    public class StringKeySerializerTarget2
+    {
+        public int TotalQuestions { get; set; }
+
+        public int TotalUnanswered { get; set; }
+
+        public int QuestionsPerMinute { get; set; }
+
+        public int AnswersPerMinute { get; set; }
+
+        public int TotalVotes { get; set; }
+
+        public int BadgesPerMinute { get; set; }
+
+        public int NewActiveUsers { get; set; }
+
+        public int ApiRevision { get; set; }
+
+        public int Site { get; set; }
+    }
+}
+
+#pragma warning restore SA1200 // Using directives should be placed correctly
+#pragma warning restore SA1403 // File may only contain a single namespace
+

--- a/sandbox/Sandbox/Program.cs
+++ b/sandbox/Sandbox/Program.cs
@@ -356,38 +356,39 @@ namespace Sandbox
         ////public int Prop7 { get; set; }
     }
 
+    [MessagePack.MessagePackObject(true)]
+    public class StringKeySerializerTarget2
+    {
+        public int TotalQuestions { get; set; }
+
+        public int TotalUnanswered { get; set; }
+
+        public int QuestionsPerMinute { get; set; }
+
+        public int AnswersPerMinute { get; set; }
+
+        public int TotalVotes { get; set; }
+
+        public int BadgesPerMinute { get; set; }
+
+        public int NewActiveUsers { get; set; }
+
+        public int ApiRevision { get; set; }
+
+        public int Site { get; set; }
+    }
+
     internal class Program
     {
         private static readonly MessagePackSerializerOptions LZ4Standard = MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block);
 
         private static void Main(string[] args)
         {
-            var o = new SimpleIntKeyData()
-            {
-                Prop1 = 100,
-                Prop2 = ByteEnum.C,
-                Prop3 = "abcde",
-                Prop4 = new SimpleStringKeyData
-                {
-                    Prop1 = 99999,
-                    Prop2 = ByteEnum.E,
-                    Prop3 = 3,
-                },
-                Prop5 = new SimpleStructIntKeyData
-                {
-                    X = 100,
-                    Y = 300,
-                    BytesSpecial = new byte[] { 9, 99, 122 },
-                },
-                Prop6 = new SimpleStructStringKeyData
-                {
-                    X = 9999,
-                    Y = new[] { 1, 10, 100 },
-                },
-                BytesSpecial = new byte[] { 1, 4, 6 },
-            };
+            var option = MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+            var data = Enumerable.Range(0, 10000).Select(x => new StringKeySerializerTarget2()).ToArray();
 
-            MessagePackSerializer.Serialize(o);
+            var bin = MessagePackSerializer.Serialize(data, option);
+            Console.WriteLine(bin.Length);
         }
 
         private static void Benchmark<T>(T target)

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCompression.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCompression.cs
@@ -14,30 +14,30 @@ namespace MessagePack
         None,
 
         /// <summary>
-        /// Compresses an entire msgpack sequence as a single contiguous block.
-        /// This is the fastest and results in the best LZ4 compression,
+        /// Compresses an entire msgpack sequence as a single lz4 block format.
+        /// This is the simple compression that achieves best compression ratio,
         /// at the cost of copying the entire sequence when necessary to get contiguous memory.
         /// </summary>
         /// <remarks>
         /// Uses msgpack type code ext99 and is compatible with v1 of this library.
         /// </remarks>
         /// <devremarks>
-        /// See also ThisLibraryExtensionTypeCodes.LZ4
+        /// See also ThisLibraryExtensionTypeCodes.Lz4Block
         /// </devremarks>
         Lz4Block,
 
         /// <summary>
-        /// Compresses an entire msgpack sequence as a multi contiguous block.
-        /// This is the fastest and results in the best LZ4 compression,
-        /// at the cost of copying the entire sequence when necessary to get contiguous memory.
+        /// Compresses an entire msgpack sequence as a array of lz4 block format.
+        /// This is compressed/decompressed in chunks that do not consume LOH,
+        /// but the compression ratio is slightly sacrificed.
         /// </summary>
         /// <remarks>
         /// Uses msgpack type code ext98 in array.
         /// </remarks>
         /// <devremarks>
-        /// See also ThisLibraryExtensionTypeCodes.LZ4Contiguous
+        /// See also ThisLibraryExtensionTypeCodes.Lz4BlockArray
         /// </devremarks>
-        Lz4ContiguousBlock,
+        Lz4BlockArray,
     }
 
 #pragma warning disable SA1649 // File name should match first type name
@@ -45,7 +45,7 @@ namespace MessagePack
     /// <summary>
     /// Extensions for <see cref="MessagePackCompression"/>.
     /// </summary>
-    public static class MessagePackCompressionExtensions
+    internal static class MessagePackCompressionExtensions
     {
         public static bool IsCompression(this MessagePackCompression compression)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCompression.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCompression.cs
@@ -25,5 +25,33 @@ namespace MessagePack
         /// See also ThisLibraryExtensionTypeCodes.LZ4
         /// </devremarks>
         Lz4Block,
+
+        /// <summary>
+        /// Compresses an entire msgpack sequence as a multi contiguous block.
+        /// This is the fastest and results in the best LZ4 compression,
+        /// at the cost of copying the entire sequence when necessary to get contiguous memory.
+        /// </summary>
+        /// <remarks>
+        /// Uses msgpack type code ext98 in array.
+        /// </remarks>
+        /// <devremarks>
+        /// See also ThisLibraryExtensionTypeCodes.LZ4Contiguous
+        /// </devremarks>
+        Lz4ContiguousBlock,
     }
+
+#pragma warning disable SA1649 // File name should match first type name
+
+    /// <summary>
+    /// Extensions for <see cref="MessagePackCompression"/>.
+    /// </summary>
+    public static class MessagePackCompressionExtensions
+    {
+        public static bool IsCompression(this MessagePackCompression compression)
+        {
+            return compression != MessagePackCompression.None;
+        }
+    }
+
+#pragma warning restore SA1649 // File name should match first type name
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -143,7 +143,7 @@ namespace MessagePack
         public static void ConvertFromJson(TextReader reader, ref MessagePackWriter writer, MessagePackSerializerOptions options = null)
         {
             options = options ?? DefaultOptions;
-            if (options.Compression == MessagePackCompression.Lz4Block)
+            if (options.Compression.IsCompression())
             {
                 using (var scratch = new Nerdbank.Streams.Sequence<byte>())
                 {
@@ -154,7 +154,7 @@ namespace MessagePack
                     }
 
                     scratchWriter.Flush();
-                    ToLZ4BinaryCore(scratch.AsReadOnlySequence, ref writer);
+                    ToLZ4BinaryCore(scratch.AsReadOnlySequence, ref writer, options.Compression);
                 }
             }
             else

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) All contributors. All rights reserved.
+// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -81,7 +81,7 @@ namespace MessagePack
 
             try
             {
-                if (options.Compression.IsCompression())
+                if (options.Compression.IsCompression() && !PrimitiveChecker<T>.IsFixedSizePrimitive)
                 {
                     using (SequencePool.Rental sequenceRental = ReusableSequenceWithMinSize.Rent())
                     {
@@ -605,6 +605,33 @@ namespace MessagePack
                     throw new MessagePackSerializationException("Invalid MessagePackCompression Code.");
                 }
             }
+        }
+
+        private static class PrimitiveChecker<T>
+        {
+            public static readonly bool IsFixedSizePrimitive;
+
+            static PrimitiveChecker()
+            {
+                IsFixedSizePrimitive = IsFixedSizePrimitiveTypeHelper(typeof(T));
+            }
+        }
+
+        private static bool IsFixedSizePrimitiveTypeHelper(Type type)
+        {
+            return type == typeof(short)
+                || type == typeof(int)
+                || type == typeof(long)
+                || type == typeof(ushort)
+                || type == typeof(uint)
+                || type == typeof(ulong)
+                || type == typeof(float)
+                || type == typeof(double)
+                || type == typeof(bool)
+                || type == typeof(byte)
+                || type == typeof(sbyte)
+                || type == typeof(char)
+            ;
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
@@ -59,14 +59,14 @@ namespace MessagePack
         internal const sbyte UnityDouble = 39;
 
         /// <summary>
-        /// The LZ4 compression extension.
+        /// The LZ4 array block compression extension.
         /// </summary>
-        internal const sbyte LZ4Contiguous = 98;
+        internal const sbyte Lz4BlockArray = 98;
 
         /// <summary>
-        /// The LZ4 compression extension.
+        /// The LZ4 single block compression extension.
         /// </summary>
-        internal const sbyte LZ4 = 99;
+        internal const sbyte Lz4Block = 99;
 
         /// <summary>
         /// For the <see cref="Formatters.TypelessFormatter"/>.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs
@@ -61,6 +61,11 @@ namespace MessagePack
         /// <summary>
         /// The LZ4 compression extension.
         /// </summary>
+        internal const sbyte LZ4Contiguous = 98;
+
+        /// <summary>
+        /// The LZ4 compression extension.
+        /// </summary>
         internal const sbyte LZ4 = 99;
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Loader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Loader.cs
@@ -93,7 +93,7 @@ namespace Assets.Scripts.Tests
 
                 new ArrayFormatter<ComplexdUnion.A>(),
                 new ArrayFormatter<ComplexdUnion.A2>(),
-
+                new ArrayFormatter<SharedData.SimpleStringKeyData>(),
 
         },
             new IFormatterResolver[]{

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/LZ4Test.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/LZ4Test.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+#pragma warning disable SA1300 // Element should begin with uppercase letter
+
+namespace MessagePack.Tests
+{
+    public class LZ4Test
+    {
+#if !UNITY_2018_3_OR_NEWER
+
+        private readonly ITestOutputHelper logger;
+
+        public LZ4Test(ITestOutputHelper logger)
+        {
+            this.logger = logger;
+        }
+
+#endif
+
+        [Fact]
+        public void Lz4Compress()
+        {
+            Execute(1);
+            Execute(10);
+            Execute(100);
+            Execute(1000);
+            Execute(10000);
+        }
+
+        private void Execute(int count)
+        {
+            // Large
+            {
+                var data = Enumerable.Range(1, count)
+                    .Select(x => new SharedData.SimpleStringKeyData
+                    {
+                        Prop1 = x,
+                        Prop2 = SharedData.ByteEnum.A,
+                        Prop3 = unchecked(x * x),
+                    })
+                    .ToArray();
+
+                var lz4Option = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4Block);
+                var lz4Contiguous = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4ContiguousBlock);
+
+                // check bin1, 2, 3 size...
+                var bin2 = MessagePackSerializer.Serialize(data, lz4Option);
+                var bin3 = MessagePackSerializer.Serialize(data, lz4Contiguous);
+
+#if !UNITY_2018_3_OR_NEWER
+                var bin1 = MessagePackSerializer.Serialize(data, MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.None));
+                logger.WriteLine("Len:" + count + " NoneSize:" + bin1.Length);
+                logger.WriteLine("Len:" + count + " Lz4BlockSize:" + bin2.Length);
+                logger.WriteLine("Len:" + count + " Lz4ContiguousBlockSize:" + bin3.Length);
+#endif
+
+                var d1 = MessagePackSerializer.Deserialize<SharedData.SimpleStringKeyData[]>(bin2, lz4Option);
+                var d2 = MessagePackSerializer.Deserialize<SharedData.SimpleStringKeyData[]>(bin2, lz4Contiguous);
+                var d3 = MessagePackSerializer.Deserialize<SharedData.SimpleStringKeyData[]>(bin3, lz4Option);
+                var d4 = MessagePackSerializer.Deserialize<SharedData.SimpleStringKeyData[]>(bin3, lz4Contiguous);
+
+                SequenceStructuralEqual(d1, data);
+                SequenceStructuralEqual(d2, data);
+                SequenceStructuralEqual(d3, data);
+                SequenceStructuralEqual(d4, data);
+            }
+        }
+
+        private static void SequenceStructuralEqual(SharedData.SimpleStringKeyData[] actual, SharedData.SimpleStringKeyData[] expected)
+        {
+            actual.Length.Is(expected.Length);
+
+            for (int i = 0; i < actual.Length; i++)
+            {
+                actual[i].Prop1.Is(expected[i].Prop1);
+                actual[i].Prop2.Is(expected[i].Prop2);
+                actual[i].Prop3.Is(expected[i].Prop3);
+            }
+        }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/LZ4Test.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/LZ4Test.cs
@@ -46,7 +46,7 @@ namespace MessagePack.Tests
                     .ToArray();
 
                 var lz4Option = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4Block);
-                var lz4Contiguous = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4ContiguousBlock);
+                var lz4Contiguous = MessagePackSerializer.DefaultOptions.WithCompression(MessagePackCompression.Lz4BlockArray);
 
                 // check bin1, 2, 3 size...
                 var bin2 = MessagePackSerializer.Serialize(data, lz4Option);

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -504,7 +504,6 @@ MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.Lz4Block = 1 -> MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.Lz4BlockArray = 2 -> MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.None = 0 -> MessagePack.MessagePackCompression
-MessagePack.MessagePackCompressionExtensions
 MessagePack.MessagePackRange
 MessagePack.MessagePackReader
 MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
@@ -814,7 +813,6 @@ static MessagePack.Internal.UnsafeMemory64.WriteRaw8(ref MessagePack.MessagePack
 static MessagePack.Internal.UnsafeMemory64.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.MessagePackCode.ToFormatName(byte code) -> string
 static MessagePack.MessagePackCode.ToMessagePackType(byte code) -> MessagePack.MessagePackType
-static MessagePack.MessagePackCompressionExtensions.IsCompression(this MessagePack.MessagePackCompression compression) -> bool
 static MessagePack.MessagePackSerializer.ConvertFromJson(System.IO.TextReader reader, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void
 static MessagePack.MessagePackSerializer.ConvertFromJson(string str, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]
 static MessagePack.MessagePackSerializer.ConvertFromJson(string str, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -502,7 +502,9 @@ MessagePack.Internal.UnsafeMemory64
 MessagePack.MessagePackCode
 MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.Lz4Block = 1 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.Lz4ContiguousBlock = 2 -> MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.None = 0 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompressionExtensions
 MessagePack.MessagePackRange
 MessagePack.MessagePackReader
 MessagePack.MessagePackReader.CancellationToken.get -> System.Threading.CancellationToken
@@ -812,6 +814,7 @@ static MessagePack.Internal.UnsafeMemory64.WriteRaw8(ref MessagePack.MessagePack
 static MessagePack.Internal.UnsafeMemory64.WriteRaw9(ref MessagePack.MessagePackWriter writer, System.ReadOnlySpan<byte> src) -> void
 static MessagePack.MessagePackCode.ToFormatName(byte code) -> string
 static MessagePack.MessagePackCode.ToMessagePackType(byte code) -> MessagePack.MessagePackType
+static MessagePack.MessagePackCompressionExtensions.IsCompression(this MessagePack.MessagePackCompression compression) -> bool
 static MessagePack.MessagePackSerializer.ConvertFromJson(System.IO.TextReader reader, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void
 static MessagePack.MessagePackSerializer.ConvertFromJson(string str, MessagePack.MessagePackSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> byte[]
 static MessagePack.MessagePackSerializer.ConvertFromJson(string str, ref MessagePack.MessagePackWriter writer, MessagePack.MessagePackSerializerOptions options = null) -> void

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -502,7 +502,7 @@ MessagePack.Internal.UnsafeMemory64
 MessagePack.MessagePackCode
 MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.Lz4Block = 1 -> MessagePack.MessagePackCompression
-MessagePack.MessagePackCompression.Lz4ContiguousBlock = 2 -> MessagePack.MessagePackCompression
+MessagePack.MessagePackCompression.Lz4BlockArray = 2 -> MessagePack.MessagePackCompression
 MessagePack.MessagePackCompression.None = 0 -> MessagePack.MessagePackCompression
 MessagePack.MessagePackCompressionExtensions
 MessagePack.MessagePackRange

--- a/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
+++ b/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
@@ -42,7 +42,7 @@ namespace MessagePack.Tests.ExtensionTests
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
             var lz4DataReader = new MessagePackReader(lz4Data);
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
-            header.TypeCode.Is(ThisLibraryExtensionTypeCodes.LZ4);
+            header.TypeCode.Is(ThisLibraryExtensionTypeCodes.Lz4Block);
 
             var decompress = MessagePackSerializer.Deserialize<int[]>(lz4Data, LZ4Standard);
 
@@ -59,7 +59,7 @@ namespace MessagePack.Tests.ExtensionTests
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
             var lz4DataReader = new MessagePackReader(lz4Data);
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
-            header.TypeCode.Is(ThisLibraryExtensionTypeCodes.LZ4);
+            header.TypeCode.Is(ThisLibraryExtensionTypeCodes.Lz4Block);
 
             var decompress = MessagePackSerializer.Deserialize(typeof(FirstSimpleData[]), lz4Data, LZ4Standard);
 


### PR DESCRIPTION
Related to #675, #680

* Add Compression.LZ4ContiguousBlock
* Impl LZ4ContiguousBlock serialization in MessagePackSerializer
* use `ReusableSequenceWithMinSize.Rent()` instead of `new Sequence` in LZ4 compression(new Sequence is still exists in Deserialize(Stream))
* Cache LZ4Transform delegate

unit test dumps serialized binary size.
when `MinimumSpanLength = 4096`, shows this result.

```
Len:1 NoneSize:23
Len:1 Lz4BlockSize:23
Len:1 Lz4ContiguousBlockSize:23
Len:10 NoneSize:221
Len:10 Lz4BlockSize:107
Len:10 Lz4ContiguousBlockSize:110
Len:100 NoneSize:2377
Len:100 Lz4BlockSize:816
Len:100 Lz4ContiguousBlockSize:819
Len:1000 NoneSize:27085
Len:1000 Lz4BlockSize:8690
Len:1000 Lz4ContiguousBlockSize:8737
Len:10000 NoneSize:279085
Len:10000 Lz4BlockSize:86004
Len:10000 Lz4ContiguousBlockSize:88304
```