### PR TITLE
Replace all creation of Sequence<byte> except in SequencePool

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -243,8 +243,9 @@ namespace MessagePack.Formatters
                     }
                     else
                     {
-                        using (var scratch = new Nerdbank.Streams.Sequence<byte>())
+                        using (var scratchRental = SequencePool.Shared.Rent())
                         {
+                            var scratch = scratchRental.Value;
                             MessagePackWriter scratchWriter = writer.Clone(scratch);
                             var count = 0;
                             TEnumerator e = this.GetSourceEnumerator(value);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -198,12 +198,11 @@ namespace MessagePack.Formatters
             }
             else
             {
-                // Optimize iteration(array is fastest)
-                var array = value as TElement[];
-                if (array != null)
-                {
-                    IMessagePackFormatter<TElement> formatter = options.Resolver.GetFormatterWithVerify<TElement>();
+                IMessagePackFormatter<TElement> formatter = options.Resolver.GetFormatterWithVerify<TElement>();
 
+                // Optimize iteration(array is fastest)
+                if (value is TElement[] array)
+                {
                     writer.WriteArrayHeader(array.Length);
 
                     foreach (TElement item in array)
@@ -211,61 +210,19 @@ namespace MessagePack.Formatters
                         writer.CancellationToken.ThrowIfCancellationRequested();
                         formatter.Serialize(ref writer, item, options);
                     }
-
-                    return;
                 }
                 else
                 {
-                    IMessagePackFormatter<TElement> formatter = options.Resolver.GetFormatterWithVerify<TElement>();
+                    int count = this.GetCountEnumerateIfNecessary(value);
+                    writer.WriteArrayHeader(count);
 
-                    // knows count or not.
-                    var seqCount = this.GetCount(value);
-                    if (seqCount != null)
+                    // Unity's foreach struct enumerator causes boxing so iterate manually.
+                    using (var e = this.GetSourceEnumerator(value))
                     {
-                        writer.WriteArrayHeader(seqCount.Value);
-
-                        // Unity's foreach struct enumerator causes boxing so iterate manually.
-                        TEnumerator e = this.GetSourceEnumerator(value);
-                        try
+                        while (e.MoveNext())
                         {
-                            while (e.MoveNext())
-                            {
-                                writer.CancellationToken.ThrowIfCancellationRequested();
-                                formatter.Serialize(ref writer, e.Current, options);
-                            }
-                        }
-                        finally
-                        {
-                            e.Dispose();
-                        }
-
-                        return;
-                    }
-                    else
-                    {
-                        using (var scratchRental = SequencePool.Shared.Rent())
-                        {
-                            var scratch = scratchRental.Value;
-                            MessagePackWriter scratchWriter = writer.Clone(scratch);
-                            var count = 0;
-                            TEnumerator e = this.GetSourceEnumerator(value);
-                            try
-                            {
-                                while (e.MoveNext())
-                                {
-                                    writer.CancellationToken.ThrowIfCancellationRequested();
-                                    count++;
-                                    formatter.Serialize(ref scratchWriter, e.Current, options);
-                                }
-                            }
-                            finally
-                            {
-                                e.Dispose();
-                            }
-
-                            scratchWriter.Flush();
-                            writer.WriteArrayHeader(count);
-                            writer.WriteRaw(scratch.AsReadOnlySequence);
+                            writer.CancellationToken.ThrowIfCancellationRequested();
+                            formatter.Serialize(ref writer, e.Current, options);
                         }
                     }
                 }
@@ -324,6 +281,24 @@ namespace MessagePack.Formatters
         protected abstract void Add(TIntermediate collection, int index, TElement value, MessagePackSerializerOptions options);
 
         protected abstract TCollection Complete(TIntermediate intermediateCollection);
+
+        private int GetCountEnumerateIfNecessary(TCollection sequence)
+        {
+            int? count = this.GetCount(sequence);
+            if (!count.HasValue)
+            {
+                count = 0;
+                using (var e = this.GetSourceEnumerator(sequence))
+                {
+                    while (e.MoveNext())
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count.Value;
+        }
     }
 
     public abstract class CollectionFormatterBase<TElement, TIntermediate, TCollection> : CollectionFormatterBase<TElement, TIntermediate, IEnumerator<TElement>, TCollection>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -182,15 +182,15 @@ namespace MessagePack.Formatters
             }
 
             // mark will be written at the end, when size is known
-            using (var scratch = new Nerdbank.Streams.Sequence<byte>())
+            using (var scratchRental = SequencePool.Shared.Rent())
             {
-                MessagePackWriter scratchWriter = writer.Clone(scratch);
+                MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                 scratchWriter.WriteString(typeName);
                 serializeMethod(formatter, ref scratchWriter, value, options);
                 scratchWriter.Flush();
 
                 // mark as extension with code 100
-                writer.WriteExtensionFormat(new ExtensionResult((sbyte)ThisLibraryExtensionTypeCodes.TypelessFormatter, scratch.AsReadOnlySequence));
+                writer.WriteExtensionFormat(new ExtensionResult((sbyte)ThisLibraryExtensionTypeCodes.TypelessFormatter, scratchRental.Value));
             }
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -20,15 +20,15 @@ namespace MessagePack
         /// </summary>
         public static void SerializeToJson<T>(TextWriter textWriter, T obj, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
-            using (var sequence = new Sequence<byte>())
+            using (var sequenceRental = SequencePool.Shared.Rent())
             {
-                var msgpackWriter = new MessagePackWriter(sequence)
+                var msgpackWriter = new MessagePackWriter(sequenceRental.Value)
                 {
                     CancellationToken = cancellationToken,
                 };
                 Serialize(ref msgpackWriter, obj, options);
                 msgpackWriter.Flush();
-                var msgpackReader = new MessagePackReader(sequence.AsReadOnlySequence)
+                var msgpackReader = new MessagePackReader(sequenceRental.Value)
                 {
                     CancellationToken = cancellationToken,
                 };
@@ -78,11 +78,11 @@ namespace MessagePack
             options = options ?? DefaultOptions;
             if (options.Compression == MessagePackCompression.Lz4Block)
             {
-                using (var scratch = new Nerdbank.Streams.Sequence<byte>())
+                using (var scratchRental = SequencePool.Shared.Rent())
                 {
-                    if (TryDecompress(ref reader, scratch))
+                    if (TryDecompress(ref reader, scratchRental.Value))
                     {
-                        var scratchReader = new MessagePackReader(scratch.AsReadOnlySequence)
+                        var scratchReader = new MessagePackReader(scratchRental.Value)
                         {
                             CancellationToken = reader.CancellationToken,
                         };
@@ -121,9 +121,9 @@ namespace MessagePack
         /// </summary>
         public static byte[] ConvertFromJson(string str, MessagePackSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
-            using (var seq = new Sequence<byte>())
+            using (var scratchRental = SequencePool.Shared.Rent())
             {
-                var writer = new MessagePackWriter(seq)
+                var writer = new MessagePackWriter(scratchRental.Value)
                 {
                     CancellationToken = cancellationToken,
                 };
@@ -133,7 +133,7 @@ namespace MessagePack
                 }
 
                 writer.Flush();
-                return seq.AsReadOnlySequence.ToArray();
+                return scratchRental.Value.AsReadOnlySequence.ToArray();
             }
         }
 
@@ -145,16 +145,16 @@ namespace MessagePack
             options = options ?? DefaultOptions;
             if (options.Compression.IsCompression())
             {
-                using (var scratch = new Nerdbank.Streams.Sequence<byte>())
+                using (var scratchRental = SequencePool.Shared.Rent())
                 {
-                    MessagePackWriter scratchWriter = writer.Clone(scratch);
+                    MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                     using (var jr = new TinyJsonReader(reader, false))
                     {
                         FromJsonCore(jr, ref scratchWriter);
                     }
 
                     scratchWriter.Flush();
-                    ToLZ4BinaryCore(scratch.AsReadOnlySequence, ref writer, options.Compression);
+                    ToLZ4BinaryCore(scratchRental.Value, ref writer, options.Compression);
                 }
             }
             else
@@ -177,15 +177,15 @@ namespace MessagePack
                         break;
                     case TinyJsonToken.StartObject:
                         // Set up a scratch area to serialize the collection since we don't know its length yet, which must be written first.
-                        using (var scratch = new Sequence<byte>())
+                        using (var scratchRental = SequencePool.Shared.Rent())
                         {
-                            MessagePackWriter scratchWriter = writer.Clone(scratch);
+                            MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                             var mapCount = FromJsonCore(jr, ref scratchWriter);
                             scratchWriter.Flush();
 
                             mapCount = mapCount / 2; // remove propertyname string count.
                             writer.WriteMapHeader(mapCount);
-                            writer.WriteRaw(scratch.AsReadOnlySequence);
+                            writer.WriteRaw(scratchRental.Value);
                         }
 
                         count++;
@@ -194,14 +194,14 @@ namespace MessagePack
                         return count; // break
                     case TinyJsonToken.StartArray:
                         // Set up a scratch area to serialize the collection since we don't know its length yet, which must be written first.
-                        using (var scratch = new Sequence<byte>())
+                        using (var scratchRental = SequencePool.Shared.Rent())
                         {
-                            MessagePackWriter scratchWriter = writer.Clone(scratch);
+                            MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                             var arrayCount = FromJsonCore(jr, ref scratchWriter);
                             scratchWriter.Flush();
 
                             writer.WriteArrayHeader(arrayCount);
-                            writer.WriteRaw(scratch.AsReadOnlySequence);
+                            writer.WriteRaw(scratchRental.Value);
                         }
 
                         count++;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -18,12 +18,12 @@ namespace MessagePack
 
         internal static byte[] GetWriterBytes<TArg>(TArg arg, GetWriterBytesAction<TArg> action)
         {
-            using (var sequence = new Sequence<byte>())
+            using (var sequenceRental = SequencePool.Shared.Rent())
             {
-                var writer = new MessagePackWriter(sequence);
+                var writer = new MessagePackWriter(sequenceRental.Value);
                 action(ref writer, arg);
                 writer.Flush();
-                return sequence.AsReadOnlySequence.ToArray();
+                return sequenceRental.Value.AsReadOnlySequence.ToArray();
             }
         }
     }

--- a/src/MessagePack/BannedSymbols.txt
+++ b/src/MessagePack/BannedSymbols.txt
@@ -1,0 +1,1 @@
+﻿M:Nerdbank.Streams.Sequence`1.#ctor; Use SequencePool.Shared.Rent() instead


### PR DESCRIPTION
This promotes much better recycling of arrays and ensures that all arrays have a minimum length so we don't get hundreds of tiny arrays for some users.

I also add a BannedSymbols.txt file so that any attempt to accidentally use "new Sequence<byte>()" will result in a compiler error/warning with advice on what to use instead.
I do this instead of simply removing the API or making any other change to the `Sequence<T>` class so it can stay nearly identical with the implementation found in Nerdbank.Streams, so we can keep it up to date as fixes are made to the original one.

Fixes #688