### PR TITLE
Add `MessagePackReader.TryRead*Header` methods

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionHeader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionHeader.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MessagePack
 {
 #if MESSAGEPACK_INTERNAL
@@ -8,7 +10,7 @@ namespace MessagePack
 #else
     public
 #endif
-    struct ExtensionHeader
+    struct ExtensionHeader : IEquatable<ExtensionHeader>
     {
         public sbyte TypeCode { get; private set; }
 
@@ -25,5 +27,7 @@ namespace MessagePack
             this.TypeCode = typeCode;
             this.Length = (uint)length;
         }
+
+        public bool Equals(ExtensionHeader other) => this.TypeCode == other.TypeCode && this.Length == other.Length;
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExtensionHeaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExtensionHeaderTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class ExtensionHeaderTests
+    {
+        [Fact]
+        public void Ctor_SByte_Int()
+        {
+            var eh = new ExtensionHeader(1, 2);
+            Assert.Equal(1, eh.TypeCode);
+            Assert.Equal(2u, eh.Length);
+        }
+
+        [Fact]
+        public void Ctor_SByte_UInt()
+        {
+            var eh = new ExtensionHeader(1, 2u);
+            Assert.Equal(1, eh.TypeCode);
+            Assert.Equal(2u, eh.Length);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var eh1 = new ExtensionHeader(1, 2);
+            var eh2 = new ExtensionHeader(2, 2);
+            var eh3 = new ExtensionHeader(1, 1);
+
+            Assert.True(eh1.Equals(eh1));
+            Assert.False(eh1.Equals(eh2));
+            Assert.False(eh1.Equals(eh3));
+            Assert.False(eh2.Equals(eh3));
+        }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
@@ -90,6 +90,7 @@ namespace MessagePack.Tests
 
             var header = new ExtensionHeader(-1, 10);
             writer.WriteExtensionFormatHeader(header);
+            writer.WriteRaw(new byte[10]);
             writer.Flush();
 
             var written = sequence.AsReadOnlySequence;

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -1,2 +1,6 @@
-﻿MessagePack.MessagePackReader.ReadDateTime(MessagePack.ExtensionHeader header) -> System.DateTime
+﻿MessagePack.ExtensionHeader.Equals(MessagePack.ExtensionHeader other) -> bool
+MessagePack.MessagePackReader.ReadDateTime(MessagePack.ExtensionHeader header) -> System.DateTime
+MessagePack.MessagePackReader.TryReadArrayHeader(out int count) -> bool
+MessagePack.MessagePackReader.TryReadExtensionFormatHeader(out MessagePack.ExtensionHeader extensionHeader) -> bool
+MessagePack.MessagePackReader.TryReadMapHeader(out int count) -> bool
 MessagePack.MessagePackStreamReader.ReadArrayAsync(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<System.Buffers.ReadOnlySequence<byte>>


### PR DESCRIPTION
These methods already existed internally. This change makes them public, adds tests, and moves the trailing length checks into the non-Try methods so that streaming reads of arrays and maps don't have to read more bytes than are absolutely necessary for the headers.

This change also updates `ReadExtensionFormatHeader` to include the same kind of buffer length check that `ReadArrayHeader` and `ReadMapHeader` had.

Fixes #723