### PR TITLE
Fix System.PlatformNotSupportedException when StandardResolver is initialized.

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs
@@ -27,7 +27,7 @@ namespace MessagePack.Resolvers
 
         private static readonly IFormatterResolver[] Resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !NETSTANDARD2_0
             DynamicObjectResolver.Instance, // Try Object
 #endif
         }).ToArray();
@@ -289,7 +289,7 @@ namespace MessagePack.Internal
             MessagePack.Unity.UnityResolver.Instance,
 #endif
 
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !NETSTANDARD2_0
             DynamicEnumResolver.Instance, // Try Enum
 #endif
 
@@ -297,7 +297,7 @@ namespace MessagePack.Internal
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection, Enum(Generic Fallback)
 #endif
 
-#if !ENABLE_IL2CPP && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !NETSTANDARD2_0
             DynamicUnionResolver.Instance, // Try Union(Interface)
 #endif
         };


### PR DESCRIPTION
**Bug description**
Dynamic resolvers are not excluded from the `StandardResolver` when targeting .NetStandard2.0 because of the misspell of the framework symbol. `System.PlatformNotSupportedException` is thrown when `StandardResolver` is initialized.

**Repro steps**
`var resolver = Resolvers.StandardResolver.Instance;`

**Expected behavior**
No exception thrown.

**Actual behavior**
`System.PlatformNotSupportedException` was thrown.

**Remarks**
According to the doc, the spelling should be `NETSTANDARD2_0`
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-if

Fix #701 