### PR TITLE
Make MessagePack.MSBuild.Task package a dev dependency

### DIFF
--- a/src/MessagePack.MSBuild.Tasks/MessagePack.MSBuild.Tasks.csproj
+++ b/src/MessagePack.MSBuild.Tasks/MessagePack.MSBuild.Tasks.csproj
@@ -9,6 +9,7 @@
     <!-- SKD depenencies local copy. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- NuGet Info -->
+    <DevelopmentDependency>true</DevelopmentDependency>
     <IsPackable>true</IsPackable>
     <Title>MessagePack CodeGenerator Tasks</Title>
     <Description>MSBuild Tasks of MessagePack for C#.</Description>


### PR DESCRIPTION
This causes NuGet to automatically add `PrivateAssets="all"` on a package reference that it adds.