### PR TITLE
improve BigInteger serialize in .NET Core

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -465,6 +465,22 @@ namespace MessagePack.Formatters
 
         public void Serialize(ref MessagePackWriter writer, System.Numerics.BigInteger value, MessagePackSerializerOptions options)
         {
+#if NETCOREAPP2_1
+            if (!writer.OldSpec)
+            {
+                // try to get bin8 buffer.
+                var span = writer.GetSpan(byte.MaxValue);
+                if (value.TryWriteBytes(span.Slice(2), out var written))
+                {
+                    span[0] = MessagePackCode.Bin8;
+                    span[1] = (byte)written;
+
+                    writer.Advance(written + 2);
+                    return;
+                }
+            }
+#endif
+
             writer.Write(value.ToByteArray());
             return;
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -478,6 +478,11 @@ namespace MessagePack.Formatters
                     writer.Advance(written + 2);
                     return;
                 }
+                else
+                {
+                    // reset writer's span previously acquired that does not use
+                    writer.Advance(0);
+                }
             }
 #endif
 


### PR DESCRIPTION
Similar as #777, use `BigInteger.TryWriteBytes` in `NETCOREAPP2_1` to avoid byte array allocation.