### PR TITLE
Respect EnumMemberAttribute when serializing enum values as strings

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/EnumAsStringFormatter`1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/EnumAsStringFormatter`1.cs
@@ -8,13 +8,14 @@ using System.Runtime.Serialization;
 
 namespace MessagePack.Formatters
 {
-    // Note:This implemenataion is 'not' fastest, should more improve.
+    // Note:This implementation is 'not' fastest, should more improve.
     public sealed class EnumAsStringFormatter<T> : IMessagePackFormatter<T>
     {
         private readonly Dictionary<string, T> nameValueMapping;
         private readonly Dictionary<T, string> valueNameMapping;
         private readonly Dictionary<string, T> enumMemberMapping;
         private readonly Dictionary<string, string> nameToEnumMemberMapping;
+
         public EnumAsStringFormatter()
         {
             Type type = typeof(T);
@@ -23,7 +24,7 @@ namespace MessagePack.Formatters
             this.nameValueMapping = new Dictionary<string, T>(names.Length);
             this.valueNameMapping = new Dictionary<T, string>();
             enumMemberMapping = new Dictionary<string, T>();
-            nameToEnumMemberMapping=new Dictionary<string, string>();
+            nameToEnumMemberMapping = new Dictionary<string, string>();
             for (int i = 0; i < names.Length; i++)
             {
                 this.nameValueMapping[names[i]] = (T)values.GetValue(i);
@@ -32,14 +33,13 @@ namespace MessagePack.Formatters
                 if (em != null)
                 {
                     enumMemberMapping.Add(em.Value, (T)values.GetValue(i));
-                    nameToEnumMemberMapping.Add(names[i],em.Value);
+                    nameToEnumMemberMapping.Add(names[i], em.Value);
                 }
             }
         }
 
         public void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
         {
-
             if (!this.nameToEnumMemberMapping.TryGetValue(value.ToString(), out var name))
             {
                 if (!this.valueNameMapping.TryGetValue(value, out name))
@@ -60,6 +60,7 @@ namespace MessagePack.Formatters
             {
                 return value;
             }
+
             if (!this.nameValueMapping.TryGetValue(name, out value))
             {
                 value = (T)Enum.Parse(typeof(T), name); // Enum.Parse is too slow

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
@@ -106,8 +106,8 @@ namespace MessagePack.Tests
             new object[] { AsStringFlagWithEnumMember.Bar, AsStringFlagWithEnumMember.Baz, "BarValue", "BazValue" },
             new object[] { AsStringFlagWithEnumMember.FooBar, AsStringFlagWithEnumMember.FooBaz, "FooBarValue", "FooBazValue" },
             new object[] { AsStringFlagWithEnumMember.BarBaz, AsStringFlagWithEnumMember.FooBarBaz, "BarBazValue", "FooBarBazValue" },
-            new object[] { AsStringFlagWithEnumMember.Bar | AsStringFlagWithEnumMember.FooBaz, AsStringFlagWithEnumMember.BarBaz | AsStringFlagWithEnumMember.FooBarBaz, "Bar, FooBaz", "BarBaz, FooBarBaz" },
-            new object[] { (AsStringFlagWithEnumMember)10, (AsStringFlagWithEnumMember)999, "Baz, FooBaz", "999" },
+            new object[] { AsStringFlagWithEnumMember.Bar | AsStringFlagWithEnumMember.FooBaz, AsStringFlagWithEnumMember.BarBaz | AsStringFlagWithEnumMember.FooBarBaz, "BarValue, FooBazValue", "BarBazValue, FooBarBazValue" },
+            new object[] { (AsStringFlagWithEnumMember)10, (AsStringFlagWithEnumMember)999, "BazValue, FooBazValue", "999" },
         };
 
         [Theory]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
@@ -39,6 +39,25 @@ namespace MessagePack.Tests
     }
 
     [Flags]
+    public enum AsStringFlagWithEnumMember
+    {
+        [EnumMember(Value = "FooValue")]
+        Foo = 0,
+        [EnumMember(Value = "BarValue")]
+        Bar = 1,
+        [EnumMember(Value = "BazValue")]
+        Baz = 2,
+        [EnumMember(Value = "FooBarValue")]
+        FooBar = 4,
+        [EnumMember(Value = "FooBazValue")]
+        FooBaz = 8,
+        [EnumMember(Value = "BarBazValue")]
+        BarBaz = 16,
+        [EnumMember(Value = "FooBarBazValue")]
+        FooBarBaz = 32,
+    }
+
+    [Flags]
     public enum AsStringFlag
     {
         Foo = 0,
@@ -80,7 +99,15 @@ namespace MessagePack.Tests
             new object[] { AsStringWithEnumMember.BarBaz, AsStringWithEnumMember.FooBarBaz, "BarBazValue", "FooBarBazValue" },
             new object[] { (AsStringWithEnumMember)10, (AsStringWithEnumMember)999, "10", "999" },
             new object[] { (AsStringWithEnumMember)10, (AsStringWithEnumMember)999, "10", "999" },
-            new object[] { (AsStringWithEnumMember)7, (AsStringWithEnumMember)7, "FooBarBazOther", "FooBarBazOther" },
+            new object[] { AsStringWithEnumMember.FooBarBazOther, AsStringWithEnumMember.FooBarBazOther, "FooBarBazOther", "FooBarBazOther" },
+
+            // flags (for flags enumMember is partially supported)
+            new object[] { AsStringFlagWithEnumMember.Foo, null, "FooValue", "null" },
+            new object[] { AsStringFlagWithEnumMember.Bar, AsStringFlagWithEnumMember.Baz, "BarValue", "BazValue" },
+            new object[] { AsStringFlagWithEnumMember.FooBar, AsStringFlagWithEnumMember.FooBaz, "FooBarValue", "FooBazValue" },
+            new object[] { AsStringFlagWithEnumMember.BarBaz, AsStringFlagWithEnumMember.FooBarBaz, "BarBazValue", "FooBarBazValue" },
+            new object[] { AsStringFlagWithEnumMember.Bar | AsStringFlagWithEnumMember.FooBaz, AsStringFlagWithEnumMember.BarBaz | AsStringFlagWithEnumMember.FooBarBaz, "Bar, FooBaz", "BarBaz, FooBarBaz" },
+            new object[] { (AsStringFlagWithEnumMember)10, (AsStringFlagWithEnumMember)999, "Baz, FooBaz", "999" },
         };
 
         [Theory]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs
@@ -72,7 +72,6 @@ namespace MessagePack.Tests
             new object[] { (AsStringFlag)10, (AsStringFlag)999, "Baz, FooBaz", "999" },
         };
 
-
         public static object[][] EnumDataForEnumMember =
         {
             new object[] { AsStringWithEnumMember.Foo, null, "FooValue", "null" },


### PR DESCRIPTION
Fix neuecc/MessagePack-CSharp#788

Added an EnumMember dictionary to string/Value to check existence of value.

in Serialize method:if enumMember exist use it as the name to serialize other wise same flow.
in Deserialize method: if value exist return it  otherwise same flow.

all unit tests were run locally.