### PR TITLE
Remove private resolver list from DynamicObjectTypeFallbackFormatter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -76,6 +76,9 @@ namespace MessagePack.Formatters
             typeof(Double?),
         };
 
+        //ForceSizePrimitiveObjectResolver.Instance,
+        //ContractlessStandardResolverAllowPrivate.Instance);
+
         // mscorlib or System.Private.CoreLib
         private static readonly bool IsMscorlib = typeof(int).AssemblyQualifiedName.Contains("mscorlib");
 
@@ -135,7 +138,7 @@ namespace MessagePack.Formatters
 
             if (typeName == null)
             {
-                Resolvers.TypelessFormatterFallbackResolver.Instance.GetFormatter<object>().Serialize(ref writer, value, options);
+                DynamicObjectTypeFallbackFormatter.Instance.Serialize(ref writer, value, options);
                 return;
             }
 
@@ -228,7 +231,7 @@ namespace MessagePack.Formatters
             }
 
             // fallback
-            return Resolvers.TypelessFormatterFallbackResolver.Instance.GetFormatter<object>().Deserialize(ref reader, options);
+            return DynamicObjectTypeFallbackFormatter.Instance.Deserialize(ref reader, options);
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
@@ -25,7 +25,12 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
-        public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverCore.Instance);
+        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
+        {
+#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+            DynamicObjectResolver.Instance, // Try Object
+#endif
+        }).ToArray();
 
         static StandardResolver()
         {
@@ -52,14 +57,22 @@ namespace MessagePack.Resolvers
                 {
                     // final fallback
 #if !ENABLE_IL2CPP
-                    Formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
+                    Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
 #endif
                 }
                 else
                 {
-                    Formatter = StandardResolverCore.Instance.GetFormatter<T>();
+                    foreach (IFormatterResolver item in Resolvers)
+                    {
+                        IMessagePackFormatter<T> f = item.GetFormatter<T>();
+                        if (f != null)
+                        {
+                            Formatter = f;
+                            return;
+                        }
+                    }
                 }
             }
         }
@@ -77,13 +90,19 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
+        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
+        {
+#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+            DynamicObjectResolver.Instance, // Try Object
+            DynamicContractlessObjectResolver.Instance, // Serializes keys as strings
+#endif
+        }).ToArray();
+
         static ContractlessStandardResolver()
         {
             Instance = new ContractlessStandardResolver();
             Options = new MessagePackSerializerOptions(Instance);
         }
-
-        public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverCore.Instance);
 
         private ContractlessStandardResolver()
         {
@@ -104,14 +123,22 @@ namespace MessagePack.Resolvers
                 {
                     // final fallback
 #if !ENABLE_IL2CPP
-                    Formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
+                    Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
 #endif
                 }
                 else
                 {
-                    Formatter = ContractlessStandardResolverCore.Instance.GetFormatter<T>();
+                    foreach (IFormatterResolver item in Resolvers)
+                    {
+                        IMessagePackFormatter<T> f = item.GetFormatter<T>();
+                        if (f != null)
+                        {
+                            Formatter = f;
+                            return;
+                        }
+                    }
                 }
             }
         }
@@ -129,13 +156,18 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
+        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
+        {
+#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+            DynamicObjectResolverAllowPrivate.Instance, // Try Object
+#endif
+        }).ToArray();
+
         static StandardResolverAllowPrivate()
         {
             Instance = new StandardResolverAllowPrivate();
             Options = new MessagePackSerializerOptions(Instance);
         }
-
-        public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverAllowPrivateCore.Instance);
 
         private StandardResolverAllowPrivate()
         {
@@ -156,14 +188,22 @@ namespace MessagePack.Resolvers
                 {
                     // final fallback
 #if !ENABLE_IL2CPP
-                    Formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
+                    Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
 #endif
                 }
                 else
                 {
-                    Formatter = StandardResolverAllowPrivateCore.Instance.GetFormatter<T>();
+                    foreach (IFormatterResolver item in Resolvers)
+                    {
+                        IMessagePackFormatter<T> f = item.GetFormatter<T>();
+                        if (f != null)
+                        {
+                            Formatter = f;
+                            return;
+                        }
+                    }
                 }
             }
         }
@@ -181,13 +221,19 @@ namespace MessagePack.Resolvers
         /// </summary>
         public static readonly MessagePackSerializerOptions Options;
 
+        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
+        {
+#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+            DynamicObjectResolverAllowPrivate.Instance, // Try Object
+            DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
+#endif
+        }).ToArray();
+
         static ContractlessStandardResolverAllowPrivate()
         {
             Instance = new ContractlessStandardResolverAllowPrivate();
             Options = new MessagePackSerializerOptions(Instance);
         }
-
-        public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverAllowPrivateCore.Instance);
 
         private ContractlessStandardResolverAllowPrivate()
         {
@@ -208,14 +254,22 @@ namespace MessagePack.Resolvers
                 {
                     // final fallback
 #if !ENABLE_IL2CPP
-                    Formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
+                    Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeFallbackFormatter.Instance;
 #else
                     Formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
 #endif
                 }
                 else
                 {
-                    Formatter = ContractlessStandardResolverAllowPrivateCore.Instance.GetFormatter<T>();
+                    foreach (IFormatterResolver item in Resolvers)
+                    {
+                        IMessagePackFormatter<T> f = item.GetFormatter<T>();
+                        if (f != null)
+                        {
+                            Formatter = f;
+                            return;
+                        }
+                    }
                 }
             }
         }
@@ -247,163 +301,5 @@ namespace MessagePack.Internal
             DynamicUnionResolver.Instance, // Try Union(Interface)
 #endif
         };
-    }
-
-    internal sealed class StandardResolverCore : IFormatterResolver
-    {
-        internal static readonly StandardResolverCore Instance = new StandardResolverCore();
-
-        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
-        {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
-            DynamicObjectResolver.Instance, // Try Object
-#endif
-        }).ToArray();
-
-        private StandardResolverCore()
-        {
-        }
-
-        public IMessagePackFormatter<T> GetFormatter<T>()
-        {
-            return FormatterCache<T>.Formatter;
-        }
-
-        private static class FormatterCache<T>
-        {
-            public static readonly IMessagePackFormatter<T> Formatter;
-
-            static FormatterCache()
-            {
-                foreach (IFormatterResolver item in Resolvers)
-                {
-                    IMessagePackFormatter<T> f = item.GetFormatter<T>();
-                    if (f != null)
-                    {
-                        Formatter = f;
-                        return;
-                    }
-                }
-            }
-        }
-    }
-
-    internal sealed class ContractlessStandardResolverCore : IFormatterResolver
-    {
-        internal static readonly ContractlessStandardResolverCore Instance = new ContractlessStandardResolverCore();
-
-        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
-        {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
-            DynamicObjectResolver.Instance, // Try Object
-            DynamicContractlessObjectResolver.Instance, // Serializes keys as strings
-#endif
-        }).ToArray();
-
-        private ContractlessStandardResolverCore()
-        {
-        }
-
-        public IMessagePackFormatter<T> GetFormatter<T>()
-        {
-            return FormatterCache<T>.Formatter;
-        }
-
-        private static class FormatterCache<T>
-        {
-            public static readonly IMessagePackFormatter<T> Formatter;
-
-            static FormatterCache()
-            {
-                foreach (IFormatterResolver item in Resolvers)
-                {
-                    IMessagePackFormatter<T> f = item.GetFormatter<T>();
-                    if (f != null)
-                    {
-                        Formatter = f;
-                        return;
-                    }
-                }
-            }
-        }
-    }
-
-    internal sealed class StandardResolverAllowPrivateCore : IFormatterResolver
-    {
-        public static readonly StandardResolverAllowPrivateCore Instance = new StandardResolverAllowPrivateCore();
-
-        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
-        {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
-            DynamicObjectResolverAllowPrivate.Instance, // Try Object
-#endif
-        }).ToArray();
-
-        private StandardResolverAllowPrivateCore()
-        {
-        }
-
-        public IMessagePackFormatter<T> GetFormatter<T>()
-        {
-            return FormatterCache<T>.Formatter;
-        }
-
-        private static class FormatterCache<T>
-        {
-            public static readonly IMessagePackFormatter<T> Formatter;
-
-            static FormatterCache()
-            {
-                foreach (IFormatterResolver item in Resolvers)
-                {
-                    IMessagePackFormatter<T> f = item.GetFormatter<T>();
-                    if (f != null)
-                    {
-                        Formatter = f;
-                        return;
-                    }
-                }
-            }
-        }
-    }
-
-    internal sealed class ContractlessStandardResolverAllowPrivateCore : IFormatterResolver
-    {
-        public static readonly ContractlessStandardResolverAllowPrivateCore Instance = new ContractlessStandardResolverAllowPrivateCore();
-
-        private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
-        {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
-            DynamicObjectResolverAllowPrivate.Instance, // Try Object
-            DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
-#endif
-        }).ToArray();
-
-        private ContractlessStandardResolverAllowPrivateCore()
-        {
-        }
-
-        public IMessagePackFormatter<T> GetFormatter<T>()
-        {
-            return FormatterCache<T>.Formatter;
-        }
-
-        private static class FormatterCache<T>
-        {
-            public static readonly IMessagePackFormatter<T> Formatter;
-
-            static FormatterCache()
-            {
-                foreach (IFormatterResolver item in Resolvers)
-                {
-                    IMessagePackFormatter<T> f = item.GetFormatter<T>();
-                    if (f != null)
-                    {
-                        Formatter = f;
-                        return;
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -96,7 +96,6 @@ MessagePack.Formatters.DoubleFormatter.Deserialize(ref MessagePack.MessagePackRe
 MessagePack.Formatters.DoubleFormatter.Serialize(ref MessagePack.MessagePackWriter writer, double value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.Formatters.DynamicObjectTypeFallbackFormatter
 MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> object
-MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.DynamicObjectTypeFallbackFormatter(params MessagePack.IFormatterResolver[] innerResolvers) -> void
 MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.Formatters.EnumAsStringFormatter<T>
 MessagePack.Formatters.EnumAsStringFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> T
@@ -875,6 +874,7 @@ static readonly MessagePack.Formatters.DateTimeOffsetFormatter.Instance -> Messa
 static readonly MessagePack.Formatters.DecimalFormatter.Instance -> MessagePack.Formatters.DecimalFormatter
 static readonly MessagePack.Formatters.DoubleArrayFormatter.Instance -> MessagePack.Formatters.DoubleArrayFormatter
 static readonly MessagePack.Formatters.DoubleFormatter.Instance -> MessagePack.Formatters.DoubleFormatter
+static readonly MessagePack.Formatters.DynamicObjectTypeFallbackFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object>
 static readonly MessagePack.Formatters.ForceByteBlockFormatter.Instance -> MessagePack.Formatters.ForceByteBlockFormatter
 static readonly MessagePack.Formatters.ForceInt16BlockArrayFormatter.Instance -> MessagePack.Formatters.ForceInt16BlockArrayFormatter
 static readonly MessagePack.Formatters.ForceInt16BlockFormatter.Instance -> MessagePack.Formatters.ForceInt16BlockFormatter
@@ -950,10 +950,8 @@ static readonly MessagePack.Nil.Default -> MessagePack.Nil
 static readonly MessagePack.Resolvers.AttributeFormatterResolver.Instance -> MessagePack.Resolvers.AttributeFormatterResolver
 static readonly MessagePack.Resolvers.BuiltinResolver.Instance -> MessagePack.Resolvers.BuiltinResolver
 static readonly MessagePack.Resolvers.ContractlessStandardResolver.Instance -> MessagePack.Resolvers.ContractlessStandardResolver
-static readonly MessagePack.Resolvers.ContractlessStandardResolver.ObjectFallbackFormatter -> MessagePack.Formatters.IMessagePackFormatter<object>
 static readonly MessagePack.Resolvers.ContractlessStandardResolver.Options -> MessagePack.MessagePackSerializerOptions
 static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Instance -> MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate
-static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.ObjectFallbackFormatter -> MessagePack.Formatters.IMessagePackFormatter<object>
 static readonly MessagePack.Resolvers.ContractlessStandardResolverAllowPrivate.Options -> MessagePack.MessagePackSerializerOptions
 static readonly MessagePack.Resolvers.DynamicContractlessObjectResolver.Instance -> MessagePack.Resolvers.DynamicContractlessObjectResolver
 static readonly MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate.Instance -> MessagePack.Resolvers.DynamicContractlessObjectResolverAllowPrivate
@@ -973,10 +971,8 @@ static readonly MessagePack.Resolvers.NativeGuidResolver.Instance -> MessagePack
 static readonly MessagePack.Resolvers.PrimitiveObjectResolver.Instance -> MessagePack.Resolvers.PrimitiveObjectResolver
 static readonly MessagePack.Resolvers.PrimitiveObjectResolver.Options -> MessagePack.MessagePackSerializerOptions
 static readonly MessagePack.Resolvers.StandardResolver.Instance -> MessagePack.Resolvers.StandardResolver
-static readonly MessagePack.Resolvers.StandardResolver.ObjectFallbackFormatter -> MessagePack.Formatters.IMessagePackFormatter<object>
 static readonly MessagePack.Resolvers.StandardResolver.Options -> MessagePack.MessagePackSerializerOptions
 static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Instance -> MessagePack.Resolvers.StandardResolverAllowPrivate
-static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.ObjectFallbackFormatter -> MessagePack.Formatters.IMessagePackFormatter<object>
 static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Options -> MessagePack.MessagePackSerializerOptions
 static readonly MessagePack.Resolvers.StaticCompositeResolver.Instance -> MessagePack.Resolvers.StaticCompositeResolver
 static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance -> MessagePack.Resolvers.TypelessContractlessStandardResolver


### PR DESCRIPTION
This actually simplified several areas and allowed the removal of special "Core" resolvers.
I do not anticipate any significant perf regression from this, but it removes a large oddity about behavior of one of the formatters that made working with MessagePack a little more difficult in some cases.

Fixes #679