### PR TITLE
Shared projects were still not correctly parsed on Linux.

### DIFF
--- a/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
+++ b/src/MessagePack.GeneratorCore/Utils/PseudoCompilation.cs
@@ -249,7 +249,8 @@ namespace MessagePack.GeneratorCore.Utils
                 {
                     if (item.Attribute("Label")?.Value == "Shared")
                     {
-                        var sharedRoot = Path.GetFullPath(Path.Combine(csProjRoot, item.Attribute("Project").Value));
+                        var projectPath = NormalizeDirectorySeparators(item.Attribute("Project").Value);
+                        var sharedRoot = Path.GetFullPath(Path.Combine(csProjRoot, projectPath));
                         foreach (var file in IterateCsFileWithoutBinObj(Path.GetDirectoryName(sharedRoot)))
                         {
                             source.Add(file);


### PR DESCRIPTION
#### Shared projects were still not correctly parsed on Linux.

The problem was that the shared project references contain `\` by default. This is not recognized on Linux as a valid folder separator.  

```
  <Import Project="..\ApiClientServer\ApiClientServer.projitems" Label="Shared" />
  <Import Project="..\ApiServer\ApiServer.projitems" Label="Shared" />
  <Import Project="..\Commons\Commons.projitems" Label="Shared" />
```

Same Issue as #971 