### PR TITLE
mpc fixes and Generated.cs refresh

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,3 +54,23 @@ jobs:
     clean: true
   - template: azure-pipelines/install-dependencies.yml
   - template: azure-pipelines/build_nonWindows.yml
+
+# This job ensures that we're running mpc regularly on the generated code that we check in.
+# It also helps exercise mpc so bugs don't go unnoticed.
+- job: codegen_diff
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - checkout: self
+    clean: true
+  - template: azure-pipelines/install-dependencies.yml
+  - pwsh: sandbox/codegen.ps1
+    displayName: Regenerate checked-in code
+  - bash: |
+        git add -u . # compare after applying git EOL normalization
+        git diff --cached --exit-code --stat \
+        || (echo "##[error] found changed files after build. please 'azure-pipelines/codegen.ps1'" \
+                 "and check in all changes" \
+            && git diff --cached \
+            && exit 1)
+    displayName: Check for uncommitted changes

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -14,8 +14,6 @@
 namespace MessagePack.Resolvers
 {
     using System;
-    using System.Buffers;
-    using MessagePack;
 
     public class GeneratedResolver : global::MessagePack.IFormatterResolver
     {
@@ -1160,7 +1158,7 @@ namespace MessagePack.Formatters
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -1454,7 +1452,7 @@ namespace MessagePack.Formatters
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -1724,7 +1722,7 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -2158,7 +2156,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -2228,7 +2226,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -2343,7 +2341,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -3156,7 +3154,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -3327,7 +3325,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {
@@ -3465,7 +3463,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 int key;
                 if (!this.____keyMapping.TryGetValue(stringKey, out key))
                 {

--- a/sandbox/Sandbox/README.md
+++ b/sandbox/Sandbox/README.md
@@ -1,9 +1,0 @@
-﻿# Updating Generated.cs
-
-Generated.cs is a generated file and should not be edited manually.
-To update Generated.cs, follow these steps:
-
-	dotnet build src\MessagePack -f netstandard2.0
-	dotnet run -p src\MessagePack.Generator -- -i sandbox\SharedData\SharedData.csproj -o sandbox\sandbox\Generated.cs
-
-The first step is because `sandbox\SharedData` references it and MPC doesn't build project references during code gen.

--- a/sandbox/Sandbox/code_generate.bat
+++ b/sandbox/Sandbox/code_generate.bat
@@ -1,1 +1,0 @@
-dotnet run -p "..\..\src\MessagePack.Generator\MessagePack.Generator.csproj" -- -i "..\SharedData\SharedData.csproj" -o "Generated.cs"

--- a/sandbox/Sandbox/codegen.bat
+++ b/sandbox/Sandbox/codegen.bat
@@ -1,0 +1,4 @@
+@echo off
+SETLOCAL
+set PS1UnderCmd=1
+powershell.exe -NoProfile -NoLogo -ExecutionPolicy bypass -Command "try { & '%~dpn0.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/sandbox/Sandbox/codegen.ps1
+++ b/sandbox/Sandbox/codegen.ps1
@@ -1,0 +1,1 @@
+dotnet run -p "$PSScriptRoot/../../src/MessagePack.Generator/MessagePack.Generator.csproj" -- -i "$PSScriptRoot/../SharedData/SharedData.csproj" -o "$PSScriptRoot/Generated.cs"

--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -14,8 +14,6 @@
 namespace MessagePack.Resolvers
 {
     using System;
-    using System.Buffers;
-    using MessagePack;
 
     public class GeneratedResolver : global::MessagePack.IFormatterResolver
     {

--- a/sandbox/TestData2/codegen.bat
+++ b/sandbox/TestData2/codegen.bat
@@ -1,0 +1,4 @@
+@echo off
+SETLOCAL
+set PS1UnderCmd=1
+powershell.exe -NoProfile -NoLogo -ExecutionPolicy bypass -Command "try { & '%~dpn0.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/sandbox/TestData2/codegen.ps1
+++ b/sandbox/TestData2/codegen.ps1
@@ -1,0 +1,1 @@
+dotnet run -p "$PSScriptRoot/../../src/MessagePack.Generator/MessagePack.Generator.csproj" -- -i "$PSScriptRoot/TestData2.csproj" -o "$PSScriptRoot/Generated.cs"

--- a/sandbox/codegen.ps1
+++ b/sandbox/codegen.ps1
@@ -1,0 +1,11 @@
+$codeGenScripts =
+    "$PSScriptRoot/Sandbox/codegen.ps1",
+    "$PSScriptRoot/TestData2/codegen.ps1"
+
+$exitCode = 0
+$codeGenScripts | % {
+    & $_
+    if ($LASTEXITCODE -ne 0) { $exitCode = 1 }
+}
+
+exit $exitCode

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -1017,7 +1017,8 @@ namespace MessagePackCompiler.CodeAnalysis
 
         private static string GetMinimallyQualifiedClassName(INamedTypeSymbol type)
         {
-            var name = type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+            var name = type.ContainingType is object ? GetMinimallyQualifiedClassName(type.ContainingType) + "_" : string.Empty;
+            name += type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             name = name.Replace(".", "_");
             name = name.Replace("<", "_");
             name = name.Replace(">", "_");

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -92,7 +92,7 @@ namespace MessagePackCompiler.CodeAnalysis
             }
 
             MessagePackFormatterAttribute = compilation.GetTypeByMetadataName("MessagePack.MessagePackFormatterAttribute");
-            if (IMessagePackSerializationCallbackReceiver == null)
+            if (MessagePackFormatterAttribute == null)
             {
                 throw new InvalidOperationException("failed to get metadata of MessagePack.MessagePackFormatterAttribute");
             }


### PR DESCRIPTION
* Fix TypeCollector's test of the wrong field
* Fix mpc codegen for nested types (fixes #1003)
* Add codegen runs to Azure Pipelines (to make sure generated.cs stays current)
* Update Generated.cs files (they'll never fall out of date again)