### PR TITLE
Add a prefix to the property names to avoid name conflicts.

### DIFF
--- a/src/MessagePack.MSBuild.Tasks/build/MessagePack.MSBUild.Tasks.props
+++ b/src/MessagePack.MSBuild.Tasks/build/MessagePack.MSBUild.Tasks.props
@@ -1,9 +1,9 @@
-﻿<Project TreatAsLocalProperty="TaskFolder;TaskAssembly">
+﻿<Project TreatAsLocalProperty="_MessagePackGeneratorTaskFolder;_MessagePackGeneratorTaskAssembly">
 
   <PropertyGroup>
-    <TaskFolder>netstandard2.0</TaskFolder>
-    <TaskAssembly>$(MSBuildThisFileDirectory)..\tasks\$(TaskFolder)\MessagePack.MSBuild.Tasks.dll</TaskAssembly>
+    <_MessagePackGeneratorTaskFolder>netstandard2.0</_MessagePackGeneratorTaskFolder>
+    <_MessagePackGeneratorTaskAssembly>$(MSBuildThisFileDirectory)..\tasks\$(_MessagePackGeneratorTaskFolder)\MessagePack.MSBuild.Tasks.dll</_MessagePackGeneratorTaskAssembly>
   </PropertyGroup>
 
-  <UsingTask TaskName="MessagePack.MSBuild.Tasks.MessagePackGenerator" AssemblyFile="$(TaskAssembly)" />
+  <UsingTask TaskName="MessagePack.MSBuild.Tasks.MessagePackGenerator" AssemblyFile="$(_MessagePackGeneratorTaskAssembly)" />
 </Project>


### PR DESCRIPTION
When `TaskFolder` or `TaskAssembly` property is used in another `*.Tasks.props`, the task will not work properly.