### PR TITLE
Fix compiler error on Unity + .NET Standard 2.0 + generated Union code

### DIFF
--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -39,6 +39,9 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\CodeGenHelpers.cs">
       <Link>Code\CodeGenHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\RuntimeTypeHandleEqualityComparer.cs">
+      <Link>Code\RuntimeTypeHandleEqualityComparer.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\Internal\DynamicAssembly.cs">
       <Link>Code\DynamicAssembly.cs</Link>
     </Compile>

--- a/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
+++ b/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
@@ -401,8 +401,13 @@ namespace MessagePack.GeneratorCore.Utils
 
         private static IEnumerable<string> GetCompileFullPaths(XElement compile, string includeOrRemovePattern, string csProjRoot)
         {
+            if (string.IsNullOrEmpty(csProjRoot))
+            {
+                csProjRoot = "./";
+            }
+
             // solve macro
-            includeOrRemovePattern = includeOrRemovePattern.Replace("$(ProjectDir)", csProjRoot);
+            includeOrRemovePattern = includeOrRemovePattern.Replace("$(ProjectDir)", csProjRoot).Replace("$(MSBuildProjectDirectory)", csProjRoot);
 
             var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
             matcher.AddIncludePatterns(includeOrRemovePattern.Split(';'));

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/RuntimeTypeHandleEqualityComparer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/RuntimeTypeHandleEqualityComparer.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace MessagePack.Internal
+{
+    // This code is used in generated code so must be public.
+
+    // RuntimeTypeHandle can embed directly by OpCodes.Ldtoken
+    // It does not implements IEquatable<T>(but GetHashCode and Equals is implemented) so needs this to avoid boxing.
+    public class RuntimeTypeHandleEqualityComparer : IEqualityComparer<RuntimeTypeHandle>
+    {
+        public static readonly IEqualityComparer<RuntimeTypeHandle> Default = new RuntimeTypeHandleEqualityComparer();
+
+        private RuntimeTypeHandleEqualityComparer()
+        {
+        }
+
+        public bool Equals(RuntimeTypeHandle x, RuntimeTypeHandle y)
+        {
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(RuntimeTypeHandle obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -480,30 +480,6 @@ namespace MessagePack.Resolvers
             internal static readonly MethodInfo WriteNil = typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.WriteNil), Type.EmptyTypes);
         }
     }
-}
-
-namespace MessagePack.Internal
-{
-    // RuntimeTypeHandle can embed directly by OpCodes.Ldtoken
-    // It does not implements IEquatable<T>(but GetHashCode and Equals is implemented) so needs this to avoid boxing.
-    public class RuntimeTypeHandleEqualityComparer : IEqualityComparer<RuntimeTypeHandle>
-    {
-        public static readonly IEqualityComparer<RuntimeTypeHandle> Default = new RuntimeTypeHandleEqualityComparer();
-
-        private RuntimeTypeHandleEqualityComparer()
-        {
-        }
-
-        public bool Equals(RuntimeTypeHandle x, RuntimeTypeHandle y)
-        {
-            return x.Equals(y);
-        }
-
-        public int GetHashCode(RuntimeTypeHandle obj)
-        {
-            return obj.GetHashCode();
-        }
-    }
 
     internal class MessagePackDynamicUnionResolverException : MessagePackSerializationException
     {


### PR DESCRIPTION
Union that generated by mpc uses `RuntimeTypeHandleEqualityComparer` but it is enclosed `#if !NET_STANDARD_2_0)` in `DynamicUnionResolver.cs`.
So if Unity + .NET Standard 2.0 + exists union code can not compile.

This PR separate `RuntimeTypeHandleEqualityComparer` to `Internal/RuntimeTypeHandleEqualityComparer.cs`.

And includes tiny fix of mpc.