### PR TITLE
Add packagejson and enable .meta for Unity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ dlldata.c
 *_p.c
 *_i.h
 *.ilk
-*.meta
 *.obj
 *.pch
 *.pdb

--- a/src/MessagePack.UnityClient/Assets/Plugins.meta
+++ b/src/MessagePack.UnityClient/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fb5bfc38043b7444b650388190ea48f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abcb1a88f6868eb4da993d61d6aeef51
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e64ff5fb973b7104f9c76c166c46f872
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor/HierarchyTreeBuilder.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor/HierarchyTreeBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50688156d1ed48e4d8e835a295e75699
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.MenuItems.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.MenuItems.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b7df7a947db56a4389c26cf3022840f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a1edf0e809243a4b95687c2fc05134c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/RuntimeUnitTestToolkit.asmdef.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/RuntimeUnitTestToolkit.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e1ad5407f3f9cec45a06a114f01e5d25
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/UnitTestRunner.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/UnitTestRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f083cc7755e80144a8cf0c8f5a36973
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/package.json.meta
+++ b/src/MessagePack.UnityClient/Assets/RuntimeUnitTestToolkit/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fa12a10b3c23d1459f13dcaab61deb2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scenes.meta
+++ b/src/MessagePack.UnityClient/Assets/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 00d5b24425ae0304c81e57f39639bbcc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scenes/Sandbox.unity.meta
+++ b/src/MessagePack.UnityClient/Assets/Scenes/Sandbox.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 730cfddf655e2164fb24fb1a88a0d9dd
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scenes/SandboxBehaviour.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scenes/SandboxBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a93abda481f95a48ad2009b8a549401
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b9088233d8c04747a541fc2613c16f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Editor.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af4eefe66f709854aaa6f1ce1f77dc41
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Editor/PackageExporter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Editor/PackageExporter.cs
@@ -18,7 +18,7 @@ public static class PackageExporter
 
         var path = Path.Combine(Application.dataPath, root);
         var assets = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
-            .Where(x => Path.GetExtension(x) == ".cs" || Path.GetExtension(x) == ".meta" || Path.GetExtension(x) == ".asmdef")
+            .Where(x => Path.GetExtension(x) == ".cs" || Path.GetExtension(x) == ".meta" || Path.GetExtension(x) == ".asmdef" || Path.GetExtension(x) == ".json")
             .Where(x => Path.GetFileNameWithoutExtension(x) != "_InternalVisibleTo")
             .Select(x => "Assets" + x.Replace(Application.dataPath, "").Replace(@"\", "/"))
             .ToArray();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Editor/PackageExporter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Editor/PackageExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce18e30e919869b4ca4b3087f79ecaa2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f4afbebafeba344faf44c6e707cbe6a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5af1793970d03ad42bce52b4e5e52bee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f684d4f03d4f86149990459d3054e2af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/IMessagePackSerializationCallbackReceiver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/IMessagePackSerializationCallbackReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1714a0e4e8a7354e90f52000abdddd9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BitOperations.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BitOperations.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b03a72c1f30f7a4f92f859479703d3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ed92c5d94108c44c93e31cd211ef1a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionHeader.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionHeader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27ccbf9800df8ad48be2d278e288b37e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionResult.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ExtensionResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e64fdfe376c995419f98e1384f33b3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31feb9a3f0d3ad14a8e475cfde930bc2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1185cc5503e9de47b44ccaf43b6d665
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionHelpers`2.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionHelpers`2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7aad614464db2c44a86b3b012e69b609
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DateTimeFormatters.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DateTimeFormatters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 619edb2526be60b41b30abdd4f514a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DictionaryFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abfb83d1822bbfc409f1f182e365e8ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13f8970ea4cf5834783e2cf34116798a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/EnumAsStringFormatter`1.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/EnumAsStringFormatter`1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dc4ef7e6eaadef48b04d66cb80b5697
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/GenericEnumFormatter`1.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/GenericEnumFormatter`1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16ee992e15116754bae00d06d3968ec1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IMessagePackFormatter`1.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IMessagePackFormatter`1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88421097d73e1de479d2004c6c23d2e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IgnoreFormatter`1.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/IgnoreFormatter`1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8916acfe5213bf940913b28c051e8231
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/MultiDimensionalArrayFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea25d9a859415b944a2932f414c2e353
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/NilFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/NilFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb4a59c3b8b4d144db65ac850daf0e53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/NullableFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/NullableFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05a403acf284b814abe1eabfbde39d1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e9c746624d882945a740f31fc8ebda9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae4d882aeb27bc54e991d848a5683387
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 368d3024351ce2e4abc42297e26c5108
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/UnsafeBinaryFormatters.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/UnsafeBinaryFormatters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b4bd9957393761499af403a5ef7ebfa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/HashCode.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/HashCode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56e9bfe9ee9b0354b8765ebefbac8d67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/IFormatterResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad1508639e1c32f489af46c74b5d3966
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: deb57fc90cc5d4e41882bb93fa71a4c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/AsymmetricKeyHashTable.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/AsymmetricKeyHashTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe3bf5c42bc27c1429b9e8bd1839b8e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/AutomataDictionary.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/AutomataDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14776842f04657842b044268a62cf6b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ByteArrayStringHashTable.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ByteArrayStringHashTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4df68ce4d7981d244b9a6e7991ef717d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/CodeGenHelpers.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/CodeGenHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e733605ab88010a4686b39fea27fe38b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DateTimeConstants.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DateTimeConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b25d1986c9838643ac125bc06eac98c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c3c62d8dc2404b43b89833c076e73ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ExpressionUtility.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ExpressionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79cc2e793fd7f1047b6c6e9718b59912
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/FarmHash.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/FarmHash.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97eed140914d52943ad6955224ce4577
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/GuidBits.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/GuidBits.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d68edf2bf3e742a4393af6f3e17345db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ILGeneratorExtensions.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ILGeneratorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 581e7074a007a6548a5e8408a4dad6dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ReflectionExtensions.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ReflectionExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6682a58039cc664c9e66b2d4b02d4d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/RuntimeTypeHandleEqualityComparer.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/RuntimeTypeHandleEqualityComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bceda592765280b4f8cb470f1ed9c532
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/Sequence`1.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/Sequence`1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46a3d0af338351d4b897b1323a92233a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 324a59f0b14af2544807199e055a1ac4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/TinyJsonReader.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/TinyJsonReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd9d3de59693d9f49be777193cd4e846
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/UnsafeMemory.Low.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/UnsafeMemory.Low.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea00cefaa2f44ee408f3975719c372cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac624935c8c91944fb27e94539d30d46
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Helper.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Helper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 135c503530b89854282de4c339084d74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Safe.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Safe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfa77bfa8e74a914cada4663d406de46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Safe32.Dirty.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Safe32.Dirty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3af434f443715345a95c309036329e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Safe64.Dirty.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Safe64.Dirty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2af5a6e86034ed44e91f32d31686d882
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Unsafe.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Unsafe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a48aac02d4c19049822a88ea40df7f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Unsafe32.Dirty.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Unsafe32.Dirty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70d519bda46ea2048bcde764d4f7088c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Unsafe64.Dirty.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.Unsafe64.Dirty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dd9161b1f56b464a8db9b3d96dca169
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/LZ4/LZ4Codec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 467a42ca49e959542b69efdf5b046249
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bbde805d927e795439d7a746d1749cab
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5abed96afe37b3c4e8d58b04054129c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCompression.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCompression.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 726b009260cea9e45a7c8541e288ca31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80f6863e06d288f489fcea7b5654b2cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSecurity.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSecurity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3c0e646c712f8d4f95190e18802ec99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializationException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 807a473ed38c2614db8e2e945c346dbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b519a41377bf3a489ab6db1e1044458
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.NonGeneric.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.NonGeneric.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e094e2dba201ea84ba880d525ce8532e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d33e055ed9d0f484d9048fb29fa84ba3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 621e07593f75d314eb0388aa92ef6805
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40b616b9ee299b04c97f5efb6c1cde9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a22e47d7013792844bd7882f11f25e1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Nil.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Nil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5ce64c07ab69e449bdf3e4144c199dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4fd16a9f0636a2448b08c076b0d0b3d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/AttributeFormatterResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/AttributeFormatterResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c02a22f37aeb19147a0a91b233f75622
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/BuiltinResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/BuiltinResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8576a58290a3c2f4b856a090338fe4e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CachingFormatterResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CachingFormatterResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b890291dfa50d64eb8a47edaeae5a2e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/CompositeResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 855ae905af3dec6449d0ced09b158a43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/ContractlessReflectionObjectResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/ContractlessReflectionObjectResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e632f1a629022ed4daaff789f1209a31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumAsStringResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumAsStringResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ceb07c86c3c5d534195759fcd8983804
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4100353110cfb7040b2fa50beb2390ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a246239c22950a44bb5bffdb3b388dd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c701699b2f5475d448a963b344407181
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf9a25b7376eeda47ab1f62b045063bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/NativeDateTimeResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/NativeDateTimeResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a20dfff612ed08419192bb868710915
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/NativeDecimalResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/NativeDecimalResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0711ad34c9883f244a09757b2470ed67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/NativeGuidResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/NativeGuidResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a30757bd25ef7c44ba11a2ecbe64a8c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/PrimitiveObjectResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/PrimitiveObjectResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e84d60bb85b40b458a001118316145d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StandardResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99e7c1a56d89ab645b824dae6b57d67c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StaticCompositeResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/StaticCompositeResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d904ee272668ccb448b3159036454caf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessContractlessStandardResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6db1c844b382ce54680f6d0ba3476abb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessObjectResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/TypelessObjectResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38df7384160fb4d478fcae83f15f45b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SafeBitConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a2f0bfda50859f4abf45bc978ea8b16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97164d8f34ce72f459fc5dff3dc7370f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReader.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73a26645b66741b4081b24bbec4379c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReaderExtensions.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequenceReaderExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74337ad77e62e5942b20dc45b62ddeab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StreamPolyfillExtensions.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StreamPolyfillExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a129c39f0ce55af4fac3a1a6bcc1380e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StringEncoding.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StringEncoding.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d573b17dc675bc4482fbc3e79f86dca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1245c7c06c9736e4f822470490920e08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/ForceSizePrimitiveFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/ForceSizePrimitiveFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ad9a757f1a235248aace5bb771bb786
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/MessagePackReader.Integers.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/MessagePackReader.Integers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d034a54b76ed3944da5cd3666462e89e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/PrimitiveFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/PrimitiveFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb48ea027ca8fa84c8677fac8791b318
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/TupleFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/TupleFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b14afc37320aee4daaa80c6b1e6529f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/UnsafeMemory.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/UnsafeMemory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50b6bcd206242f944833ba2d0548b028
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/ValueTupleFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/T4/ValueTupleFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98e54c0165ce30446938aa828e753eb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/ThisLibraryExtensionTypeCodes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d1907f02cbdd5942a88a8770336fe7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd59b5f0ae164f9409ead73a9c4be0fb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Extension.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Extension.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 031220404c62bc94da8ead6e623a7a44
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Extension/UnityBlitResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Extension/UnityBlitResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2780e6c52e347c540a336113d4a61fd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Extension/UnsafeBlitFormatter.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Extension/UnsafeBlitFormatter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 314e1d2058a6e9d4297aa329b34150d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Formatters.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/Formatters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43031b10b3132bf438ca856926d4a8f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/MessagePackWindow.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/MessagePackWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7b2124e98ab01345a59ac40b0979625
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/UnityResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Unity/UnityResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88a64133a719d3e40a7725f13b2f0191
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityShims.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/UnityShims.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2c1e3ee181f94c4dbe4c88385f7cbb4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f968cf11be4a47f42a5b1fcb33a6bf6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/_InternalVisibleTo.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/_InternalVisibleTo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f5e1e226cd7d794d9e787db25c31f2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/package.json
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "com.neuecc.messagepack",
+    "displayName": "MessagePack",
+    "version": "2.2.0",
+    "unity": "2018.4",
+    "description": "Extremely Fast MessagePack Serializer for C#.",
+    "keywords": [ "Serializer" ],
+    "license": "MIT",
+    "category": "Scripting",
+    "dependencies": {}
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/package.json.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b8639f4c743fac45bc51854f278b3b1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a7c2a7db1bc8424397eb60db9ab8c12
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8320adf513c8aba4b97520b6c54dcaf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Generated.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Generated.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c7c6cccd73eb424ab9e96c87dfc1acd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Generated/GeneratedResolver.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Generated/GeneratedResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83a940d45983fcc44838973ca450dd43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Loader.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Loader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f8fb4df4d9ecb74c88f774a73916828
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/MsgPack.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/MsgPack.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4e7b753d6e308c4ba5b722c4b7f3a2e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/MsgPack/MsgPack.dll.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/MsgPack/MsgPack.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 68264162529643f4b95651903372982e
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6818b90f9113faf449f89c3dbc32c121
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82287a4d7f4e1814baf603459b140505
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AnonymousTypeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b02878ea4ce0a994594c7cb54fab4df6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AutomataTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AutomataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 123a059d58a379d4dbde054490ad1637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ByteArrayComparerTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ByteArrayComparerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acb02d290e7e77140b874abea72854f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ByteArrayStringHashTableTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ByteArrayStringHashTableTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bb557e2a9ab1d2438ca432e6b020ca2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/CollectionTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/CollectionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79d444e32d5a37246b44a71688304d84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e20e6f466593ed04f9ffeba1f6177f26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa618486ff276824780d9f2aa954a2b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DictionaryTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DictionaryTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24cd6864c7f1ad24db1713b3c61ae333
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6633c2fd13eac445893e4533c8ed94a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb5b5155ee1d6d645a2342109205846d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverDerivedAttributeInheritanceTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47b972c73e6ec6448a18203ffbf057d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 562cafaf73e9d4c4ea996a2484c2edba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dee8a654fedabc4db607c4885127f24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3bd589513a14cd47bace33c5c16de98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/EnumAsStringTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b83e763440481945a514fc63c9950bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExtensionHeaderTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExtensionHeaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10cc4a629f149104cadf8142b8c36314
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FloatConversionTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FloatConversionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b9c16b487cc8db4a91cb3c0eceffcbf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FormatterTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FormatterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6702bd6f976f7bf4fbc4037456699be1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/GenericFormatters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 992838eac2c03014697d04c0c828b1c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/IgnoreTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/IgnoreTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cb2c993851bcaf4c80efe93ffea3552
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/LZ4Test.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/LZ4Test.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79f96ad327acd1a4b958a7ec0a6cbb4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 937508c226a289a4aaf0129228847cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackFormatterPerFieldTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackFormatterPerFieldTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d963dd8b7d8ac6479d853fc1169eee2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.ReadString.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.ReadString.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83aa417f2fe19a944a5efa3e1f083b40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 536dfa75c03e2f9469675dea1d5d606c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ee563309d2c26148b48c8532f2dc21b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerOptionsTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerOptionsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c3a2ab7df8497d4d9e0276feb196633
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e10329f1021f2394f80a113aee2f869b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dd9f6a05b1a3b34cadf94b3cf86f9d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackStreamReaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76cafd21b8f4d9a44a181dca662db083
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 652db240751a15b428e5ea19ebef89b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultiDimensionalArrayTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultiDimensionalArrayTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abb3ccc3c36c2bb43b477394f5611d1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultibyteCharPropertyTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MultibyteCharPropertyTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d2014cac87aaf742a885707ea1f0210
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NewGuidFormatterTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NewGuidFormatterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5ad4fb67f249a247974b64fff7ecc58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93a921c6f2817d949b3fbcad82d2bb0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ObjectResolverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5728df3325b81164097b89dd489018ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OldSpecBinaryFormatterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 817cf31957bc3cb439ad926b0e49c5b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OneByteAtATimeStream.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/OneByteAtATimeStream.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6a5f0376a7697c4bba2872792d438e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveObjectFormatterTests.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveObjectFormatterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9937df0c84c8d3940a110511ad8bc726
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f756a57ab361ee74ea4d34b8b3364a7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitivelikeFormatterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc0555d457a90e44d93a51a7aa6c1e21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/SpecifiedFormatterResolverTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/SpecifiedFormatterResolverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 541c1c4bfd8d6e145bcdd98476f12c25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/T4.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/T4.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d4384a987a607b4cb16bb618063f151
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/T4/MessagePackReaderTests.ReadInt.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/T4/MessagePackReaderTests.ReadInt.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f0dd84798929b04fb9a6e7495140b85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestBase.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d6b0bae2b5dbc44ab2da3063c1b76f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestConstants.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5dfa727ef6a4e5459b11035eb29674e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ToJsonTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ToJsonTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04cc8495a56deb048ad0f8fbd5d1e7cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/UnionResolverTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/UnionResolverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72cee026c3c7f864387e1fdf5e548b6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/UnsafeFormattersTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/UnsafeFormattersTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d292ecc87d9e98246a42c417da6d2eb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/UnsafeMemoryTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/UnsafeMemoryTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d4ee9d058bf0804c9992bba6ab39b64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/Utils.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5409056a0ea673e45831b32c3f86118d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/Utils/ChainingAssertion.Ext.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/Utils/ChainingAssertion.Ext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71c31e2815f05de47855e34c6850bbc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ValueTupleTest.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ValueTupleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e490457980adff4a819041212566e05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3190bb35428741143b9770de8d601246
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/ChainingAssertion.Unity.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/ChainingAssertion.Unity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85707c419a3bb384bb7dc5c4083e0b09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1770ba4f39d386941b4d373d271adfb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 00377cd9294f890479d50a176e226cf9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`.packagejson` is enable to use by Unity Package Manager.
src/MessagePack.UnityClient/Assets/Scripts/MessagePack/package.json

> Currently `Version` tag should replace manually, it is worst for release pipeline.

and remove `.meta` ignore in `.gitignore`.
Because `.meta` is important for Unity.