### PR TITLE
Avoid infinite loop when IBufferWriter<T>.GetMemory returns empty memory

### DIFF
--- a/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\StringEncoding.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\DateTimeConstants.cs" />
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\GuidBits.cs" />
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Utilities.cs" Link="Utilities.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
@@ -61,7 +61,7 @@ namespace MessagePack
             _sequencePool = default;
             _rental = default;
 
-            var memory = _output.GetMemory();
+            var memory = _output.GetMemoryCheckResult();
             MemoryMarshal.TryGetArray(memory, out _segment);
             _span = memory.Span;
         }
@@ -216,7 +216,7 @@ namespace MessagePack
                 this.MigrateToSequence();
             }
 
-            var memory = _output.GetMemory(count);
+            var memory = _output.GetMemoryCheckResult(count);
             MemoryMarshal.TryGetArray(memory, out _segment);
             _span = memory.Span;
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Buffers;
-using MessagePack.Formatters;
-using Microsoft;
-using Nerdbank.Streams;
 
 namespace MessagePack
 {
@@ -25,6 +22,17 @@ namespace MessagePack
                 writer.Flush();
                 return sequenceRental.Value.AsReadOnlySequence.ToArray();
             }
+        }
+
+        internal static Memory<T> GetMemoryCheckResult<T>(this IBufferWriter<T> bufferWriter, int size = 0)
+        {
+            var memory = bufferWriter.GetMemory(size);
+            if (memory.IsEmpty)
+            {
+                throw new InvalidOperationException("The underlying IBufferWriter<byte>.GetMemory(int) method returned an empty memory block, which is not allowed. This is a bug in " + bufferWriter.GetType().FullName);
+            }
+
+            return memory;
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
@@ -111,5 +111,31 @@ namespace MessagePack.Tests
             writer.CancellationToken = cts.Token;
             Assert.Equal(cts.Token, writer.CancellationToken);
         }
+
+        [Fact]
+        public void TryWriteWithBuggyWriter()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var writer = new MessagePackWriter(new BuggyBufferWriter());
+                writer.WriteRaw(new byte[10]);
+            });
+        }
+
+        /// <summary>
+        /// Besides being effectively a no-op, this <see cref="IBufferWriter{T}"/>
+        /// is buggy because it can return empty arrays, which should never happen.
+        /// A sizeHint=0 means give me whatever memory is available, but should never be empty.
+        /// </summary>
+        private class BuggyBufferWriter : IBufferWriter<byte>
+        {
+            public void Advance(int count)
+            {
+            }
+
+            public Memory<byte> GetMemory(int sizeHint = 0) => new byte[sizeHint];
+
+            public Span<byte> GetSpan(int sizeHint = 0) => new byte[sizeHint];
+        }
     }
 }


### PR DESCRIPTION
Fixes #710