### PR TITLE
Always copy arrays from the underlying sequence

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)MessagePack.ruleset</CodeAnalysisRuleSet>
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -81,23 +81,7 @@ namespace MessagePack.Formatters
 
         public ArraySegment<byte> Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
-            ReadOnlySequence<byte>? bytes = reader.ReadBytes();
-            if (bytes.HasValue)
-            {
-                // Don't allocate and copy an array if we can return a segment directly into the sequence.
-                if (bytes.Value.IsSingleSegment && MemoryMarshal.TryGetArray(bytes.Value.First, out ArraySegment<byte> segment))
-                {
-                    return segment;
-                }
-                else
-                {
-                    return new ArraySegment<byte>(bytes.Value.ToArray());
-                }
-            }
-            else
-            {
-                return default;
-            }
+            return reader.ReadBytes() is ReadOnlySequence<byte> bytes ? new ArraySegment<byte>(bytes.ToArray()) : default;
         }
     }
 


### PR DESCRIPTION
Even if we *can* find an array segment from contiguous memory, the `ReadOnlySequence<byte>` we deserialize from is only guaranteed to not be recycled during deserialization. So we must not deserialize values that share memory with it.

Fixes #712