### PR TITLE
Fix `MessagePackSecurity.GetEqualityComparer<object>` to not return null

### DIFF
--- a/src/MessagePack/MessagePackSecurity.cs
+++ b/src/MessagePack/MessagePackSecurity.cs
@@ -56,6 +56,7 @@ namespace MessagePack
         /// </summary>
         /// <param name="copyFrom">The template to copy from.</param>
         protected MessagePackSecurity(MessagePackSecurity copyFrom)
+            : this()
         {
             if (copyFrom is null)
             {

--- a/tests/MessagePack.Tests/MessagePackSecurityTests.cs
+++ b/tests/MessagePack.Tests/MessagePackSecurityTests.cs
@@ -125,6 +125,13 @@ public class MessagePackSecurityTests
         Assert.NotEqual(eq.GetHashCode(o), eq.GetHashCode(new object()));
     }
 
+    [Fact]
+    public void EqualityComparer_ObjectFallback_AfterCopyCtor()
+    {
+        var security = MessagePackSecurity.UntrustedData.WithMaximumObjectGraphDepth(15);
+        Assert.NotNull(security.GetEqualityComparer<object>());
+    }
+
     /// <summary>
     /// Verifies that arbitrary other types not known to be hash safe will be rejected.
     /// </summary>


### PR DESCRIPTION
Fixes #810