### PR TITLE
[mpc] Fix collecting closed type generics

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -55,7 +55,7 @@ namespace MessagePackCompiler
                 sw.Restart();
                 logger("Method Collect Start");
 
-                var (objectInfo, enumInfo, genericInfo, unionInfo, unboundGenericInfo) = collector.Collect();
+                var (objectInfo, enumInfo, genericInfo, unionInfo, closedTypeGenericInfo) = collector.Collect();
 
                 logger("Method Collect Complete:" + sw.Elapsed.ToString());
 
@@ -66,7 +66,7 @@ namespace MessagePackCompiler
                 {
                     // SingleFile Output
                     var objectFormatterTemplates = objectInfo
-                        .Concat(unboundGenericInfo)
+                        .Concat(closedTypeGenericInfo)
                         .GroupBy(x => x.Namespace)
                         .Select(x => new FormatterTemplate()
                         {
@@ -138,7 +138,7 @@ namespace MessagePackCompiler
                 else
                 {
                     // Multiple File output
-                    foreach (var x in objectInfo.Concat(unboundGenericInfo))
+                    foreach (var x in objectInfo.Concat(closedTypeGenericInfo))
                     {
                         var template = new FormatterTemplate()
                         {
@@ -185,7 +185,7 @@ namespace MessagePackCompiler
                     await OutputToDirAsync(output, resolverTemplate.Namespace, resolverTemplate.ResolverName, multioutSymbol, resolverTemplate.TransformText(), cancellationToken).ConfigureAwait(false);
                 }
 
-                if (objectInfo.Length == 0 && enumInfo.Length == 0 && genericInfo.Length == 0 && unionInfo.Length == 0 && unboundGenericInfo.Length == 0)
+                if (objectInfo.Length == 0 && enumInfo.Length == 0 && genericInfo.Length == 0 && unionInfo.Length == 0 && closedTypeGenericInfo.Length == 0)
                 {
                     logger("Generated result is empty, unexpected result?");
                 }


### PR DESCRIPTION
Most of work was done in #830.
However, current implementation fails on this code:
```csharp
[MessagePackObject]
public class CustomGenericClass<T>
{
    [Key(1)] public List<T> ListOfT;
}

[MessagePackObject]
public class ClassToSerialize
{
    [Key(0)] public CustomGenericClass<string> GenericField;
}
```
<details>
  <summary>Generated code</summary>

```csharp
        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(3)
            {
                { typeof(global::CustomGenericClass<string>), 0 },
                { typeof(global::System.Collections.Generic.List<T>), 1 },
                { typeof(global::ClassToSerialize), 2 },
            };
        }
```
and
```csharp
            switch (key)
            {
                case 0: return new MessagePack.Formatters.CustomGenericClassFormatter<string>();
                case 1: return new global::MessagePack.Formatters.ListFormatter<T>();
                case 2: return new MessagePack.Formatters.ClassToSerializeFormatter();
                default: return null;
            }
```

</details>

MPC is trying to collect type argument `T` from open generic type  `CustomGenericClass<T>` here:
https://github.com/neuecc/MessagePack-CSharp/blob/275eb96cdcce5d10c3326a2b940af5fcdeeda066/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs#L544-L548
But because type argument has no declared accessibility (`Accessibility.NotApplicable`) it fails to pass `IsAllowAccessibility` check and collect stops there.

We can skip all generics definitions (e.g. `Foo<T>`) and collect only closed type references (e.g. `Foo<string>`). That's a main purpose of this commit.

<details>
  <summary>Generated code</summary>

```csharp
        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(3)
            {
                { typeof(global::CustomGenericClass<string>), 0 },
                { typeof(global::System.Collections.Generic.List<string>), 1 },
                { typeof(global::ClassToSerialize), 2 },
            };
        }
```
and
```csharp
            switch (key)
            {
                case 0: return new MessagePack.Formatters.CustomGenericClassFormatter<string>();
                case 1: return new global::MessagePack.Formatters.ListFormatter<string>();
                case 2: return new MessagePack.Formatters.ClassToSerializeFormatter();
                default: return null;
            }
```

</details>