### PR TITLE
Fix invalid bge-emit on string-key dynamic code gen

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/AutomataDictionary.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/AutomataDictionary.cs
@@ -398,7 +398,7 @@ namespace MessagePack.Internal
                     // if(key < mid)
                     il.EmitLdloc(key);
                     il.EmitULong(mid);
-                    il.Emit(OpCodes.Bge, gotoRight);
+                    il.Emit(OpCodes.Bge_Un, gotoRight);
                     EmitSearchNextCore(il, bytesSpan, key, onFound, onNotFound, l, l.Length);
 
                     // else

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultibyteCharPropertyTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultibyteCharPropertyTest.cs
@@ -36,11 +36,12 @@ namespace MessagePack.Tests
             byte[] bytes = MessagePackSerializer.Serialize(data);
 
             MessagePackSerializer.ConvertToJson(bytes).Is(@"{""A"":1,""B"":2,""にほんご"":3,""简体字"":4,""훈민정음"":5}");
-            MessagePackSerializer.Deserialize<データ>(bytes).IsStructuralEqual(data);
-
-            bytes = MessagePackSerializer.Typeless.Serialize(data);
-
-            (MessagePackSerializer.Typeless.Deserialize(bytes) as データ).IsStructuralEqual(data);
+            var a = MessagePackSerializer.Deserialize<データ>(bytes);
+            a.A.Is(data.A);
+            a.B.Is(data.B);
+            a.にほんご.Is(data.にほんご);
+            a.简体字.Is(data.简体字);
+            a.훈민정음.Is(data.훈민정음);
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultibyteCharPropertyTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultibyteCharPropertyTest.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace MessagePack.Tests
+{
+    public class MultibyteCharPropertyTest
+    {
+        [MessagePackObject(true)]
+        public class データ
+        {
+            public int A { get; set; }
+
+            public int B { get; set; }
+
+            public int にほんご { get; set; }
+
+            public int 简体字 { get; set; }
+
+            public int 훈민정음 { get; set; }
+        }
+
+        [Fact]
+        public void ConvertMultibyteCharProperty()
+        {
+            var data = new データ
+            {
+                A = 1,
+                B = 2,
+                にほんご = 3,
+                简体字 = 4,
+                훈민정음 = 5,
+            };
+
+            byte[] bytes = MessagePackSerializer.Serialize(data);
+
+            MessagePackSerializer.ConvertToJson(bytes).Is(@"{""A"":1,""B"":2,""にほんご"":3,""简体字"":4,""훈민정음"":5}");
+            MessagePackSerializer.Deserialize<データ>(bytes).IsStructuralEqual(data);
+
+            bytes = MessagePackSerializer.Typeless.Serialize(data);
+
+            (MessagePackSerializer.Typeless.Deserialize(bytes) as データ).IsStructuralEqual(data);
+        }
+    }
+}


### PR DESCRIPTION
related to #875 and #878
For example `AutomataKeyGen.GetKey("あああ")` returns `9359467944985395683UL`.
generated code is like following.

```csharp
if(key < 67UL)
{
    // ....
}
else
{
    if (key != 9359467944985395683UL) break;
    ....
    あああ = ReadInt32();
}
```

But current generated code returns `if(key < 67UL)` == true.

Because I used `il.Emit(OpCodes.Bge` to compare ulong.
I've changed to use `OpCodes.Bge_Un` and add tests written by @ksd1918 at #878

Fixes  #875