### PR TITLE
[docs] Add clarification that use of `Union` and `IMessagePackSerializationCallbackReceiver` with structs will cause boxing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ public class SampleCallback : IMessagePackSerializationCallbackReceiver
     }
 }
 ```
+Since interfaces are treated as reference types, there is no way to call a method on a `struct` referred to by an interface without having to box the underlying struct first. Thus using `IMessagePackSerializationCallbackReceiver` with `struct` will cause boxing on serialization and deserialization.
 
 ## Union
 
@@ -517,6 +518,7 @@ public class SubUnionType2 : ParentUnionType
 ```
 
 Please be mindful that you cannot reuse the same keys in derived types that are already present in the parent type, as internally a single flat array or map will be used and thus cannot have duplicate indexes/keys.
+Using `Union` with `struct` will cause hidden boxing on (de)serialization.
 
 ## Dynamic (Untyped) Deserialization
 


### PR DESCRIPTION
Since interfaces are treated as reference types, there is no way to call a method on a struct referred to by an interface without having to box the underlying struct first.
We use call to an interface method in `Union` and  `IMessagePackSerializationCallbackReceiver`.

Examples:
https://github.com/neuecc/MessagePack-CSharp/blob/56fa86219d01d0a183babbbbcb34abbdea588a02/sandbox/Sandbox/Generated.cs#L2211

https://github.com/neuecc/MessagePack-CSharp/blob/56fa86219d01d0a183babbbbcb34abbdea588a02/sandbox/Sandbox/Generated.cs#L599