### PR TITLE
Invoke the default constructor for value types

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -36,6 +36,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="memory">The buffer to read from.</param>
         public MessagePackReader(ReadOnlyMemory<byte> memory)
+            : this()
         {
             this.reader = new SequenceReader<byte>(memory);
         }
@@ -45,6 +46,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="readOnlySequence">The sequence to read from.</param>
         public MessagePackReader(in ReadOnlySequence<byte> readOnlySequence)
+            : this()
         {
             this.reader = new SequenceReader<byte>(readOnlySequence);
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -36,6 +36,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="writer">The writer to use.</param>
         public MessagePackWriter(IBufferWriter<byte> writer)
+            : this()
         {
             this.writer = new BufferWriter(writer);
             this.OldSpec = false;
@@ -47,6 +48,7 @@ namespace MessagePack
         /// <param name="sequencePool">The pool from which to draw an <see cref="IBufferWriter{T}"/> if required..</param>
         /// <param name="array">An array to start with so we can avoid accessing the <paramref name="sequencePool"/> if possible.</param>
         internal MessagePackWriter(SequencePool sequencePool, byte[] array)
+            : this()
         {
             this.writer = new BufferWriter(sequencePool, array);
             this.OldSpec = false;


### PR DESCRIPTION
When building inside the AspNetCore repository, the compiler flags not intializing auto-properties as errors.