### PR TITLE
Normalize End-of-Lines

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -220,13 +220,20 @@ namespace MessagePackCompiler
                 fi.Directory.Create();
             }
 
-            System.IO.File.WriteAllText(path, text, NoBomUtf8);
+            System.IO.File.WriteAllText(path, NormalizeNewLines(text), NoBomUtf8);
             return Task.CompletedTask;
         }
 
         private static string MultiSymbolToSafeFilePath(string symbol)
         {
             return symbol.Replace("!", "NOT_").Replace("(", string.Empty).Replace(")", string.Empty).Replace("||", "_OR_").Replace("&&", "_AND_");
+        }
+
+        private static string NormalizeNewLines(string content)
+        {
+            // The T4 generated code may be text with mixed line ending types. (CR + CRLF)
+            // We need to normalize the line ending type in each Operating Systems. (e.g. Windows=CRLF, Linux/macOS=LF)
+            return content.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
         }
     }
 }


### PR DESCRIPTION
The T4 generated code may be text with mixed line ending types. (CR + CRLF)

We need to normalize the line ending type in each Operating Systems. (e.g. Windows=CRLF, Linux/macOS=LF)

- ref: https://github.com/Cysharp/MagicOnion/pull/297