### PR TITLE
[mpc]: Ignore missing Include attribute in PackageReference tag

### DIFF
--- a/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
+++ b/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
@@ -322,10 +322,13 @@ namespace MessagePack.GeneratorCore.Utils
                 foreach (var item in document.Descendants("PackageReference"))
                 {
                     var originalTargetFramework = document.Descendants("TargetFramework").FirstOrDefault()?.Value ?? document.Descendants("TargetFrameworks").First().Value.Split(';').First();
-                    var includePath = item.Attribute("Include").Value.Trim().ToLower(); // maybe lower
-                    var packageVersion = item.Attribute("Version").Value.Trim();
-
-                    CollectNugetPackages(includePath, packageVersion, originalTargetFramework);
+                    var includeXAttribute = item.Attribute("Include");
+                    if (includeXAttribute != null)
+                    {
+                        var includePath = includeXAttribute.Value.Trim().ToLower(); // maybe lower
+                        var packageVersion = item.Attribute("Version").Value.Trim();
+                        CollectNugetPackages(includePath, packageVersion, originalTargetFramework);
+                    }
                 }
 
                 foreach (var item in resolvedDllPaths)


### PR DESCRIPTION
`mpc` is trying to resolve nuget dependencies by itself.
If you reference e.g. MSBuild task, `mpc` fails on this code:
```csproj
<PackageReference Update="@(PackageReference)" PrivateAssets="All" />
```

Probably, we can exclude `PrivateAssets="all"` from analysis as well. 
But this is not covered by this PR.