### PR TITLE
Fix MessagePackStreamReader to not throw given certain message boundaries

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -142,6 +142,11 @@ namespace MessagePack
         /// </remarks>
         internal bool TrySkip()
         {
+            if (this.reader.Remaining == 0)
+            {
+                return false;
+            }
+
             byte code = this.NextCode;
             switch (code)
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs
@@ -131,6 +131,17 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        public async Task ReadAsync_EveryTruncationPositionPossible()
+        {
+            using (var reader = new MessagePackStreamReader(new OneByteAtATimeStream(this.twoMessages)))
+            {
+                Assert.True((await reader.ReadAsync(this.timeoutToken)).HasValue);
+                Assert.True((await reader.ReadAsync(this.timeoutToken)).HasValue);
+                Assert.False((await reader.ReadAsync(this.timeoutToken)).HasValue);
+            }
+        }
+
+        [Fact]
         public void DisposeClosesStream()
         {
             var ms = new MemoryStream();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OneByteAtATimeStream.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OneByteAtATimeStream.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MessagePack.Tests
+{
+    internal class OneByteAtATimeStream : Stream
+    {
+        private readonly ReadOnlySequence<byte> source;
+
+        private SequencePosition position;
+
+        internal OneByteAtATimeStream(ReadOnlySequence<byte> source)
+        {
+            this.source = source;
+            this.position = source.Start;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (this.position.Equals(this.source.End))
+            {
+                return Task.FromResult(0);
+            }
+
+            buffer[offset] = this.source.Slice(this.position, 1).First.Span[0];
+            this.position = this.source.GetPosition(1, this.position);
+            return Task.FromResult(1);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
When the available buffer happens to end just before an array or map element, we would throw an exception. This fixes that to just wait for more bytes.

Fixes #764