### PR TITLE
Feature/supportmultipleplatforms

### DIFF
--- a/src/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack/Formatters/CollectionFormatter.cs
@@ -243,7 +243,7 @@ namespace MessagePack.Formatters
                         {
                             while (e.MoveNext())
                             {
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                                 offset += formatter.Serialize(ref bytes, offset, e.Current, formatterResolver);
 #else
                                 offset += formatter.Serialize(ref bytes, (int)offset, (TElement)e.Current, (IFormatterResolver)formatterResolver);
@@ -274,7 +274,7 @@ namespace MessagePack.Formatters
                             while (e.MoveNext())
                             {
                                 count++;
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                                 var writeSize = formatter.Serialize(ref bytes, offset, e.Current, formatterResolver);
 #else
                                 var writeSize = formatter.Serialize(ref bytes, (int)offset, (TElement)e.Current, (IFormatterResolver)formatterResolver);

--- a/src/MessagePack/Formatters/CollectionHelpers`2.cs
+++ b/src/MessagePack/Formatters/CollectionHelpers`2.cs
@@ -28,7 +28,11 @@ namespace MessagePack.Formatters
         /// </remarks>
         static CollectionHelpers()
         {
+#if UAP
+            var ctor = typeof(TCollection).GetConstructor(new Type[] { typeof(int), typeof(TEqualityComparer) });
+#else
             var ctor = typeof(TCollection).GetTypeInfo().GetConstructor(new Type[] { typeof(int), typeof(TEqualityComparer) });
+#endif
             if (ctor != null)
             {
                 ParameterExpression param1 = Expression.Parameter(typeof(int), "count");

--- a/src/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs
+++ b/src/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD || NETFRAMEWORK
+﻿#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
 
 using MessagePack.Resolvers;
 using System;

--- a/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -408,7 +408,7 @@ namespace MessagePack.Formatters
     }
 
 #if NETSTANDARD || NETFRAMEWORK
-
+#if !XAMARIN_IOS
     public sealed class BigIntegerFormatter : IMessagePackFormatter<System.Numerics.BigInteger>
     {
         public static readonly IMessagePackFormatter<System.Numerics.BigInteger> Instance = new BigIntegerFormatter();
@@ -465,7 +465,7 @@ namespace MessagePack.Formatters
             return new System.Numerics.Complex(real, imaginary);
         }
     }
-
+#endif
     public sealed class LazyFormatter<T> : IMessagePackFormatter<Lazy<T>>
     {
         public int Serialize(ref byte[] bytes, int offset, Lazy<T> value, IFormatterResolver formatterResolver)

--- a/src/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack/Formatters/TypelessFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD || NETFRAMEWORK
+﻿#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
 
 using MessagePack.Internal;
 using System;

--- a/src/MessagePack/Internal/AutomataDictionary.cs
+++ b/src/MessagePack/Internal/AutomataDictionary.cs
@@ -172,7 +172,7 @@ namespace MessagePack.Internal
 
         // IL Emit
 
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
         public void EmitMatch(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
         {
@@ -338,7 +338,7 @@ namespace MessagePack.Internal
                 }
             }
 
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
             // SearchNext(ref byte* p, ref int rest, ref ulong key)
             public void EmitSearchNext(ILGenerator il, LocalBuilder p, LocalBuilder rest, LocalBuilder key, Action<KeyValuePair<string, int>> onFound, Action onNotFound)
@@ -474,7 +474,7 @@ namespace MessagePack.Internal
 
 #if !NETSTANDARD
 
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
         static MethodInfo dynamicGetKeyMethod;
         static readonly object gate = new object();

--- a/src/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack/Internal/DynamicAssembly.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
 using System;
 using System.Reflection;

--- a/src/MessagePack/Internal/ILGeneratorExtensions.cs
+++ b/src/MessagePack/Internal/ILGeneratorExtensions.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
 using System;
 using System.Linq;

--- a/src/MessagePack/LZ4/LZ4MessagePackSerializer.JSON.cs
+++ b/src/MessagePack/LZ4/LZ4MessagePackSerializer.JSON.cs
@@ -192,7 +192,7 @@ namespace MessagePack
                         builder.Append(dt.ToString("o", CultureInfo.InvariantCulture));
                         builder.Append("\"");
                     }
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                     else if (extHeader.TypeCode == TypelessFormatter.ExtensionTypeCode)
                     {
                         int startOffset = offset;

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <!-- for iOS and UWP (.NET Native) remove the IL, omitting the GENERATE_DYNAMIC_CODE flag -->
   <PropertyGroup Condition=" $(TargetFramework) == 'uap10.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;UAP</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" $(TargetFramework) == 'xamarin.ios10' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+	<!-- Using MSBuild.Sdk.Extras from oren novotny to support uap.10 and xamarin.ios10 platform targets out of the box	  
+		 see: https://github.com/onovotny/MSBuildSdkExtras -->
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net47;uap10.0;xamarin.ios10</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);ENABLE_UNSAFE_MSGPACK</DefineConstants>
@@ -33,13 +35,36 @@
     <None Include="MessagePackSerializer.Typeless.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  
+  <!-- for all standard .net targets, add the GENERATE_DYNAMIC_CODE flag -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net')) ">
+    <DefineConstants>$(DefineConstants);GENERATE_DYNAMIC_CODE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net')) ">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>  
+  
+  <!-- for iOS and UWP (.NET Native) remove the IL nugets -->
+  <ItemGroup Condition=" $(TargetFramework) == 'uap10.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework) == 'xamarin.ios10'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+  </ItemGroup>
+  <!-- for iOS and UWP (.NET Native) remove the IL, omitting the GENERATE_DYNAMIC_CODE flag -->
+  <PropertyGroup Condition=" $(TargetFramework) == 'uap10.0'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" $(TargetFramework) == 'xamarin.ios10' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Update="Formatters\ForceSizePrimitiveFormatter.tt">

--- a/src/MessagePack/MessagePackSecurity.cs
+++ b/src/MessagePack/MessagePackSecurity.cs
@@ -160,7 +160,11 @@ namespace MessagePack
             IEqualityComparer<T> result = null;
             if (typeof(T).GetTypeInfo().IsEnum)
             {
+#if UAP
+                Type underlyingType = Enum.GetUnderlyingType(typeof(T));
+#else
                 Type underlyingType = typeof(T).GetTypeInfo().GetEnumUnderlyingType();
+#endif
                 result =
                     underlyingType == typeof(sbyte) ? CollisionResistantHasher<T>.Instance :
                     underlyingType == typeof(byte) ? CollisionResistantHasher<T>.Instance :
@@ -169,6 +173,7 @@ namespace MessagePack
                     underlyingType == typeof(int) ? CollisionResistantHasher<T>.Instance :
                     underlyingType == typeof(uint) ? CollisionResistantHasher<T>.Instance :
                     null;
+
             }
             else
             {

--- a/src/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack/MessagePackSerializer.Json.cs
@@ -268,7 +268,7 @@ namespace MessagePack
                         builder.Append(dt.ToString("o", CultureInfo.InvariantCulture));
                         builder.Append("\"");
                     }
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                     else if (extHeader.TypeCode == TypelessFormatter.ExtensionTypeCode)
                     {
                         int startOffset = offset;

--- a/src/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack/Resolvers/BuiltinResolver.cs
@@ -129,10 +129,12 @@ namespace MessagePack.Internal
             { typeof(ArraySegment<byte>?),new StaticNullableFormatter<ArraySegment<byte>>(ByteArraySegmentFormatter.Instance) },
 
 #if NETSTANDARD || NETFRAMEWORK
+#if !XAMARIN_IOS
             {typeof(System.Numerics.BigInteger), BigIntegerFormatter.Instance},
             {typeof(System.Numerics.BigInteger?), new StaticNullableFormatter<System.Numerics.BigInteger>(BigIntegerFormatter.Instance)},
             {typeof(System.Numerics.Complex), ComplexFormatter.Instance},
             {typeof(System.Numerics.Complex?), new StaticNullableFormatter<System.Numerics.Complex>(ComplexFormatter.Instance)},
+#endif
             {typeof(System.Threading.Tasks.Task), TaskUnitFormatter.Instance},
 #endif
         };

--- a/src/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
 using System;
 using MessagePack.Formatters;

--- a/src/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1,5 +1,5 @@
 ﻿#if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
 using System;
 using System.Linq;

--- a/src/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace MessagePack.Resolvers
 {
 #if !UNITY_WSA
-#if !NET_STANDARD_2_0
+#if !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
     /// <summary>
     /// UnionResolver by dynamic code generation.

--- a/src/MessagePack/Resolvers/StandardResolver.cs
+++ b/src/MessagePack/Resolvers/StandardResolver.cs
@@ -12,7 +12,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new StandardResolver();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverCore.Instance);
 #endif
 
@@ -34,7 +34,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -52,7 +52,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new ContractlessStandardResolver();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverCore.Instance);
 #endif
 
@@ -74,7 +74,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -92,7 +92,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new StandardResolverAllowPrivate();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(StandardResolverAllowPrivateCore.Instance);
 #endif
 
@@ -114,7 +114,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -132,7 +132,7 @@ namespace MessagePack.Resolvers
     {
         public static readonly IFormatterResolver Instance = new ContractlessStandardResolverAllowPrivate();
 
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
         public static readonly IMessagePackFormatter<object> ObjectFallbackFormatter = new DynamicObjectTypeFallbackFormatter(ContractlessStandardResolverAllowPrivateCore.Instance);
 #endif
 
@@ -154,7 +154,7 @@ namespace MessagePack.Resolvers
                 if (typeof(T) == typeof(object))
                 {
                     // final fallback
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
                     formatter = (IMessagePackFormatter<T>)ObjectFallbackFormatter;
 #else
                     formatter = PrimitiveObjectResolver.Instance.GetFormatter<T>();
@@ -182,7 +182,7 @@ namespace MessagePack.Internal
             MessagePack.Unity.UnityResolver.Instance,
 #endif
 
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
 
             DynamicEnumResolver.Instance, // Try Enum
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection
@@ -197,7 +197,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
             DynamicObjectResolver.Instance, // Try Object
 #endif
         }).ToArray();
@@ -236,7 +236,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
             DynamicObjectResolver.Instance, // Try Object
             DynamicContractlessObjectResolver.Instance, // Serializes keys as strings
 #endif
@@ -277,7 +277,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
 #endif
         }).ToArray();
@@ -316,7 +316,7 @@ namespace MessagePack.Internal
 
         static readonly IFormatterResolver[] resolvers = StandardResolverHelper.DefaultResolvers.Concat(new IFormatterResolver[]
         {
-#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0
+#if !ENABLE_IL2CPP && !UNITY_WSA && !NET_STANDARD_2_0 && GENERATE_DYNAMIC_CODE
             DynamicObjectResolverAllowPrivate.Instance, // Try Object
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
 #endif

--- a/src/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs
@@ -17,13 +17,17 @@ namespace MessagePack.Resolvers
             BuiltinResolver.Instance, // Try Builtin
             AttributeFormatterResolver.Instance, // Try use [MessagePackFormatter]
 #if !ENABLE_IL2CPP
+#if GENERATE_DYNAMIC_CODE
             DynamicEnumResolver.Instance, // Try Enum
             DynamicGenericResolver.Instance, // Try Array, Tuple, Collection
             DynamicUnionResolver.Instance, // Try Union(Interface)
             DynamicObjectResolver.Instance, // Try Object
 #endif
+#endif
+#if GENERATE_DYNAMIC_CODE
             DynamicContractlessObjectResolverAllowPrivate.Instance, // Serializes keys as strings
             TypelessObjectResolver.Instance
+#endif
         };
 
         TypelessContractlessStandardResolver()

--- a/src/MessagePack/Resolvers/TypelessObjectResolver.cs
+++ b/src/MessagePack/Resolvers/TypelessObjectResolver.cs
@@ -5,7 +5,7 @@ using MessagePack.Internal;
 
 namespace MessagePack.Resolvers
 {
-#if NETSTANDARD || NETFRAMEWORK
+#if (NETSTANDARD || NETFRAMEWORK) && GENERATE_DYNAMIC_CODE
 
     /// <summary>
     /// Used for `object` fields/collections, ex: var arr = new object[] { 1, "a", new Model() };


### PR DESCRIPTION
Added **real** support for iOS and UWP by 

- [x] introducing them as target platform.
- [x] introducing a compiler directive `GENERATE_DYNAMIC_CODE` which is disabled for UAP and iOS
- [x] removed all dynamic code generation for UAP and iOS

Basically, UWP and iOS should work with the default Messagepack implementation.
For example, on UWP, the `.net native toolchain` combined with `optimize code` could remove the dynamic code.
Sometimes it does, sometimes it does not. This leads to compiling an UWP release build for nearliy 1 hour just to get a runtime error that "dynamic code is not allowed".
This is very, very tedius!