### PR TITLE
StaticCompositeResolver.Register -> StaticCompositeResolver.Instance.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,7 +1247,7 @@ Here is sample of configuration.
 StaticCompositeResolver.Instance.Register(
     MessagePack.Unity.UnityResolver.Instance,
     MessagePack.Unity.Extension.UnityBlitWithPrimitiveArrayResolver.Instance,
-    MessagePack.Resolvers.StandardResolver.Instance,
+    MessagePack.Resolvers.StandardResolver.Instance
 );
 
 var options = MessagePackSerializerOptions.Standard.WithResolver(StaticCompositeResolver.Instance);
@@ -1324,7 +1324,7 @@ By default, `mpc.exe` generates resolver to `MessagePack.Resolvers.GeneratedReso
 StaticCompositeResolver.Instance.Register(new IFormatterResolver[]
 {
     MessagePack.Resolvers.GeneratedResolver.Instance,
-    MessagePack.Resolvers.StandardResolver.Instance,
+    MessagePack.Resolvers.StandardResolver.Instance
 });
 
 // Store it for reuse.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StaticCompositeResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StaticCompositeResolver.cs
@@ -26,41 +26,41 @@ namespace MessagePack.Resolvers
 
         /// <summary>
         /// Initializes a singleton instance with the specified formatters.
-        /// This method can only call before use StaticCompositeResolver.Instance.
+        /// This method can only call before use StaticCompositeResolver.Instance.GetFormatter.
         /// If call twice in the Register methods, registered formatters and resolvers will be overridden.
         /// </summary>
         /// <param name="formatters">
         /// A list of instances of <see cref="IMessagePackFormatter{T}"/>.
         /// The formatters are searched in the order given, so if two formatters support serializing the same type, the first one is used.
         /// </param>
-        public static void Register(params IMessagePackFormatter[] formatters)
+        public void Register(params IMessagePackFormatter[] formatters)
         {
-            if (Instance.freezed)
+            if (this.freezed)
             {
                 throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
             }
 
-            if (formatters is null)
+            if (this.formatters is null)
             {
                 throw new ArgumentNullException(nameof(formatters));
             }
 
-            Instance.formatters = formatters;
-            Instance.resolvers = Array.Empty<IFormatterResolver>();
+            this.formatters = formatters;
+            this.resolvers = Array.Empty<IFormatterResolver>();
         }
 
         /// <summary>
         /// Initializes a singleton instance with the specified formatters and sub-resolvers.
-        /// This method can only call before use StaticCompositeResolver.Instance.
+        /// This method can only call before use StaticCompositeResolver.Instance.GetFormatter.
         /// If call twice in the Register methods, registered formatters and resolvers will be overridden.
         /// </summary>
         /// <param name="resolvers">
         /// A list of resolvers to use for serializing types.
         /// The resolvers are searched in the order given, so if two resolvers support serializing the same type, the first one is used.
         /// </param>
-        public static void Register(params IFormatterResolver[] resolvers)
+        public void Register(params IFormatterResolver[] resolvers)
         {
-            if (Instance.freezed)
+            if (this.freezed)
             {
                 throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
             }
@@ -70,13 +70,13 @@ namespace MessagePack.Resolvers
                 throw new ArgumentNullException(nameof(resolvers));
             }
 
-            Instance.formatters = Array.Empty<IMessagePackFormatter>();
-            Instance.resolvers = resolvers;
+            this.formatters = Array.Empty<IMessagePackFormatter>();
+            this.resolvers = resolvers;
         }
 
         /// <summary>
         /// Initializes a singleton instance with the specified formatters and sub-resolvers.
-        /// This method can only call before use StaticCompositeResolver.Instance.
+        /// This method can only call before use StaticCompositeResolver.Instance.GetFormatter.
         /// If call twice in the Register methods, registered formatters and resolvers will be overridden.
         /// </summary>
         /// <param name="formatters">
@@ -87,9 +87,9 @@ namespace MessagePack.Resolvers
         /// A list of resolvers to use for serializing types for which <paramref name="formatters"/> does not include a formatter.
         /// The resolvers are searched in the order given, so if two resolvers support serializing the same type, the first one is used.
         /// </param>
-        public static void Register(IReadOnlyList<IMessagePackFormatter> formatters, IReadOnlyList<IFormatterResolver> resolvers)
+        public void Register(IReadOnlyList<IMessagePackFormatter> formatters, IReadOnlyList<IFormatterResolver> resolvers)
         {
-            if (Instance.freezed)
+            if (this.freezed)
             {
                 throw new InvalidOperationException("Register must call on startup(before use GetFormatter<T>).");
             }
@@ -104,8 +104,8 @@ namespace MessagePack.Resolvers
                 throw new ArgumentNullException(nameof(resolvers));
             }
 
-            Instance.formatters = formatters;
-            Instance.resolvers = resolvers;
+            this.formatters = formatters;
+            this.resolvers = resolvers;
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Loader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Loader.cs
@@ -18,7 +18,7 @@ namespace Assets.Scripts.Tests
             // adhoc resolver registration to running test.
 #if ENABLE_IL2CPP
 
-            StaticCompositeResolver.Register(new IMessagePackFormatter[]{
+            StaticCompositeResolver.Instance.Register(new IMessagePackFormatter[]{
                 new ListFormatter<int>(),
                 new LinkedListFormatter<int>(),
                 new QueueFormatter<int>(),

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -663,6 +663,9 @@ MessagePack.Resolvers.StandardResolverAllowPrivate
 MessagePack.Resolvers.StandardResolverAllowPrivate.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>
 MessagePack.Resolvers.StaticCompositeResolver
 MessagePack.Resolvers.StaticCompositeResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>
+MessagePack.Resolvers.StaticCompositeResolver.Register(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter> formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver> resolvers) -> void
+MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.Formatters.IMessagePackFormatter[] formatters) -> void
+MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.IFormatterResolver[] resolvers) -> void
 MessagePack.Resolvers.TypelessContractlessStandardResolver
 MessagePack.Resolvers.TypelessContractlessStandardResolver.GetFormatter<T>() -> MessagePack.Formatters.IMessagePackFormatter<T>
 MessagePack.Resolvers.TypelessContractlessStandardResolver.TypelessContractlessStandardResolver() -> void
@@ -854,9 +857,6 @@ static MessagePack.MessagePackSerializerOptions.Standard.get -> MessagePack.Mess
 static MessagePack.Resolvers.CompositeResolver.Create(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter> formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver> resolvers) -> MessagePack.IFormatterResolver
 static MessagePack.Resolvers.CompositeResolver.Create(params MessagePack.Formatters.IMessagePackFormatter[] formatters) -> MessagePack.IFormatterResolver
 static MessagePack.Resolvers.CompositeResolver.Create(params MessagePack.IFormatterResolver[] resolvers) -> MessagePack.IFormatterResolver
-static MessagePack.Resolvers.StaticCompositeResolver.Register(System.Collections.Generic.IReadOnlyList<MessagePack.Formatters.IMessagePackFormatter> formatters, System.Collections.Generic.IReadOnlyList<MessagePack.IFormatterResolver> resolvers) -> void
-static MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.Formatters.IMessagePackFormatter[] formatters) -> void
-static MessagePack.Resolvers.StaticCompositeResolver.Register(params MessagePack.IFormatterResolver[] resolvers) -> void
 static readonly MessagePack.Formatters.BigIntegerFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Numerics.BigInteger>
 static readonly MessagePack.Formatters.BitArrayFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.BitArray>
 static readonly MessagePack.Formatters.BooleanArrayFormatter.Instance -> MessagePack.Formatters.BooleanArrayFormatter


### PR DESCRIPTION
ReadMe was written `StaticCompositeResolver.Instance.Register` but current implementation is `StaticCompositeResolver.Register`.
There are 3 choices

* Fix ReadMe
* Fix Implementation
* Add both(static and instance methods)

I chose static method is same as previous API(`CompositeResolver.Register`)
but I think `StaticCompositeResolver.Instance.Register` is better, intuitive.
Therefore, this PR changed the implementation.