### PR TITLE
Move SequenceReader into our own namespace

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReader.cs
@@ -5,10 +5,12 @@
  * The .NET Foundation licenses this file to you under the MIT license.
  * See the LICENSE file in the project root for more information. */
 
+using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace System.Buffers
+namespace MessagePack
 {
     internal ref partial struct SequenceReader<T>
         where T : unmanaged, IEquatable<T>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReaderExtensions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReaderExtensions.cs
@@ -5,12 +5,13 @@
  * The .NET Foundation licenses this file to you under the MIT license.
  * See the LICENSE file in the project root for more information. */
 
+using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace System.Buffers
+namespace MessagePack
 {
     internal static partial class SequenceReaderExtensions
     {


### PR DESCRIPTION
It is no longer replaceable by what is included in netcoreapp3.1