### PR TITLE
Remove formatter instance cache from TypelessFormatter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -41,7 +41,7 @@ namespace MessagePack.Resolvers
             DynamicObjectResolver.Instance, // Try Object
 #endif
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
-            new TypelessObjectResolver(),
+            TypelessObjectResolver.Instance,
         };
 
         static TypelessContractlessStandardResolver()

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessObjectResolver.cs
@@ -20,26 +20,16 @@ namespace MessagePack.Resolvers
     /// </summary>
     public sealed class TypelessObjectResolver : IFormatterResolver
     {
+        public static readonly IFormatterResolver Instance = new TypelessObjectResolver();
+
         private static readonly IFormatterResolver[] Resolvers = new IFormatterResolver[]
         {
             ForceSizePrimitiveObjectResolver.Instance,
             ContractlessStandardResolverAllowPrivate.Instance,
         };
 
-        /// <summary>
-        /// Backing field for the <see cref="Formatter"/> property.
-        /// </summary>
-        private TypelessFormatter formatter = new TypelessFormatter();
-
-        /// <summary>
-        /// Gets or sets the <see cref="TypelessFormatter"/> used when serializing/deserializing values typed as <see cref="object"/>/.
-        /// </summary>
-        /// <value>A instance of a formatter. Never null.</value>
-        /// <exception cref="ArgumentNullException">Thrown if assigned a value of null.</exception>
-        public TypelessFormatter Formatter
+        private TypelessObjectResolver()
         {
-            get => this.formatter;
-            set => this.formatter = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <inheritdoc />
@@ -47,7 +37,7 @@ namespace MessagePack.Resolvers
         {
             if (typeof(T) == typeof(object))
             {
-                return (IMessagePackFormatter<T>)(object)this.Formatter;
+                return (IMessagePackFormatter<T>)TypelessFormatter.Instance;
             }
             else
             {

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -416,7 +416,6 @@ MessagePack.Formatters.TwoDimensionalArrayFormatter<T>.TwoDimensionalArrayFormat
 MessagePack.Formatters.TypelessFormatter
 MessagePack.Formatters.TypelessFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> object
 MessagePack.Formatters.TypelessFormatter.Serialize(ref MessagePack.MessagePackWriter writer, object value, MessagePack.MessagePackSerializerOptions options) -> void
-MessagePack.Formatters.TypelessFormatter.TypelessFormatter() -> void
 MessagePack.Formatters.UInt16ArrayFormatter
 MessagePack.Formatters.UInt16ArrayFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> ushort[]
 MessagePack.Formatters.UInt16ArrayFormatter.Serialize(ref MessagePack.MessagePackWriter writer, ushort[] value, MessagePack.MessagePackSerializerOptions options) -> void
@@ -664,10 +663,7 @@ MessagePack.Resolvers.TypelessContractlessStandardResolver
 MessagePack.Resolvers.TypelessContractlessStandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>
 MessagePack.Resolvers.TypelessContractlessStandardResolver.TypelessContractlessStandardResolver() -> void
 MessagePack.Resolvers.TypelessObjectResolver
-MessagePack.Resolvers.TypelessObjectResolver.Formatter.get -> MessagePack.Formatters.TypelessFormatter
-MessagePack.Resolvers.TypelessObjectResolver.Formatter.set -> void
 MessagePack.Resolvers.TypelessObjectResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>
-MessagePack.Resolvers.TypelessObjectResolver.TypelessObjectResolver() -> void
 MessagePack.TinyJsonException
 MessagePack.TinyJsonException.TinyJsonException(string message) -> void
 abstract MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.Add(TIntermediate collection, int index, TElement value, MessagePack.MessagePackSerializerOptions options) -> void
@@ -935,6 +931,7 @@ static readonly MessagePack.Formatters.SingleArrayFormatter.Instance -> MessageP
 static readonly MessagePack.Formatters.SingleFormatter.Instance -> MessagePack.Formatters.SingleFormatter
 static readonly MessagePack.Formatters.StringBuilderFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Text.StringBuilder>
 static readonly MessagePack.Formatters.TimeSpanFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.TimeSpan>
+static readonly MessagePack.Formatters.TypelessFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<object>
 static readonly MessagePack.Formatters.UInt16ArrayFormatter.Instance -> MessagePack.Formatters.UInt16ArrayFormatter
 static readonly MessagePack.Formatters.UInt16Formatter.Instance -> MessagePack.Formatters.UInt16Formatter
 static readonly MessagePack.Formatters.UInt32ArrayFormatter.Instance -> MessagePack.Formatters.UInt32ArrayFormatter
@@ -977,6 +974,7 @@ static readonly MessagePack.Resolvers.StandardResolverAllowPrivate.Options -> Me
 static readonly MessagePack.Resolvers.StaticCompositeResolver.Instance -> MessagePack.Resolvers.StaticCompositeResolver
 static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Instance -> MessagePack.Resolvers.TypelessContractlessStandardResolver
 static readonly MessagePack.Resolvers.TypelessContractlessStandardResolver.Options -> MessagePack.MessagePackSerializerOptions
+static readonly MessagePack.Resolvers.TypelessObjectResolver.Instance -> MessagePack.IFormatterResolver
 virtual MessagePack.Formatters.CollectionFormatterBase<TElement, TIntermediate, TEnumerator, TCollection>.GetCount(TCollection sequence) -> int?
 virtual MessagePack.MessagePackSerializerOptions.Clone() -> MessagePack.MessagePackSerializerOptions
 virtual MessagePack.MessagePackSerializerOptions.LoadType(string typeName) -> System.Type


### PR DESCRIPTION
The `TypelessFormatter` would get its formatter objects from `options.Resolver` argument, which can of course vary from call to call. Yet this `TypelessFormatter` was stored by `TypelessObjectResolver` which in turn is stored in the static, shared `TypelessContractlessStandardResolver`. This is a big problem because that means over time using the `TypelessContractlessStandardResolver` with different resolvers passed through `options` could lead to the `TypelessFormatter` using the wrong formatters for a given serialization.

Now that these instances are truly safe to share, I made a couple more singletons.