### PR TITLE
Mpc support for generic class unions

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -583,7 +583,7 @@ namespace MessagePackCompiler.CodeAnalysis
                 formatterBuilder.Append(type.ContainingNamespace.ToDisplayString() + ".");
             }
 
-            formatterBuilder.Append(GetMiniallyQualifiedClassName(type));
+            formatterBuilder.Append(GetMinimallyQualifiedClassName(type));
             formatterBuilder.Append("Formatter");
 
             var genericSerializationInfo = new GenericSerializationInfo
@@ -1004,7 +1004,7 @@ namespace MessagePackCompiler.CodeAnalysis
                 ConstructorParameters = constructorParameters.ToArray(),
                 IsIntKey = isIntKey,
                 Members = isIntKey ? intMembers.Values.ToArray() : stringMembers.Values.ToArray(),
-                Name = GetMiniallyQualifiedClassName(type),
+                Name = GetMinimallyQualifiedClassName(type),
                 FullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 Namespace = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString(),
                 HasIMessagePackSerializationCallbackReceiver = hasSerializationConstructor,
@@ -1015,7 +1015,7 @@ namespace MessagePackCompiler.CodeAnalysis
             return info;
         }
 
-        private static string GetMiniallyQualifiedClassName(INamedTypeSymbol type)
+        private static string GetMinimallyQualifiedClassName(INamedTypeSymbol type)
         {
             var name = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             name = name.Replace(".", "_");

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -429,6 +429,24 @@ namespace MessagePackCompiler.CodeAnalysis
             this.collectedUnionInfo.Add(info);
         }
 
+        private void CollectGenericUnion(INamedTypeSymbol type)
+        {
+            System.Collections.Immutable.ImmutableArray<TypedConstant>[] unionAttrs = type.GetAttributes().Where(x => x.AttributeClass.ApproximatelyEqual(this.typeReferences.UnionAttribute)).Select(x => x.ConstructorArguments).ToArray();
+            if (unionAttrs.Length == 0)
+            {
+                return;
+            }
+
+            var subTypes = unionAttrs.Select(x => x[1].Value).OfType<INamedTypeSymbol>().ToArray();
+            foreach (var sType in subTypes)
+            {
+                var info = GetObjectInfo(sType);
+                collectedObjectInfo.Add(info);
+            }
+        }
+
+
+
         private void CollectArray(IArrayTypeSymbol array)
         {
             ITypeSymbol elemType = array.ElementType;
@@ -547,6 +565,7 @@ namespace MessagePackCompiler.CodeAnalysis
             // Skip generic symbol declaration itself (open type, e.g. Foo<T>) because we can get nothing useful from it anyways.
             if (type.IsDefinition)
             {
+                this.CollectGenericUnion(type);
                 return;
             }
 
@@ -977,15 +996,18 @@ namespace MessagePackCompiler.CodeAnalysis
                 needsCastOnAfter = !type.GetMembers("OnAfterDeserialize").Any();
             }
 
-            string templateParametersString;
-            if (type.TypeParameters.Count() > 0)
-            {
-                templateParametersString = "<" + string.Join(", ", type.TypeParameters) + ">";
-            }
-            else
-            {
-                templateParametersString = null;
-            }
+            //string templateParametersString;
+            //if (type.TypeParameters.Count() > 0)
+            //{
+            //    templateParametersString = "<" + string.Join(", ", type.TypeParameters) + ">";
+            //}
+            //else
+            //{
+            //    templateParametersString = null;
+            //}
+
+            var nameBuilder = new StringBuilder();
+            FormatName(type, nameBuilder);
 
             var info = new ObjectSerializationInfo
             {
@@ -993,14 +1015,31 @@ namespace MessagePackCompiler.CodeAnalysis
                 ConstructorParameters = constructorParameters.ToArray(),
                 IsIntKey = isIntKey,
                 Members = isIntKey ? intMembers.Values.ToArray() : stringMembers.Values.ToArray(),
-                Name = type.ToDisplayString(ShortTypeNameFormat).Replace(".", "_"),
-                TemplateParametersString = templateParametersString,
+                Name = nameBuilder.ToString().Replace(".", "_"),
+                TemplateParametersString = null,
                 FullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 Namespace = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString(),
                 HasIMessagePackSerializationCallbackReceiver = hasSerializationConstructor,
                 NeedsCastOnAfter = needsCastOnAfter,
                 NeedsCastOnBefore = needsCastOnBefore,
             };
+
+            void FormatName(INamedTypeSymbol symbol, StringBuilder builder)
+            {
+                builder.Append(symbol.ToDisplayString(ShortTypeNameFormat));
+
+                if (symbol.IsGenericType)
+                {
+                    foreach (var genericType in symbol.TypeArguments)
+                    {
+                        if (genericType is INamedTypeSymbol nameGenericType)
+                        {
+                            builder.Append("_");
+                            FormatName(nameGenericType, builder);
+                        }
+                    }
+                }
+            }
 
             return info;
         }


### PR DESCRIPTION
### Mpc now supports generating formatters base on generic class unions.


- Added CollectGenericUnion method, which reads the union attributes on generic class definitions.
- Formatter names are now created by using the MinimallyQualifiedFormat to support generic classes. 

```CSharp
[MessagePackObject]
[Union(0, typeof(Wrapper<string>))]
[Union(1, typeof(Wrapper<int[]>))]
[Union(2, typeof(Wrapper<IEnumerable<Guid>>))]
public class Wrapper<T>
{
    [Key(0)]
    public T Content { get; set; }
}
```
Mpc will now recognize these Unions and generate the formatters accordingly 

```CSharp
...
    case 1: return new MessagePack.Formatters.Wrapper_string_Formatter();
    case 2: return new MessagePack.Formatters.Wrapper_intArray1_Formatter();
    case 3: return new MessagePack.Formatters.Wrapper_IEnumerable_Guid__Formatter();
...
```



### Issue

This enables #964 