### PR TITLE
MessagePack.AspNetCoreMvcFormatter supports AspNetCore3 BodyWriter

### DIFF
--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePack.AspNetCoreMvcFormatter.csproj
@@ -1,20 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Title>ASP.NET Core MVC Input/Output MessagePack formatter</Title>
     <Description>ASP.NET Core MVC Input/Output MessagePack formatter.</Description>
     <PackageTags>MsgPack;MessagePack;Serialization;Formatter;Serializer;aspnetcore;aspnetcoremvc</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.2" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)'=='netcoreapp3.0'">
+      <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.2" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <ProjectReference Include="..\MessagePack\MessagePack.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
@@ -41,17 +41,37 @@ namespace MessagePack.AspNetCoreMvcFormatter
             {
                 if (context.Object == null)
                 {
+#if NETSTANDARD2_0
                     context.HttpContext.Response.Body.WriteByte(MessagePackCode.Nil);
                     return Task.CompletedTask;
+#else
+                    var writer = context.HttpContext.Response.BodyWriter;
+                    var span = writer.GetSpan(1);
+                    span[0] = MessagePackCode.Nil;
+                    writer.Advance(1);
+                    return writer.FlushAsync().AsTask();
+#endif
                 }
                 else
                 {
+#if NETSTANDARD2_0
                     return MessagePackSerializer.SerializeAsync(context.Object.GetType(), context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
+#else
+                    var writer = context.HttpContext.Response.BodyWriter;
+                    MessagePackSerializer.Serialize(context.Object.GetType(), writer, context.Object, this.options, context.HttpContext.RequestAborted);
+                    return writer.FlushAsync().AsTask();
+#endif
                 }
             }
             else
             {
+#if NETSTANDARD2_0
                 return MessagePackSerializer.SerializeAsync(context.ObjectType, context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
+#else
+                var writer = context.HttpContext.Response.BodyWriter;
+                MessagePackSerializer.Serialize(context.ObjectType, writer, context.Object, this.options, context.HttpContext.RequestAborted);
+                return writer.FlushAsync().AsTask();
+#endif
             }
         }
     }


### PR DESCRIPTION
AspNetCore3 exposes BodyWriter and MessagePack v2 supports IBufferWriter directly.
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/request-response?view=aspnetcore-3.1

This change uses `HttpContext.Response.BodyWriter` on OutputFormatter.
In the case of `InputFormatter`, MessagePack read Stream fully and cache to the internal pool so doesn't use BodyReader.