### PR TITLE
Add support for sortKeys on the MessagePackObjectAttribute

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 
 #pragma warning disable SA1649 // File name should match first type name
 
@@ -12,9 +13,15 @@ namespace MessagePack
     {
         public bool KeyAsPropertyName { get; private set; }
 
-        public MessagePackObjectAttribute(bool keyAsPropertyName = false)
+        /// <summary>
+        /// Gets a value indicating whether to sort the data before serialization.
+        /// </summary>
+        public bool SortKeys { get; private set; }
+
+        public MessagePackObjectAttribute(bool keyAsPropertyName = false, bool sortKeys = false)
         {
             this.KeyAsPropertyName = keyAsPropertyName;
+            this.SortKeys = sortKeys;
         }
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/Attributes.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
 
 #pragma warning disable SA1649 // File name should match first type name
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1870,10 +1870,10 @@ namespace MessagePack.Internal
             {
                 members = intMembers.Values.OrderBy(x => x.IntKey).ToArray();
             }
-            else if (contractAttr.SortKeys)
+            else if (contractAttr != null && contractAttr.SortKeys)
             {
                 members = stringMembers.Values
-                    .OrderBy(x => x.StringKey, StringComparer.CurrentCulture)
+                    .OrderBy(x => x.StringKey)
                     .ToArray();
             }
             else

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1870,6 +1870,12 @@ namespace MessagePack.Internal
             {
                 members = intMembers.Values.OrderBy(x => x.IntKey).ToArray();
             }
+            else if (contractAttr.SortKeys)
+            {
+                members = stringMembers.Values
+                    .OrderBy(x => x.StringKey, StringComparer.CurrentCulture)
+                    .ToArray();
+            }
             else
             {
                 members = stringMembers.Values


### PR DESCRIPTION
- Add a new property on the MessagePackObjectAttribute to indicate that we want to sort all the values based on the key.
- If the sortKeys is set to true, sort the EmittableMember values.
- This was added to be compatible with msgpack-javascript, which has option to sortKeys.
- Maybe this should be implemented in MessagePackSerializerOptions, so it can be decided pr. encoding as oppose to being wired into the type definition?