### PR TITLE
Make MessagePackWriter's GetSpan and Advance methods public

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1070,6 +1070,28 @@ namespace MessagePack
         }
 
         /// <summary>
+        /// Gets memory where raw messagepack data can be written.
+        /// </summary>
+        /// <param name="length">The size of the memory block required.</param>
+        /// <returns>The span of memory to write to. This *may* exceed <paramref name="length"/>.</returns>
+        /// <remarks>
+        /// <para>After initializing the resulting memory, always follow up with a call to <see cref="Advance(int)"/>.</para>
+        /// <para>
+        /// This is similar in purpose to <see cref="WriteRaw(ReadOnlySpan{byte})"/>
+        /// but provides uninitialized memory for the caller to write to instead of copying initialized memory from elsewhere.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="IBufferWriter{T}.GetSpan(int)"/>
+        public Span<byte> GetSpan(int length) => this.writer.GetSpan(length);
+
+        /// <summary>
+        /// Commits memory previously returned from <see cref="GetSpan(int)"/> as initialized.
+        /// </summary>
+        /// <param name="length">The number of bytes initialized with messagepack data from the previously returned span.</param>
+        /// <seealso cref="IBufferWriter{T}.Advance(int)"/>
+        public void Advance(int length) => this.writer.Advance(length);
+
+        /// <summary>
         /// Writes a 16-bit integer in big endian format.
         /// </summary>
         /// <param name="value">The integer.</param>
@@ -1101,10 +1123,6 @@ namespace MessagePack
             WriteBigEndian(value, span);
             this.writer.Advance(8);
         }
-
-        internal Span<byte> GetSpan(int length) => this.writer.GetSpan(length);
-
-        internal void Advance(int length) => this.writer.Advance(length);
 
         internal byte[] FlushAndGetArray()
         {

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -580,10 +580,12 @@ MessagePack.MessagePackType.Nil = 2 -> MessagePack.MessagePackType
 MessagePack.MessagePackType.String = 5 -> MessagePack.MessagePackType
 MessagePack.MessagePackType.Unknown = 0 -> MessagePack.MessagePackType
 MessagePack.MessagePackWriter
+MessagePack.MessagePackWriter.Advance(int length) -> void
 MessagePack.MessagePackWriter.CancellationToken.get -> System.Threading.CancellationToken
 MessagePack.MessagePackWriter.CancellationToken.set -> void
 MessagePack.MessagePackWriter.Clone(System.Buffers.IBufferWriter<byte> writer) -> MessagePack.MessagePackWriter
 MessagePack.MessagePackWriter.Flush() -> void
+MessagePack.MessagePackWriter.GetSpan(int length) -> System.Span<byte>
 MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte> writer) -> void
 MessagePack.MessagePackWriter.OldSpec.get -> bool
 MessagePack.MessagePackWriter.OldSpec.set -> void


### PR DESCRIPTION
This can provide a more convenient API when callers want to write raw messagepack to the final underyling buffers instead of an intermediate buffer only to then copy it in using `WriteRaw`.

Closes #711

Also closes #485 by providing a reasonable alternative to accepting a `stackalloc` allocated span from callers, since they can write to our own internal buffers directly.