### PR TITLE
Fix #971 Shared Projects incorrecly included.

### DIFF
--- a/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
+++ b/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
@@ -249,7 +249,7 @@ namespace MessagePack.GeneratorCore.Utils
                 {
                     if (item.Attribute("Label")?.Value == "Shared")
                     {
-                        var sharedRoot = Path.GetDirectoryName(Path.Combine(csProjRoot, item.Attribute("Project").Value));
+                        var sharedRoot = Path.GetFullPath(Path.Combine(csProjRoot, item.Attribute("Project").Value));
                         foreach (var file in IterateCsFileWithoutBinObj(Path.GetDirectoryName(sharedRoot)))
                         {
                             source.Add(file);


### PR DESCRIPTION
## Fix for #971

The issue was that shared projected are referenced with a `..\`
E.g.
```xml
  <Import Project="..\SharedProject.projitems" Label="Shared" />
```
CollectDocument incorrectly parsed that as navigation up by one folder instead of the `SharedProject` folder. 

`mpc -i 
C:\source\AllMyProjects\MsgPackProject.csproj` would call the `IterateCsFileWithoutBinObj()` method with the path 
`C:\source\AllMyProjects\..\SharedProject.projitems` instead of `C:\source\AllMyProjects\SharedProject.projitems`

This change calls Path.GetFullPath that resolves '..\' to the actual path.


