### PR TITLE
Make more consumable as submodule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
 # EditorConfig is awesome:http://EditorConfig.org
 
-# top-most EditorConfig file
-root = true
-
 # Don't use tabs for indentation.
 [*]
 indent_style = space

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
@@ -4,6 +4,10 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionHeader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionHeader.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 
 namespace MessagePack

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionResult.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionResult.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DateTimeConstants.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DateTimeConstants.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 
 namespace MessagePack.Internal

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/GuidBits.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/GuidBits.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 using System.Diagnostics;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 
 namespace MessagePack

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Nil.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Nil.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReader.cs
@@ -5,6 +5,10 @@
  * The .NET Foundation licenses this file to you under the MIT license.
  * See the LICENSE file in the project root for more information. */
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReaderExtensions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReaderExtensions.cs
@@ -5,6 +5,10 @@
  * The .NET Foundation licenses this file to you under the MIT license.
  * See the LICENSE file in the project root for more information. */
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StringEncoding.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StringEncoding.cs
@@ -7,6 +7,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
+#if CSHARP8
+#nullable disable
+#endif
+
 namespace MessagePack
 {
     internal static class StringEncoding

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/MessagePackReader.Integers.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/MessagePackReader.Integers.cs
@@ -4,6 +4,10 @@
 /* THIS (.cs) FILE IS GENERATED. DO NOT CHANGE IT.
  * CHANGE THE .tt FILE INSTEAD. */
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 

--- a/src/MessagePack/MessagePackReader.Integers.tt
+++ b/src/MessagePack/MessagePackReader.Integers.tt
@@ -6,6 +6,10 @@
 /* THIS (.cs) FILE IS GENERATED. DO NOT CHANGE IT.
  * CHANGE THE .tt FILE INSTEAD. */
 
+#if CSHARP8
+#nullable disable
+#endif
+
 using System;
 using System.Buffers;
 


### PR DESCRIPTION
* We need .editorconfig to not claim to be root, so that the outer git repo can define its own to suppress warnings that may be turned on for the importing project.
* When the importing project uses nullable ref types, the shared source files get annotated and warnings are produced inappropriately. We need each of these shared source files to suppress nullability in such a way that C# 7.x compilers can still handle it (e.g. Unity)

CC: @pranavkm 