### PR TITLE
Span based constructors for SequenceReader and MessagePackReader

### DIFF
--- a/sandbox/PerfBenchmarkDotNet/MessagePackReaderBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/MessagePackReaderBenchmark.cs
@@ -31,7 +31,7 @@ namespace PerfBenchmarkDotNet
         [BenchmarkCategory("2.0")]
         public void ReadByte20()
         {
-            var reader = new newmsgpack::MessagePack.MessagePackReader(this.buffer);
+            var reader = new newmsgpack::MessagePack.MessagePackReader(this.buffer.AsMemory());
             for (int i = 0; i < this.buffer.Length; i++)
             {
                 reader.ReadInt32();

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
@@ -60,10 +60,9 @@ namespace MessagePack
 
             _sequencePool = default;
             _rental = default;
+            _segment = default;
 
-            var memory = _output.GetMemoryCheckResult();
-            MemoryMarshal.TryGetArray(memory, out _segment);
-            _span = memory.Span;
+            _span = _output.GetSpanCheckResult();
         }
 
         /// <summary>
@@ -83,6 +82,25 @@ namespace MessagePack
             _segment = new ArraySegment<byte>(array);
             _span = _segment.AsSpan();
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferWriter"/> struct.
+        /// </summary>
+        /// <param name="span">The Span to be wrapped.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public BufferWriter(Span<byte> span)
+        {
+            _buffered = 0;
+            _bytesCommitted = 0;
+            _output = null;
+
+            _sequencePool = default;
+            _rental = default;
+            _segment = default;
+
+            _span = span;
+        }
+
 
         /// <summary>
         /// Gets the result of the last call to <see cref="IBufferWriter{T}.GetSpan(int)"/>.
@@ -136,7 +154,7 @@ namespace MessagePack
 
                 _bytesCommitted += buffered;
                 _buffered = 0;
-                _output.Advance(buffered);
+                _output?.Advance(buffered);
                 _span = default;
             }
         }
@@ -216,9 +234,7 @@ namespace MessagePack
                 this.MigrateToSequence();
             }
 
-            var memory = _output.GetMemoryCheckResult(count);
-            MemoryMarshal.TryGetArray(memory, out _segment);
-            _span = memory.Span;
+            _span = _output.GetSpanCheckResult(count);
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -54,6 +54,17 @@ namespace MessagePack
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackReader"/> struct.
+        /// </summary>
+        /// <param name="span">The buffer to read from.</param>
+        public MessagePackReader(ReadOnlySpan<byte> span)
+            : this()
+        {
+            this.reader = new SequenceReader<byte>(span);
+            this.Depth = 0;
+        }
+
+        /// <summary>
         /// Gets or sets the cancellation token for this deserialization operation.
         /// </summary>
         public CancellationToken CancellationToken { get; set; }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -55,6 +55,17 @@ namespace MessagePack
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackWriter"/> struct.
+        /// </summary>
+        /// <param name="span">The Span to use.</param>
+        public MessagePackWriter(Span<byte> span)
+            : this()
+        {
+            this.writer = new BufferWriter(span);
+            this.OldSpec = false;
+        }
+
+        /// <summary>
         /// Gets or sets the cancellation token for this serialization operation.
         /// </summary>
         public CancellationToken CancellationToken { get; set; }
@@ -63,6 +74,11 @@ namespace MessagePack
         /// Gets or sets a value indicating whether to write in <see href="https://github.com/msgpack/msgpack/blob/master/spec-old.md">old spec</see> compatibility mode.
         /// </summary>
         public bool OldSpec { get; set; }
+
+        /// <summary>
+        /// Gets number of bytes committed to underlying buffer.
+        /// </summary>
+        public long BytesCommitted => this.writer.BytesCommitted;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackWriter"/> struct,

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -33,15 +33,15 @@ namespace MessagePack
             }
         }
 
-        internal static Memory<T> GetMemoryCheckResult<T>(this IBufferWriter<T> bufferWriter, int size = 0)
+        internal static Span<T> GetSpanCheckResult<T>(this IBufferWriter<T> bufferWriter, int size = 0)
         {
-            var memory = bufferWriter.GetMemory(size);
-            if (memory.IsEmpty)
+            var span = bufferWriter.GetSpan(size);
+            if (span.IsEmpty)
             {
-                throw new InvalidOperationException("The underlying IBufferWriter<byte>.GetMemory(int) method returned an empty memory block, which is not allowed. This is a bug in " + bufferWriter.GetType().FullName);
+                throw new InvalidOperationException("The underlying IBufferWriter<byte>.GetSpan(int) method returned an empty memory block, which is not allowed. This is a bug in " + bufferWriter.GetType().FullName);
             }
 
-            return memory;
+            return span;
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs
@@ -86,7 +86,7 @@ namespace MessagePack.Tests
         public void ByteArraySegmentTest(ArraySegment<byte> t, ArraySegment<byte>? t2, byte[] reference)
         {
             MessagePackSerializer.Serialize(t).Is(MessagePackSerializer.Serialize(reference));
-            new MessagePackReader(MessagePackSerializer.Serialize(t2)).IsNil.IsTrue();
+            new MessagePackReader(MessagePackSerializer.Serialize(t2).AsMemory()).IsNil.IsTrue();
         }
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
@@ -863,5 +863,21 @@ namespace MessagePack.Tests
                 target.AsReadOnlySequence.ToArray().SequenceEqual(small.AsReadOnlySequence.ToArray()).IsTrue();
             }
         }
+
+        [Fact]
+        public void StackAllocatedBuffers()
+        {
+            Span<byte> buffer = stackalloc byte[20];
+
+            var writer = new MessagePackWriter(buffer);
+            writer.WriteInt64(-1);
+            writer.Flush();
+
+            writer.BytesCommitted.Equals(9);
+
+            var resultBuffer = buffer.Slice(0, (int)writer.BytesCommitted);
+            var reader = new MessagePackReader(resultBuffer);
+            reader.ReadInt64().Equals(-1);
+        }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs
@@ -217,7 +217,7 @@ namespace MessagePack.Tests
         [Fact]
         public void CancellationToken()
         {
-            var reader = new MessagePackReader(default);
+            var reader = new MessagePackReader((ReadOnlyMemory<byte>)default);
             Assert.False(reader.CancellationToken.CanBeCanceled);
 
             var cts = new CancellationTokenSource();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs
@@ -56,7 +56,7 @@ namespace MessagePack.Tests
         {
             SimpleIntKeyData n = null;
             var bytes = MessagePackSerializer.Serialize(n);
-            var reader = new MessagePackReader(bytes);
+            var reader = new MessagePackReader(bytes.AsMemory());
             reader.IsNil.IsTrue();
             bytes.Length.Is(1);
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs
@@ -80,7 +80,7 @@ namespace MessagePack.Tests
         {
             var sourceBytes = Enumerable.Range(0, arrayLength).Select(i => unchecked((byte)i)).ToArray(); // long byte array
             var messagePackBytes = SerializeByClassicMsgPack(sourceBytes, MsgPack.Serialization.SerializationMethod.Array);
-            var messagePackBytesReader = new MessagePackReader(messagePackBytes);
+            var messagePackBytesReader = new MessagePackReader(messagePackBytes.AsMemory());
             var deserializedBytes = MessagePackSerializer.Deserialize<byte[]>(ref messagePackBytesReader);
             Assert.NotNull(deserializedBytes);
             Assert.Equal(sourceBytes, deserializedBytes);
@@ -89,7 +89,7 @@ namespace MessagePack.Tests
         [Fact]
         public void DeserializeNil()
         {
-            var messagePackReader = new MessagePackReader(new byte[] { MessagePackCode.Nil });
+            var messagePackReader = new MessagePackReader(new byte[] { MessagePackCode.Nil }.AsMemory());
 
             var deserializedObj = MessagePackSerializer.Deserialize<byte[]>(ref messagePackReader);
             Assert.Null(deserializedObj);
@@ -109,7 +109,7 @@ namespace MessagePack.Tests
                 Value = Enumerable.Range(0, arrayLength).Select(i => unchecked((byte)i)).ToArray(), // long byte array
             };
             var messagePackBytes = SerializeByClassicMsgPack(foo, MsgPack.Serialization.SerializationMethod.Map);
-            var oldSpecReader = new MessagePackReader(messagePackBytes);
+            var oldSpecReader = new MessagePackReader(messagePackBytes.AsMemory());
             Foo deserializedFoo = MessagePackSerializer.Deserialize<Foo>(ref oldSpecReader);
             Assert.NotNull(deserializedFoo);
             Assert.Equal(foo.Id, deserializedFoo.Id);

--- a/src/MessagePack/PublicAPI.Shipped.txt
+++ b/src/MessagePack/PublicAPI.Shipped.txt
@@ -513,6 +513,7 @@ MessagePack.MessagePackReader.End.get -> bool
 MessagePack.MessagePackReader.IsNil.get -> bool
 MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlyMemory<byte> memory) -> void
 MessagePack.MessagePackReader.MessagePackReader(in System.Buffers.ReadOnlySequence<byte> readOnlySequence) -> void
+MessagePack.MessagePackReader.MessagePackReader(System.ReadOnlySpan<byte> span) -> void
 MessagePack.MessagePackReader.NextCode.get -> byte
 MessagePack.MessagePackReader.NextMessagePackType.get -> MessagePack.MessagePackType
 MessagePack.MessagePackReader.Position.get -> System.SequencePosition
@@ -587,8 +588,10 @@ MessagePack.MessagePackWriter.Clone(System.Buffers.IBufferWriter<byte> writer) -
 MessagePack.MessagePackWriter.Flush() -> void
 MessagePack.MessagePackWriter.GetSpan(int length) -> System.Span<byte>
 MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte> writer) -> void
+MessagePack.MessagePackWriter.MessagePackWriter(System.Span<byte> span) -> void
 MessagePack.MessagePackWriter.OldSpec.get -> bool
 MessagePack.MessagePackWriter.OldSpec.set -> void
+MessagePack.MessagePackWriter.BytesCommitted.get -> long
 MessagePack.MessagePackWriter.Write(System.DateTime dateTime) -> void
 MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<byte> src) -> void
 MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<char> value) -> void

--- a/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
+++ b/tests/MessagePack.Tests/ExtensionTests/LZ4Test.cs
@@ -40,7 +40,7 @@ namespace MessagePack.Tests.ExtensionTests
             var lz4Data = MessagePackSerializer.Serialize(originalData, LZ4Standard);
 
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
-            var lz4DataReader = new MessagePackReader(lz4Data);
+            var lz4DataReader = new MessagePackReader(lz4Data.AsMemory());
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
             header.TypeCode.Is(ThisLibraryExtensionTypeCodes.Lz4Block);
 
@@ -57,7 +57,7 @@ namespace MessagePack.Tests.ExtensionTests
             var lz4Data = MessagePackSerializer.Serialize(typeof(FirstSimpleData[]), originalData, LZ4Standard);
 
             PeekMessagePackType(lz4Data).Is(MessagePackType.Extension);
-            var lz4DataReader = new MessagePackReader(lz4Data);
+            var lz4DataReader = new MessagePackReader(lz4Data.AsMemory());
             ExtensionHeader header = lz4DataReader.ReadExtensionFormatHeader();
             header.TypeCode.Is(ThisLibraryExtensionTypeCodes.Lz4Block);
 


### PR DESCRIPTION
We use a lot of unmanaged buffers, and it seems all parts for handling native spans are already in place, only constructors overloads are missing.