### PR TITLE
Fix duplicate header read in `ConvertToJson` in ext format

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -404,12 +404,12 @@ namespace MessagePack
 #endif
                     else
                     {
-                        ExtensionResult ext = reader.ReadExtensionFormat();
+                        var data = reader.ReadRaw((long)extHeader.Length);
                         writer.Write("[");
-                        writer.Write(ext.TypeCode);
+                        writer.Write(extHeader.TypeCode);
                         writer.Write(",");
                         writer.Write("\"");
-                        writer.Write(Convert.ToBase64String(ext.Data.ToArray()));
+                        writer.Write(Convert.ToBase64String(data.ToArray()));
                         writer.Write("\"");
                         writer.Write("]");
                     }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ToJsonTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ToJsonTest.cs
@@ -65,5 +65,29 @@ namespace MessagePack.Tests
             this.JsonConvert(inputJson, MessagePackSerializerOptions.Standard).Is(expectedRoundTripJson);
             this.JsonConvert(inputJson, LZ4Standard).Is(expectedRoundTripJson);
         }
+
+        [Fact]
+        public void ExtJson()
+        {
+            var sequence = new Sequence<byte>();
+            var writer = new MessagePackWriter(sequence);
+            writer.WriteExtensionFormat(new ExtensionResult(47, new byte[] { 1, 10, 100 }));
+            writer.Flush();
+
+            var msgpack = sequence.AsReadOnlySequence;
+            var str = MessagePackSerializer.ConvertToJson(msgpack);
+            var b64 = Convert.ToBase64String(new byte[] { 1, 10, 100 });
+
+            str.Is(@"[47,""" + b64 + @"""]");
+        }
+
+        [Fact]
+        public void DateTimeJson()
+        {
+            var now = new DateTime(1999, 12, 19, 11, 19, 19, DateTimeKind.Utc);
+            var bin = MessagePackSerializer.Serialize(now);
+            var json = MessagePackSerializer.ConvertToJson(bin);
+            json.Is(@"""1999-12-19T11:19:19.0000000Z""");
+        }
     }
 }


### PR DESCRIPTION
```csharp
writer.WriteExtensionFormat(new ExtensionResult(47, new byte[] { 1, 10, 100 }));
writer.Flush();
// exception
var str = MessagePackSerializer.ConvertToJson(sequence.AsReadOnlySequence);
```

throws exception when call `ConvertToJson` when target block is ext format.

because it read extension header twice.

```csharp
var header = reader.ReadExtensionFormatHeader();
var ext = reader.ReadExtensionFormat();
```

This PR fixed it and add tests.