### PR TITLE
Simplify CompositeResolver.Create

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -146,30 +146,17 @@ namespace MessagePack.Internal
             var hash = key.GetHashCode();
             Entry entry = table[hash & table.Length - 1];
 
-            if (entry == null)
+            while (entry != null)
             {
-                goto NOT_FOUND;
-            }
-
-            if (entry.Key == key)
-            {
-                value = entry.Value;
-                return true;
-            }
-
-            Entry next = entry.Next;
-            while (next != null)
-            {
-                if (next.Key == key)
+                if (entry.Key == key)
                 {
-                    value = next.Value;
+                    value = entry.Value;
                     return true;
                 }
 
-                next = next.Next;
+                entry = entry.Next;
             }
 
-NOT_FOUND:
             value = default(TValue);
             return false;
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 #pragma warning disable SA1649 // File name should match first type name
 
@@ -138,6 +139,7 @@ namespace MessagePack.Internal
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(Type key, out TValue value)
         {
             Entry[] table = this.buckets;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using MessagePack.Formatters;
+using MessagePack.Internal;
 
 namespace MessagePack.Resolvers
 {
@@ -17,9 +16,6 @@ namespace MessagePack.Resolvers
     /// <remarks>
     /// This class is not thread-safe for mutations. It is thread-safe when not being written to.
     /// </remarks>
-#if ENABLE_IL2CPP
-    [Obsolete("CompositeResolver is not supported in IL2CPP, use StaticCompositeResolver instead.", false)]
-#endif
     public static class CompositeResolver
     {
         private static readonly ReadOnlyDictionary<Type, IMessagePackFormatter> EmptyFormattersByType = new ReadOnlyDictionary<Type, IMessagePackFormatter>(new Dictionary<Type, IMessagePackFormatter>());
@@ -52,105 +48,60 @@ namespace MessagePack.Resolvers
                 throw new ArgumentNullException(nameof(resolvers));
             }
 
-            var formattersByType = new Dictionary<Type, IMessagePackFormatter>();
-            foreach (IMessagePackFormatter formatter in formatters)
-            {
-                if (formatter == null)
-                {
-                    throw new ArgumentException("An element in the array is null.", nameof(formatters));
-                }
-
-                bool foundAny = false;
-                foreach (Type implInterface in formatter.GetType().GetTypeInfo().ImplementedInterfaces)
-                {
-                    TypeInfo ti = implInterface.GetTypeInfo();
-                    if (ti.IsGenericType && ti.GetGenericTypeDefinition() == typeof(IMessagePackFormatter<>))
-                    {
-                        foundAny = true;
-                        if (!formattersByType.ContainsKey(ti.GenericTypeArguments[0]))
-                        {
-                            formattersByType.Add(ti.GenericTypeArguments[0], formatter);
-                        }
-                    }
-                }
-
-                if (!foundAny)
-                {
-                    throw new ArgumentException("No formatters found on this object: " + formatter.GetType().FullName, nameof(formatter));
-                }
-            }
-
             // Make a copy of the resolvers list provided by the caller to guard against them changing it later.
-            var immutableResolvers = new ReadOnlyCollection<IFormatterResolver>(resolvers.ToArray());
+            var immutableFormatters = formatters.ToArray();
+            var immutableResolvers = resolvers.ToArray();
 
-            // Return a type optimized for no formatters if applicable.
-            return formattersByType.Count > 0
-                ? (IFormatterResolver)new CachingResolver(new ReadOnlyDictionary<Type, IMessagePackFormatter>(formattersByType), immutableResolvers)
-                : new CachingResolverWithNoFormatters(immutableResolvers);
+            return new CachingResolver(immutableFormatters, immutableResolvers);
         }
 
         public static IFormatterResolver Create(params IFormatterResolver[] resolvers) => Create(Array.Empty<IMessagePackFormatter>(), resolvers);
 
         public static IFormatterResolver Create(params IMessagePackFormatter[] formatters) => Create(formatters, Array.Empty<IFormatterResolver>());
 
-        private class CachingResolver : CachingFormatterResolver
+        private class CachingResolver : IFormatterResolver
         {
-            private readonly ReadOnlyDictionary<Type, IMessagePackFormatter> formattersByType;
-            private readonly ReadOnlyCollection<IFormatterResolver> subResolvers;
+            private readonly ThreadsafeTypeKeyHashTable<IMessagePackFormatter> formattersCache = new ThreadsafeTypeKeyHashTable<IMessagePackFormatter>();
+            private readonly IMessagePackFormatter[] subFormatters;
+            private readonly IFormatterResolver[] subResolvers;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="CachingResolver"/> class.
             /// </summary>
-            internal CachingResolver(ReadOnlyDictionary<Type, IMessagePackFormatter> formattersByType, ReadOnlyCollection<IFormatterResolver> subResolvers)
+            internal CachingResolver(IMessagePackFormatter[] subFormatters, IFormatterResolver[] subResolvers)
             {
-                this.formattersByType = formattersByType ?? throw new ArgumentNullException(nameof(formattersByType));
+                this.subFormatters = subFormatters ?? throw new ArgumentNullException(nameof(subFormatters));
                 this.subResolvers = subResolvers ?? throw new ArgumentNullException(nameof(subResolvers));
             }
 
-            /// <inheritdoc/>
-            protected override IMessagePackFormatter<T> GetFormatterCore<T>()
+            public IMessagePackFormatter<T> GetFormatter<T>()
             {
-                if (!this.formattersByType.TryGetValue(typeof(T), out IMessagePackFormatter formatter))
+                if (!this.formattersCache.TryGetValue(typeof(T), out IMessagePackFormatter formatter))
                 {
+                    foreach (var subFormatter in this.subFormatters)
+                    {
+                        if (subFormatter is IMessagePackFormatter<T>)
+                        {
+                            formatter = subFormatter;
+                            goto CACHE;
+                        }
+                    }
+
                     foreach (IFormatterResolver resolver in this.subResolvers)
                     {
                         formatter = resolver.GetFormatter<T>();
                         if (formatter != null)
                         {
-                            break;
+                            goto CACHE;
                         }
                     }
+
+// when not found, cache null.
+CACHE:
+                    this.formattersCache.TryAdd(typeof(T), formatter);
                 }
 
                 return (IMessagePackFormatter<T>)formatter;
-            }
-        }
-
-        private class CachingResolverWithNoFormatters : CachingFormatterResolver
-        {
-            private readonly ReadOnlyCollection<IFormatterResolver> subResolvers;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="CachingResolverWithNoFormatters"/> class.
-            /// </summary>
-            internal CachingResolverWithNoFormatters(ReadOnlyCollection<IFormatterResolver> subResolvers)
-            {
-                this.subResolvers = subResolvers ?? throw new ArgumentNullException(nameof(subResolvers));
-            }
-
-            /// <inheritdoc/>
-            protected override IMessagePackFormatter<T> GetFormatterCore<T>()
-            {
-                foreach (IFormatterResolver resolver in this.subResolvers)
-                {
-                    IMessagePackFormatter<T> formatter = resolver.GetFormatter<T>();
-                    if (formatter != null)
-                    {
-                        return (IMessagePackFormatter<T>)formatter;
-                    }
-                }
-
-                return null;
             }
         }
     }


### PR DESCRIPTION
`CompsoiteResolver.GetFormatterCore` throws AOT exception in Unity IL2CPP.
To fix it, simplify code.