### PR TITLE
Reworked anonymous type check. 

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ReflectionExtensions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ReflectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -20,10 +21,12 @@ namespace MessagePack.Internal
 
         public static bool IsAnonymous(this System.Reflection.TypeInfo type)
         {
-            return type.GetCustomAttribute<CompilerGeneratedAttribute>() != null
-                && type.IsGenericType && type.Name.Contains("AnonymousType")
-                && (type.Name.StartsWith("<>") || type.Name.StartsWith("VB$"))
-                && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
+            return type.Namespace == null
+                   && type.IsSealed
+                   && (type.Name.StartsWith("<>f__AnonymousType", StringComparison.Ordinal)
+                       || type.Name.StartsWith("<>__AnonType", StringComparison.Ordinal)
+                       || type.Name.StartsWith("VB$AnonymousType_", StringComparison.Ordinal))
+                   && type.IsDefined(typeof(CompilerGeneratedAttribute), false);
         }
 
         public static bool IsIndexer(this System.Reflection.PropertyInfo propertyInfo)

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs
@@ -24,6 +24,14 @@ namespace MessagePack.Tests
 
             MessagePackSerializer.ConvertToJson(data).Is(@"{""Hoge"":100,""Huga"":true,""Yaki"":{""Rec"":1,""T"":10},""Nano"":""nanoanno""}");
         }
+
+        [Fact]
+        public void EmptyAnonymousType()
+        {
+            var testData = new { };
+            var data = MessagePackSerializer.Serialize(testData, ContractlessStandardResolver.Options);
+            MessagePackSerializer.ConvertToJson(data).Is(@"{}");
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in #917.

### Overview

It now handles:
- anonymous types generated by `mcs` compiler (Mono) in C# projects
- anonymous types generated by `vbc` compiler in VB.Net projects
- anonymous records generated by `fsc` compiler in F# projects
- empty anonymous type (`new {}`) generated both by `csc` compiler (Roslyn) and by `mcs` compiler for C# projects

### Additional info
Removed `NotPublic` check at all, because F# generates `public` classes. Previous version of this check had done nothing anyway.
Removed `IsGenericType` check, because both Roslyn and Mono are generate non-generic class if there are no any fields in anonymous type.
Added a check that the namespace is null as the least expensive check, because all compilers are generate anonymous types in global namespace.

### Anonymous type name generation
by Roslyn for VB:
https://github.com/dotnet/roslyn/blob/91571a3bb038e05e7bf2ab87510273a1017faed0/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNames.vb#L270-L278

by Roslyn for C#:
https://github.com/dotnet/roslyn/blob/91571a3bb038e05e7bf2ab87510273a1017faed0/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs#L62-L73

by Mono for C#:
https://github.com/mono/mono/blob/d0f51b4e834042cfa593748ada942033b458cc40/mcs/mcs/anonymous.cs#L2026-L2039

by FSharp for F#:
https://github.com/dotnet/fsharp/blob/2e0b61185c88ead325700ffefc653acd076087fa/src/fsharp/TypedTree.fs#L4012-L4014

### Fun fact
While all compilers are just increment index in the name for each generated class (e.g. `VB$AnonymousType_0`, `VB$AnonymousType_1`), F# is using trimmed sha1 hash of byte array with assembly name, const flag and member names. Result is something like `<>f__AnonymousType1055873781`.