### PR TITLE
Fix mpc and more details to ReadMe

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -183,6 +183,11 @@ namespace MessagePackCompiler
 
                     await OutputToDirAsync(output, resolverTemplate.Namespace, resolverTemplate.ResolverName, multioutSymbol, resolverTemplate.TransformText(), cancellationToken).ConfigureAwait(false);
                 }
+
+                if (objectInfo.Length == 0 && enumInfo.Length == 0 && genericInfo.Length == 0 & unionInfo.Length == 0)
+                {
+                    logger("Generated result is empty, unexpected result?");
+                }
             }
 
             logger("Output Generation Complete:" + sw.Elapsed.ToString());

--- a/src/MessagePack.GeneratorCore/MessagePackCompilation.cs
+++ b/src/MessagePack.GeneratorCore/MessagePackCompilation.cs
@@ -74,7 +74,10 @@ namespace MessagePackCompiler
                 syntaxTrees.Add(CSharpSyntaxTree.ParseText(DummyAnnotation, parseOption));
             }
 
-            foreach (var item in locations.Select(Path.GetFullPath).Distinct().Where(x => !x.Contains("MonoBleedingEdge")))
+            // ignore Unity's default metadatas(to avoid conflict .NET Core runtime import)
+            // MonoBleedingEdge = .NET 4.x Unity metadata
+            // 2.0.0 = .NET Standard 2.0 Unity metadata
+            foreach (var item in locations.Select(Path.GetFullPath).Distinct().Where(x => !(x.Contains("MonoBleedingEdge") || x.Contains("2.0.0"))))
             {
                 metadata.Add(MetadataReference.CreateFromFile(item));
             }


### PR DESCRIPTION
related to #727
mpc does not work on .NET Standard 2.0 Unity project because that duplicate assembly load both .NET Core runtime and unity shims.
already mpc has avoided duplicate load code in .NET 4.6 project, so use same path on .NET Standard 2.0.

and add ReadMe to full sample initialize code(automaticaly initialize on play mode and editor mode).