### PR TITLE
Fix CreatePeekReader so it's truly equivalent to the original

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -117,7 +117,11 @@ namespace MessagePack
         /// The two readers may then be used independently without impacting each other.
         /// </summary>
         /// <returns>A new <see cref="MessagePackReader"/>.</returns>
-        public MessagePackReader CreatePeekReader() => this.Clone(this.reader.Sequence.Slice(this.reader.Position));
+        /// <devremarks>
+        /// Since this is a struct, copying it completely is as simple as returning itself
+        /// from a property that isn't a "ref return" property.
+        /// </devremarks>
+        public MessagePackReader CreatePeekReader() => this;
 
         /// <summary>
         /// Advances the reader to the next MessagePack primitive to be read.

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
@@ -231,6 +231,26 @@ namespace MessagePack.Tests
             AssertIncomplete((ref MessagePackWriter writer) => writer.Write(0xff), (ref MessagePackReader reader) => reader.ReadUInt64());
         }
 
+        [Fact]
+        public void CreatePeekReader()
+        {
+            var cts = new CancellationTokenSource();
+            var reader = new MessagePackReader(StringEncodedAsFixStr) { CancellationToken = cts.Token };
+            reader.ReadRaw(1); // advance to test that the peek reader starts from a non-initial position.
+            var peek = reader.CreatePeekReader();
+
+            // Verify equivalence
+            Assert.Equal(reader.CancellationToken, peek.CancellationToken);
+            Assert.Equal(reader.Position, peek.Position);
+            Assert.Equal(reader.Sequence, peek.Sequence);
+
+            // Verify that advancing the peek reader does not advance the original.
+            var originalPosition = reader.Position;
+            peek.ReadRaw(1);
+            Assert.NotEqual(originalPosition, peek.Position);
+            Assert.Equal(originalPosition, reader.Position);
+        }
+
         private delegate void ReaderOperation(ref MessagePackReader reader);
 
         private delegate T ReadOperation<T>(ref MessagePackReader reader);


### PR DESCRIPTION
This makes a pattern such as this safe:

```cs
var peekReader = reader.CreatePeekReader();
peekReader.Read*();
// This is no longer exploration. We want to continue this way.
reader = peekReader;
```