### PR TITLE
warning disable 0162 for unity

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1295,6 +1295,8 @@ namespace MessagePack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy)
         {
+#pragma warning disable 0162
+
             if (Utilities.IsMono)
             {
                 // mono does not guarantee overlapped memcpy so for Unity and NETSTANDARD use slow path.
@@ -1317,6 +1319,8 @@ namespace MessagePack
             {
                 Buffer.MemoryCopy(source, destination, destinationSizeInBytes, sourceBytesToCopy);
             }
+
+#pragma warning restore 0162
         }
     }
 }


### PR DESCRIPTION
`Utilities.IsMono` is always true in Unity so shows unreachable code on Unity.

![image](https://user-images.githubusercontent.com/46207/87366560-f5178a80-c5b3-11ea-95c5-adeae7eee6f2.png)

This PR adds warning disable 0162 where uses Utilities.IsMono.