### PR TITLE
Improve performance of standard decimal serialization by using Utf8Formatter

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -111,12 +111,14 @@ namespace MessagePack.Formatters
             var dest = writer.GetSpan(MessagePackRange.MaxFixStringLength);
             if (System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(1), out var written))
             {
-                // write string header
+                // write header
                 dest[0] = (byte)(MessagePackCode.MinFixStr | written);
                 writer.Advance(written + 1);
             }
             else
             {
+                // reset writer's span previously acquired that does not use
+                writer.Advance(0);
                 writer.Write(value.ToString(CultureInfo.InvariantCulture));
             }
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -184,21 +184,7 @@ namespace MessagePack.Formatters
                 }
             }
 
-            // fallback
-            {
-                var seqLen = (int)sequence.Length;
-                var rentArray = ArrayPool<byte>.Shared.Rent(seqLen);
-                try
-                {
-                    sequence.CopyTo(rentArray);
-                    var str = Encoding.UTF8.GetString(rentArray.AsSpan(0, seqLen));
-                    return decimal.Parse(str, CultureInfo.InvariantCulture);
-                }
-                finally
-                {
-                    ArrayPool<byte>.Shared.Return(rentArray);
-                }
-            }
+            throw new MessagePackSerializationException("Can't parse to decimal, input string was not in a correct format.");
         }
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -165,7 +165,19 @@ namespace MessagePack.Formatters
             }
 
             // fallback
-            return decimal.Parse(reader.ReadString(), CultureInfo.InvariantCulture);
+            {
+                var rentArray = ArrayPool<byte>.Shared.Rent((int)sequence.Length);
+                try
+                {
+                    sequence.CopyTo(rentArray);
+                    var str = Encoding.UTF8.GetString(rentArray.AsSpan(0, (int)sequence.Length));
+                    return decimal.Parse(str, CultureInfo.InvariantCulture);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(rentArray);
+                }
+            }
         }
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -108,12 +108,63 @@ namespace MessagePack.Formatters
 
         public void Serialize(ref MessagePackWriter writer, decimal value, MessagePackSerializerOptions options)
         {
-            writer.Write(value.ToString(CultureInfo.InvariantCulture));
-            return;
+            var dest = writer.GetSpan(MessagePackRange.MaxFixStringLength);
+            if (System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(1), out var written))
+            {
+                // write string header
+                dest[0] = (byte)(MessagePackCode.MinFixStr | written);
+                writer.Advance(written + 1);
+            }
+            else
+            {
+                writer.Write(value.ToString(CultureInfo.InvariantCulture));
+            }
         }
 
         public decimal Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
+            if (!(reader.ReadStringSequence() is ReadOnlySequence<byte> sequence))
+            {
+                throw new MessagePackSerializationException(string.Format("Unexpected msgpack code {0} ({1}) encountered.", MessagePackCode.Nil, MessagePackCode.ToFormatName(MessagePackCode.Nil)));
+            }
+
+            if (sequence.IsSingleSegment)
+            {
+                if (System.Buffers.Text.Utf8Parser.TryParse(sequence.First.Span, out decimal result, out _))
+                {
+                    return result;
+                }
+            }
+            else
+            {
+                if (sequence.Length < 128)
+                {
+                    Span<byte> span = stackalloc byte[(int)sequence.Length];
+                    sequence.CopyTo(span);
+                    if (System.Buffers.Text.Utf8Parser.TryParse(span, out decimal result, out _))
+                    {
+                        return result;
+                    }
+                }
+                else
+                {
+                    var rentArray = ArrayPool<byte>.Shared.Rent((int)sequence.Length);
+                    try
+                    {
+                        sequence.CopyTo(rentArray);
+                        if (System.Buffers.Text.Utf8Parser.TryParse(rentArray.AsSpan(0, (int)sequence.Length), out decimal result, out _))
+                        {
+                            return result;
+                        }
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(rentArray);
+                    }
+                }
+            }
+
+            // fallback
             return decimal.Parse(reader.ReadString(), CultureInfo.InvariantCulture);
         }
     }


### PR DESCRIPTION
use Utf8Formatter instead of ToString to avoid string allocation. #776 
Utf8Formatter also has Guid format but Guid is already using custom direct encoder/decoder.