### PR TITLE
Add the leaveOpen flag to MessagePackStreamReader

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -20,16 +20,25 @@ namespace MessagePack
     public partial class MessagePackStreamReader : IDisposable
     {
         private readonly Stream stream;
+        private readonly bool leaveOpen;
         private SequencePool.Rental sequenceRental = SequencePool.Shared.Rent();
         private SequencePosition? endOfLastMessage;
-        private bool leaveOpen;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
+        /// </summary>
+        /// <param name="stream">The stream to read from. This stream will be disposed of when this <see cref="MessagePackStreamReader"/> is disposed.</param>
+        public MessagePackStreamReader(Stream stream)
+            : this(stream, leaveOpen: false)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
         /// </summary>
         /// <param name="stream">The stream to read from.</param>
-        /// <param name="leaveOpen">If true, leaves the stream open after the reader object is disposed; otherwise, false.</param>
-        public MessagePackStreamReader(Stream stream, bool leaveOpen = false)
+        /// <param name="leaveOpen">If true, leaves the stream open after this <see cref="MessagePackStreamReader"/> is disposed; otherwise, false.</param>
+        public MessagePackStreamReader(Stream stream, bool leaveOpen)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
             this.leaveOpen = leaveOpen;
@@ -88,7 +97,7 @@ namespace MessagePack
             {
                 this.stream.Dispose();
             }
-            
+
             this.sequenceRental.Dispose();
             this.sequenceRental = default;
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -22,14 +22,17 @@ namespace MessagePack
         private readonly Stream stream;
         private SequencePool.Rental sequenceRental = SequencePool.Shared.Rent();
         private SequencePosition? endOfLastMessage;
+        private bool leaveOpen;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
         /// </summary>
         /// <param name="stream">The stream to read from.</param>
-        public MessagePackStreamReader(Stream stream)
+        /// <param name="leaveOpen">If true, leaves the stream open after the reader object is disposed; otherwise, false.</param>
+        public MessagePackStreamReader(Stream stream, bool leaveOpen = false)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            this.leaveOpen = leaveOpen;
         }
 
         /// <summary>
@@ -81,7 +84,11 @@ namespace MessagePack
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.stream.Dispose();
+            if (!this.leaveOpen)
+            {
+                this.stream.Dispose();
+            }
+            
             this.sequenceRental.Dispose();
             this.sequenceRental = default;
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -90,6 +90,20 @@ namespace MessagePack
             }
         }
 
+        /// <summary>
+        /// Arranges for the next read operation to start by reading from the underlying <see cref="Stream"/>
+        /// instead of any data buffered from a previous read.
+        /// </summary>
+        /// <remarks>
+        /// This is appropriate if the underlying <see cref="Stream"/> has been repositioned such that
+        /// any previously buffered data is no longer applicable to what the caller wants to read.
+        /// </remarks>
+        public void DiscardBufferedData()
+        {
+            this.sequenceRental.Value.Reset();
+            this.endOfLastMessage = default;
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs
@@ -146,5 +146,13 @@ namespace MessagePack.Tests
             new MessagePackStreamReader(ms).Dispose();
             Assert.False(ms.CanSeek);
         }
+
+        [Fact]
+        public void DisposeDoesNotCloseStream_IfAskedNotTo()
+        {
+            var ms = new MemoryStream();
+            new MessagePackStreamReader(ms, leaveOpen: true).Dispose();
+            Assert.True(ms.CanSeek);
+        }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs
@@ -140,6 +140,26 @@ namespace MessagePack.Tests
         }
 
         [Fact]
+        public async Task DiscardBufferedData()
+        {
+            var ms = new MemoryStream(this.twoMessages.ToArray());
+            using (var reader = new MessagePackStreamReader(ms))
+            {
+                var message1a = await reader.ReadAsync(this.TimeoutToken);
+                Assert.NotNull(message1a);
+                Assert.Equal(this.twoMessages.Slice(0, this.messagePositions[0]).ToArray(), message1a.Value.ToArray());
+
+                ms.Position = 0;
+                reader.DiscardBufferedData();
+
+                // Verify that we can read the message at the start of the new position.
+                var message1b = await reader.ReadAsync(this.TimeoutToken);
+                Assert.NotNull(message1b);
+                Assert.Equal(this.twoMessages.Slice(0, this.messagePositions[0]).ToArray(), message1b.Value.ToArray());
+            }
+        }
+
+        [Fact]
         public void DisposeClosesStream()
         {
             var ms = new MemoryStream();

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ MessagePack.MessagePackReader.ReadDateTime(MessagePack.ExtensionHeader header) -
 MessagePack.MessagePackReader.TryReadArrayHeader(out int count) -> bool
 MessagePack.MessagePackReader.TryReadExtensionFormatHeader(out MessagePack.ExtensionHeader extensionHeader) -> bool
 MessagePack.MessagePackReader.TryReadMapHeader(out int count) -> bool
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen) -> void
 MessagePack.MessagePackStreamReader.ReadArrayAsync(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<System.Buffers.ReadOnlySequence<byte>>
 MessagePack.MessagePackWriter.WriteBinHeader(int length) -> void
 MessagePack.MessagePackWriter.WriteStringHeader(int byteCount) -> void

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -7,6 +7,7 @@ MessagePack.MessagePackReader.ReadDateTime(MessagePack.ExtensionHeader header) -
 MessagePack.MessagePackReader.TryReadArrayHeader(out int count) -> bool
 MessagePack.MessagePackReader.TryReadExtensionFormatHeader(out MessagePack.ExtensionHeader extensionHeader) -> bool
 MessagePack.MessagePackReader.TryReadMapHeader(out int count) -> bool
+MessagePack.MessagePackStreamReader.DiscardBufferedData() -> void
 MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen) -> void
 MessagePack.MessagePackStreamReader.ReadArrayAsync(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<System.Buffers.ReadOnlySequence<byte>>
 MessagePack.MessagePackWriter.WriteBinHeader(int length) -> void


### PR DESCRIPTION
Adds the leaveOpen flag from StreamReader to the constructor. Setting this to true will leave the underlying stream open when the reader is disposed.

This allows the user to manage the stream outside the reader, doing multiple reads on it at different offsets etc.