### PR TITLE
Bring back serialization of members with explicit attributes 

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1533,6 +1533,7 @@ namespace MessagePack.Internal
                             throw new MessagePackDynamicObjectResolverException("all public members must mark KeyAttribute or IgnoreMemberAttribute." + " type: " + type.FullName + " member:" + item.Name);
                         }
 
+                        member.IsExplicitContract = true;
                         if (key.IntKey == null && key.StringKey == null)
                         {
                             throw new MessagePackDynamicObjectResolverException("both IntKey and StringKey are null." + " type: " + type.FullName + " member:" + item.Name);
@@ -1548,6 +1549,8 @@ namespace MessagePack.Internal
                             // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
                             continue;
                         }
+
+                        member.IsExplicitContract = true;
 
                         // use Order first
                         if (pseudokey.Order != -1)
@@ -1643,6 +1646,7 @@ namespace MessagePack.Internal
                             throw new MessagePackDynamicObjectResolverException("all public members must mark KeyAttribute or IgnoreMemberAttribute." + " type: " + type.FullName + " member:" + item.Name);
                         }
 
+                        member.IsExplicitContract = true;
                         if (key.IntKey == null && key.StringKey == null)
                         {
                             throw new MessagePackDynamicObjectResolverException("both IntKey and StringKey are null." + " type: " + type.FullName + " member:" + item.Name);
@@ -1658,6 +1662,8 @@ namespace MessagePack.Internal
                             // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
                             continue;
                         }
+
+                        member.IsExplicitContract = true;
 
                         // use Order first
                         if (pseudokey.Order != -1)
@@ -1869,7 +1875,7 @@ namespace MessagePack.Internal
                 BestmatchConstructor = ctor,
                 ConstructorParameters = constructorParameters.ToArray(),
                 IsIntKey = isIntKey,
-                Members = members.Where(m => constructorParameters.Contains(m) || m.IsWritable).ToArray(),
+                Members = members.Where(m => m.IsExplicitContract || constructorParameters.Contains(m) || m.IsWritable).ToArray(),
             };
         }
 
@@ -1937,6 +1943,11 @@ namespace MessagePack.Internal
                     return mi.DeclaringType.GetTypeInfo().IsValueType;
                 }
             }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether this member is explicitly opted in with an attribute.
+            /// </summary>
+            public bool IsExplicitContract { get; set; }
 
             public MessagePackFormatterAttribute GetMessagePackFormatterAttribute()
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !ENABLE_IL2CPP
+
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MessagePack.Tests
+{
+    public class DynamicObjectResolverTests
+    {
+        private readonly ITestOutputHelper logger;
+
+        public DynamicObjectResolverTests(ITestOutputHelper logger)
+        {
+            this.logger = logger;
+        }
+
+        [Fact]
+        public void SerializeTypeWithReadOnlyField()
+        {
+            Assert3MemberClassSerializedContent(MessagePackSerializer.Serialize(new TestMessageWithReadOnlyField()));
+        }
+
+        [Fact]
+        public void SerializeTypeWithReadOnlyProperty()
+        {
+            Assert3MemberClassSerializedContent(MessagePackSerializer.Serialize(new TestMessageWithReadOnlyProperty()));
+        }
+
+        [Fact]
+        public void SerializeTypeWithReadWriteFields()
+        {
+            Assert3MemberClassSerializedContent(MessagePackSerializer.Serialize(new TestMessageWithReadWriteFields()));
+        }
+
+        private static void Assert3MemberClassSerializedContent(ReadOnlyMemory<byte> msgpack)
+        {
+            var reader = new MessagePackReader(msgpack);
+            Assert.Equal(3, reader.ReadArrayHeader());
+            Assert.Equal(1, reader.ReadInt32());
+            Assert.Equal(2, reader.ReadInt32());
+            Assert.Equal(3, reader.ReadInt32());
+        }
+
+        [MessagePackObject]
+        public class TestMessageWithReadOnlyField
+        {
+            [Key(0)]
+            public int Field1 = 1;
+
+            [Key(1)]
+            public readonly int Field2 = 2;
+
+            [Key(2)]
+            public int Field3 = 3;
+        }
+
+        [MessagePackObject]
+        public class TestMessageWithReadWriteFields
+        {
+            [Key(0)]
+            public int Property1 = 1;
+
+            [Key(1)]
+            public int Property2 = 2;
+
+            [Key(2)]
+            public int Property3 = 3;
+        }
+
+        [MessagePackObject]
+        public class TestMessageWithReadOnlyProperty
+        {
+            [Key(0)]
+            public int Property1 { get; set; } = 1;
+
+            [Key(1)]
+            public int Property2 => 2;
+
+            [Key(2)]
+            public int Property3 { get; set; } = 3;
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
In #582, @rohahn made a change that changed v1.8 behavior in what *appears* to not be important to the focus of that pull request. In this PR I try to split the difference to bring back some v1.8 behavior without regressing any of the tests @rohahn added in #582.

Fixes #766