### PR TITLE
Preserve types of integers when using typeless resolver

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -32,6 +32,7 @@ namespace MessagePack.Resolvers
         private static readonly IReadOnlyList<IFormatterResolver> Resolvers = new IFormatterResolver[]
         {
             NativeDateTimeResolver.Instance, // Native c# DateTime format, preserving timezone
+            ForceSizePrimitiveObjectResolver.Instance, // Preserve particular integer types
             BuiltinResolver.Instance, // Try Builtin
             AttributeFormatterResolver.Instance, // Try use [MessagePackFormatter]
 #if !ENABLE_IL2CPP

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
@@ -47,6 +47,22 @@ public class MessagePackSerializerTypelessTests
         Assert.DoesNotContain(ThisAssembly.AssemblyVersion, json);
     }
 
+    [Theory]
+    [InlineData((sbyte)1)]
+    [InlineData((byte)1)]
+    [InlineData((short)1)]
+    [InlineData((ushort)1)]
+    [InlineData((int)1)]
+    [InlineData((uint)1)]
+    [InlineData((long)1)]
+    [InlineData((ulong)1)]
+    public void PrimitiveIntTypePreservation(object boxedValue)
+    {
+        object roundTripValue = MessagePackSerializer.Typeless.Deserialize(MessagePackSerializer.Typeless.Serialize(boxedValue));
+        Assert.Equal(boxedValue, roundTripValue);
+        Assert.IsType(boxedValue.GetType(), roundTripValue);
+    }
+
     public class MyObject
     {
         public object SomeValue { get; set; }


### PR DESCRIPTION
Although the `ForceSizePrimitiveObjectResolver` was already in the resolver chain, it was via `TypelessObjectResolver` which was the first last resolver, and the `BuiltinResolver` which was earlier in the chain answered the call for integer formatters before it ever got to the `TypelessObjectResolver`, so all integers were serialized using the most compact mechanism rather than the type-preserving one.

Related to #425 