### PR TITLE
Improve generation of generic formatters

### DIFF
--- a/MessagePack.sln
+++ b/MessagePack.sln
@@ -78,7 +78,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.Generator", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.MSBuild.Tasks", "src\MessagePack.MSBuild.Tasks\MessagePack.MSBuild.Tasks.csproj", "{8DB135F5-A6FE-44E4-9853-7B48ED21F21B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePackAnalyzer.Tests", "tests\MessagePackAnalyzer.Tests\MessagePackAnalyzer.Tests.csproj", "{7E5FB4B9-A0F5-4B10-A1F3-03AC0BC8265A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePackAnalyzer.Tests", "tests\MessagePackAnalyzer.Tests\MessagePackAnalyzer.Tests.csproj", "{7E5FB4B9-A0F5-4B10-A1F3-03AC0BC8265A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePack.Generator.Tests", "tests\MessagePack.Generator.Tests\MessagePack.Generator.Tests.csproj", "{6AC51E68-4681-463A-B4B6-BD53517244B2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -270,6 +272,14 @@ Global
 		{7E5FB4B9-A0F5-4B10-A1F3-03AC0BC8265A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7E5FB4B9-A0F5-4B10-A1F3-03AC0BC8265A}.Release|NoVSIX.ActiveCfg = Release|Any CPU
 		{7E5FB4B9-A0F5-4B10-A1F3-03AC0BC8265A}.Release|NoVSIX.Build.0 = Release|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Debug|NoVSIX.ActiveCfg = Debug|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Debug|NoVSIX.Build.0 = Debug|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Release|NoVSIX.ActiveCfg = Release|Any CPU
+		{6AC51E68-4681-463A-B4B6-BD53517244B2}.Release|NoVSIX.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -298,6 +308,7 @@ Global
 		{32C91908-5CAD-4C95-B240-ACBBACAC9476} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
 		{8DB135F5-A6FE-44E4-9853-7B48ED21F21B} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
 		{7E5FB4B9-A0F5-4B10-A1F3-03AC0BC8265A} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
+		{6AC51E68-4681-463A-B4B6-BD53517244B2} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3911209-2DBF-47F8-98F6-BBC0EDFE63DE}

--- a/azure-pipelines/build_nonWindows.yml
+++ b/azure-pipelines/build_nonWindows.yml
@@ -20,3 +20,11 @@ steps:
     projects: tests/MessagePackAnalyzer.Tests/MessagePackAnalyzer.Tests.csproj
     arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
     testRunTitle: netcoreapp3.1-$(Agent.JobName)-Analyzers
+
+- task: DotNetCoreCLI@2
+  displayName: Run MessagePack.Generator.Tests
+  inputs:
+    command: test
+    projects: tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
+    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
+    testRunTitle: netcoreapp3.1-$(Agent.JobName)-Generator

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -2253,6 +2253,90 @@ namespace MessagePack.Formatters.SharedData
         }
     }
 
+    public sealed class DynamicArgumentTupleFormatter<T1,T2,T3,T4,T5,T6,T7,T8,T9> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
+    {
+
+
+        public void Serialize(ref MessagePackWriter writer, global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            IFormatterResolver formatterResolver = options.Resolver;
+            writer.WriteArrayHeader(9);
+            formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.Item1, options);
+            formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.Item2, options);
+            formatterResolver.GetFormatterWithVerify<T3>().Serialize(ref writer, value.Item3, options);
+            formatterResolver.GetFormatterWithVerify<T4>().Serialize(ref writer, value.Item4, options);
+            formatterResolver.GetFormatterWithVerify<T5>().Serialize(ref writer, value.Item5, options);
+            formatterResolver.GetFormatterWithVerify<T6>().Serialize(ref writer, value.Item6, options);
+            formatterResolver.GetFormatterWithVerify<T7>().Serialize(ref writer, value.Item7, options);
+            formatterResolver.GetFormatterWithVerify<T8>().Serialize(ref writer, value.Item8, options);
+            formatterResolver.GetFormatterWithVerify<T9>().Serialize(ref writer, value.Item9, options);
+        }
+
+        public global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                throw new InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            options.Security.DepthStep(ref reader);
+            IFormatterResolver formatterResolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+            var __Item1__ = default(T1);
+            var __Item2__ = default(T2);
+            var __Item3__ = default(T3);
+            var __Item4__ = default(T4);
+            var __Item5__ = default(T5);
+            var __Item6__ = default(T6);
+            var __Item7__ = default(T7);
+            var __Item8__ = default(T8);
+            var __Item9__ = default(T9);
+
+            for (int i = 0; i < length; i++)
+            {
+                var key = i;
+
+                switch (key)
+                {
+                    case 0:
+                        __Item1__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        break;
+                    case 1:
+                        __Item2__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        break;
+                    case 2:
+                        __Item3__ = formatterResolver.GetFormatterWithVerify<T3>().Deserialize(ref reader, options);
+                        break;
+                    case 3:
+                        __Item4__ = formatterResolver.GetFormatterWithVerify<T4>().Deserialize(ref reader, options);
+                        break;
+                    case 4:
+                        __Item5__ = formatterResolver.GetFormatterWithVerify<T5>().Deserialize(ref reader, options);
+                        break;
+                    case 5:
+                        __Item6__ = formatterResolver.GetFormatterWithVerify<T6>().Deserialize(ref reader, options);
+                        break;
+                    case 6:
+                        __Item7__ = formatterResolver.GetFormatterWithVerify<T7>().Deserialize(ref reader, options);
+                        break;
+                    case 7:
+                        __Item8__ = formatterResolver.GetFormatterWithVerify<T8>().Deserialize(ref reader, options);
+                        break;
+                    case 8:
+                        __Item9__ = formatterResolver.GetFormatterWithVerify<T9>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>(__Item1__, __Item2__, __Item3__, __Item4__, __Item5__, __Item6__, __Item7__, __Item8__, __Item9__);
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
     public sealed class Empty1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Empty1>
     {
 
@@ -2556,6 +2640,114 @@ namespace MessagePack.Formatters.SharedData
 
             var ____result = new global::SharedData.FooClass();
             ____result.XYZ = __XYZ__;
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class GenericClassFormatter<T1,T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericClass<T1, T2>>
+    {
+
+
+        public void Serialize(ref MessagePackWriter writer, global::SharedData.GenericClass<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            IFormatterResolver formatterResolver = options.Resolver;
+            writer.WriteArrayHeader(2);
+            formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
+            formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.MyProperty1, options);
+        }
+
+        public global::SharedData.GenericClass<T1, T2> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            IFormatterResolver formatterResolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+            var __MyProperty0__ = default(T1);
+            var __MyProperty1__ = default(T2);
+
+            for (int i = 0; i < length; i++)
+            {
+                var key = i;
+
+                switch (key)
+                {
+                    case 0:
+                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        break;
+                    case 1:
+                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.GenericClass<T1, T2>();
+            ____result.MyProperty0 = __MyProperty0__;
+            ____result.MyProperty1 = __MyProperty1__;
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class GenericStructFormatter<T1,T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericStruct<T1, T2>>
+    {
+
+
+        public void Serialize(ref MessagePackWriter writer, global::SharedData.GenericStruct<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            IFormatterResolver formatterResolver = options.Resolver;
+            writer.WriteArrayHeader(2);
+            formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
+            formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.MyProperty1, options);
+        }
+
+        public global::SharedData.GenericStruct<T1, T2> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                throw new InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            options.Security.DepthStep(ref reader);
+            IFormatterResolver formatterResolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+            var __MyProperty0__ = default(T1);
+            var __MyProperty1__ = default(T2);
+
+            for (int i = 0; i < length; i++)
+            {
+                var key = i;
+
+                switch (key)
+                {
+                    case 0:
+                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        break;
+                    case 1:
+                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.GenericStruct<T1, T2>();
+            ____result.MyProperty0 = __MyProperty0__;
+            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/Definitions.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/Definitions.cs
@@ -24,9 +24,11 @@ namespace MessagePackCompiler.CodeAnalysis
 
         public string FullName { get; set; }
 
-        public string TemplateParametersString { get; set; }
-
         public string Namespace { get; set; }
+
+        public string[] GenericTypeParameters { get; set; }
+
+        public bool IsOpenGenericType { get; set; }
 
         public bool IsIntKey { get; set; }
 
@@ -52,7 +54,7 @@ namespace MessagePackCompiler.CodeAnalysis
 
         public bool NeedsCastOnAfter { get; set; }
 
-        public string FormatterName => (this.Namespace == null ? this.Name : this.Namespace + "." + this.Name) + "Formatter";
+        public string FormatterName => (this.Namespace == null ? this.Name : this.Namespace + "." + this.Name) + "Formatter" + (this.IsOpenGenericType ? $"<{string.Join(",", this.GenericTypeParameters)}>" : string.Empty);
 
         public int WriteCount
         {

--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -55,7 +55,7 @@ namespace MessagePackCompiler
                 sw.Restart();
                 logger("Method Collect Start");
 
-                var (objectInfo, enumInfo, genericInfo, unionInfo, closedTypeGenericInfo) = collector.Collect();
+                var (objectInfo, enumInfo, genericInfo, unionInfo, closedTypeGenericInfo, openedTypeGenericInfo) = collector.Collect();
 
                 logger("Method Collect Complete:" + sw.Elapsed.ToString());
 

--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -55,7 +55,7 @@ namespace MessagePackCompiler
                 sw.Restart();
                 logger("Method Collect Start");
 
-                var (objectInfo, enumInfo, genericInfo, unionInfo, closedTypeGenericInfo, openedTypeGenericInfo) = collector.Collect();
+                var (objectInfo, enumInfo, genericInfo, unionInfo) = collector.Collect();
 
                 logger("Method Collect Complete:" + sw.Elapsed.ToString());
 
@@ -66,7 +66,6 @@ namespace MessagePackCompiler
                 {
                     // SingleFile Output
                     var objectFormatterTemplates = objectInfo
-                        .Concat(closedTypeGenericInfo)
                         .GroupBy(x => x.Namespace)
                         .Select(x => new FormatterTemplate()
                         {
@@ -138,7 +137,7 @@ namespace MessagePackCompiler
                 else
                 {
                     // Multiple File output
-                    foreach (var x in objectInfo.Concat(closedTypeGenericInfo))
+                    foreach (var x in objectInfo)
                     {
                         var template = new FormatterTemplate()
                         {
@@ -179,13 +178,13 @@ namespace MessagePackCompiler
                         Namespace = namespaceDot + "Resolvers",
                         FormatterNamespace = namespaceDot + "Formatters",
                         ResolverName = resolverName,
-                        RegisterInfos = genericInfo.Cast<IResolverRegisterInfo>().Concat(enumInfo).Concat(unionInfo).Concat(objectInfo).ToArray(),
+                        RegisterInfos = genericInfo.Cast<IResolverRegisterInfo>().Concat(enumInfo).Concat(unionInfo).Concat(objectInfo.Where(x => !x.IsOpenGenericType)).ToArray(),
                     };
 
                     await OutputToDirAsync(output, resolverTemplate.Namespace, resolverTemplate.ResolverName, multioutSymbol, resolverTemplate.TransformText(), cancellationToken).ConfigureAwait(false);
                 }
 
-                if (objectInfo.Length == 0 && enumInfo.Length == 0 && genericInfo.Length == 0 && unionInfo.Length == 0 && closedTypeGenericInfo.Length == 0)
+                if (objectInfo.Length == 0 && enumInfo.Length == 0 && genericInfo.Length == 0 && unionInfo.Length == 0)
                 {
                     logger("Generated result is empty, unexpected result?");
                 }

--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -97,7 +97,7 @@ namespace MessagePackCompiler
                         Namespace = namespaceDot + "Resolvers",
                         FormatterNamespace = namespaceDot + "Formatters",
                         ResolverName = resolverName,
-                        RegisterInfos = genericInfo.Cast<IResolverRegisterInfo>().Concat(enumInfo).Concat(unionInfo).Concat(objectInfo).ToArray(),
+                        RegisterInfos = genericInfo.Cast<IResolverRegisterInfo>().Concat(enumInfo).Concat(unionInfo).Concat(objectInfo.Where(x => !x.IsOpenGenericType)).ToArray(),
                     };
 
                     var sb = new StringBuilder();

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -48,7 +48,7 @@ namespace ");
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.Name));
             this.Write("Formatter");
-            this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.TemplateParametersString != null? objInfo.TemplateParametersString : ""));
+            this.Write(this.ToStringHelper.ToStringWithCulture((objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters)}>" : "")));
             this.Write(" : global::MessagePack.Formatters.IMessagePackFormatter<");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(">\r\n    {\r\n");

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -26,7 +26,7 @@ namespace <#= Namespace #>
     using MessagePack;
 <# foreach(var objInfo in ObjectSerializationInfos) { #>
 
-    public sealed class <#= objInfo.Name #>Formatter<#= objInfo.TemplateParametersString != null? objInfo.TemplateParametersString : "" #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
+    public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters)}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
     {
 <# foreach(var item in objInfo.Members) { #>
 <# if(item.CustomFormatterTypeName != null) { #>

--- a/tests/MessagePack.Generator.Tests/GenerateEnumFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateEnumFormatterTest.cs
@@ -1,0 +1,62 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MessagePack.Generator.Tests
+{
+    public class GenerateEnumFormatterTest
+    {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public GenerateEnumFormatterTest(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async Task EnumFormatter()
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyMessagePackObject
+    {
+        [Key(0)]
+        public MyEnum EnumValue { get; set; }
+    }
+
+    public enum MyEnum
+    {
+        A, B, C
+    }
+}
+            ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+            symbols.Should().Contain(x => x.Name == "MyEnumFormatter");
+        }
+    }
+}

--- a/tests/MessagePack.Generator.Tests/GenerateEnumFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateEnumFormatterTest.cs
@@ -25,6 +25,7 @@ namespace MessagePack.Generator.Tests
             using var tempWorkarea = TemporaryProjectWorkarea.Create();
             var contents = @"
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace TempProject

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -26,6 +26,7 @@ namespace MessagePack.Generator.Tests
             using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
             var contents = @"
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace TempProject
@@ -54,11 +55,11 @@ namespace TempProject
                 string.Empty);
 
             var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
             var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
             var formatters = symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).ToArray();
-            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<IEnumerable<System.Guid>>>");
-            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<int[]>>");
-            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<string>>");
+            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<T>>");
         }
 
         [Fact]
@@ -67,6 +68,7 @@ namespace TempProject
             using var tempWorkarea = TemporaryProjectWorkarea.Create();
             var contents = @"
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace TempProject
@@ -92,6 +94,8 @@ namespace TempProject
                 string.Empty);
 
             var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
             var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
 
             var types = symbols.Select(x => x.ToDisplayString()).ToArray();
@@ -107,6 +111,7 @@ namespace TempProject
             using var tempWorkarea = TemporaryProjectWorkarea.Create();
             var contents = @"
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace TempProject
@@ -134,6 +139,8 @@ namespace TempProject
                 string.Empty);
 
             var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
             var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
 
             var types = symbols.Select(x => x.ToDisplayString()).ToArray();

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -24,6 +24,107 @@ namespace MessagePack.Generator.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public async Task NullableFormatter(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyObject
+    {
+        [Key(0)]
+        public int? ValueNullableInt { get; set; }
+        [Key(1)]
+        public MyEnum? ValueNullableEnum { get; set; }
+        [Key(2)]
+        public ValueTuple<int, long>? ValueNullableStruct { get; set; }
+    }
+
+    public enum MyEnum
+    {
+        A, B, C
+    }
+}
+            ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            compilation.GetResolverKnownFormatterTypes().Should().Contain(new[]
+            {
+                "global::MessagePack.Formatters.NullableFormatter<(int, long)>",
+                "global::MessagePack.Formatters.NullableFormatter<global::TempProject.MyEnum>",
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WellKnownGenericsFormatter(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyObject
+    {
+        [Key(0)]
+        public List<int> ValueList { get; set; }
+        [Key(1)]
+        public List<List<int>> ValueListNested { get; set; }
+        [Key(2)]
+        public ValueTuple<int, string, long> ValueValueTuple { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            compilation.GetResolverKnownFormatterTypes().Should().Contain(new[]
+            {
+                "global::MessagePack.Formatters.ListFormatter<int>",
+                "global::MessagePack.Formatters.ListFormatter<global::System.Collections.Generic.List<int>>",
+                "global::MessagePack.Formatters.ValueTupleFormatter<int, string, long>",
+                "TempProject.Generated.Formatters.TempProject.MyObjectFormatter",
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public async Task GenericsUnionFormatter(bool isSingleFileOutput)
         {
             using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
@@ -91,7 +192,6 @@ namespace TempProject
         [Key(0)]
         public T Content { get; set; }
     }
-
 
     [MessagePackObject]
     public class MyObject
@@ -207,6 +307,56 @@ namespace TempProject
                 "TempProject.Generated.Formatters.TempProject.MyObjectFormatter",
                 "TempProject.Generated.Formatters.TempProject.MyObjectNestedFormatter",
             });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GenericsOfTFormatter_FormatterOnly(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    // This type is not used by the project.
+    // It may be referenced by other projects.
+    [MessagePackObject]
+    public class MyGenericObject<T>
+    {
+        [Key(0)]
+        public T Content { get; set; }
+    }
+}
+                ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var types = symbols.Select(x => x.ToDisplayString()).ToArray();
+            types.Should().Contain("TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T>");
+
+            var formatters = symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).ToArray();
+            formatters.Should().Contain("MessagePack.Formatters.IMessagePackFormatter<TempProject.MyGenericObject<T>>");
+
+            // The generated resolver doesn't know closed-type generic formatter.
+            compilation.GetResolverKnownFormatterTypes().Should().BeEmpty();
         }
     }
 }

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -1,0 +1,146 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MessagePack.Generator.Tests
+{
+    public class GenerateGenericsFormatterTest
+    {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public GenerateGenericsFormatterTest(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async Task GenericsUnionFormatter()
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    [Union(0, typeof(Wrapper<string>))]
+    [Union(1, typeof(Wrapper<int[]>))]
+    [Union(2, typeof(Wrapper<IEnumerable<Guid>>))]
+    public class Wrapper<T>
+    {
+        [Key(0)]
+        public T Content { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+            var formatters = symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).ToArray();
+            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<IEnumerable<System.Guid>>>");
+            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<int[]>>");
+            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.Wrapper<string>>");
+        }
+
+        [Fact]
+        public async Task GenericsOfTFormatter()
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
+            var contents = @"
+using System;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T>
+    {
+        [Key(0)]
+        public T Content { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var types = symbols.Select(x => x.ToDisplayString()).ToArray();
+            types.Should().Contain("TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T>");
+
+            var formatters = symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).ToArray();
+            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.MyGenericObject<T>>");
+        }
+
+        [Fact]
+        public async Task GenericsOfT1T2Formatter()
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T1, T2>
+    {
+        [Key(0)]
+        public T1 ValueA { get; set; }
+        [Key(1)]
+        public T2 ValueB { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var types = symbols.Select(x => x.ToDisplayString()).ToArray();
+            types.Should().Contain("TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T1, T2>");
+
+            var formatters = symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).ToArray();
+            formatters.Should().Contain(x => x == "MessagePack.Formatters.IMessagePackFormatter<TempProject.MyGenericObject<T1, T2>>");
+        }
+    }
+}

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -23,7 +23,7 @@ namespace MessagePack.Generator.Tests
         [Fact]
         public async Task GenericsUnionFormatter()
         {
-            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
             var contents = @"
 using System;
 using MessagePack;
@@ -64,7 +64,7 @@ namespace TempProject
         [Fact]
         public async Task GenericsOfTFormatter()
         {
-            using var tempWorkarea = TemporaryProjectWorkarea.Create(false);
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
             var contents = @"
 using System;
 using MessagePack;

--- a/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
+++ b/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+
+    <IsPackable>false</IsPackable>
+    <CodeAnalysisRuleSet>..\MessagePack.Tests\MessagePack.Tests.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MessagePack\MessagePack.csproj" />
+    <ProjectReference Include="..\..\src\MessagePack.Annotations\MessagePack.Annotations.csproj" />
+    <ProjectReference Include="..\..\src\MessagePack.GeneratorCore\MessagePack.GeneratorCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
+++ b/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
+++ b/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
@@ -85,6 +85,7 @@ namespace MessagePack.Generator.Tests
                 .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Linq.dll")))
                 .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Console.dll")))
                 .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Runtime.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Memory.dll")))
                 .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "netstandard.dll")))
                 .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
                 .AddReferences(MetadataReference.CreateFromFile(typeof(MessagePack.MessagePackObjectAttribute).Assembly.Location))

--- a/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
+++ b/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
@@ -70,7 +70,7 @@ namespace MessagePack.Generator.Tests
             File.WriteAllText(Path.Combine(ProjectDirectory, fileName), contents.Trim());
         }
 
-        public CompilationContainer GetOutputCompilation()
+        public OutputCompilation GetOutputCompilation()
         {
             var refAsmDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
 
@@ -91,7 +91,7 @@ namespace MessagePack.Generator.Tests
                 .AddReferences(MetadataReference.CreateFromFile(typeof(IMessagePackFormatter<>).Assembly.Location))
                 .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-            return new CompilationContainer(compilation);
+            return new OutputCompilation(compilation);
         }
 
         public void Dispose()
@@ -103,11 +103,11 @@ namespace MessagePack.Generator.Tests
         }
     }
 
-    public class CompilationContainer
+    public class OutputCompilation
     {
         public Compilation Compilation { get; }
 
-        public CompilationContainer(Compilation compilation)
+        public OutputCompilation(Compilation compilation)
         {
             this.Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
         }

--- a/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
+++ b/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using MessagePack.Formatters;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace MessagePack.Generator.Tests
+{
+    /// <summary>
+    /// Provides a temporary work area for unit testing.
+    /// </summary>
+    public class TemporaryProjectWorkarea : IDisposable
+    {
+        private readonly string tempDirPath;
+        private readonly string csprojFileName = "TempProject.csproj";
+        private readonly bool cleanOnDisposing;
+
+        public string CsProjectPath { get; }
+
+        public string ProjectDirectory { get; }
+
+        public string OutputDirectory { get; }
+
+        public static TemporaryProjectWorkarea Create(bool cleanOnDisposing = true)
+        {
+            return new TemporaryProjectWorkarea(cleanOnDisposing);
+        }
+
+        private TemporaryProjectWorkarea(bool cleanOnDisposing)
+        {
+            this.cleanOnDisposing = cleanOnDisposing;
+            this.tempDirPath = Path.Combine(Path.GetTempPath(), $"MessagePack.Generator.Tests-{Guid.NewGuid()}");
+
+            ProjectDirectory = Path.Combine(tempDirPath, "Project");
+            OutputDirectory = Path.Combine(tempDirPath, "Output");
+
+            Directory.CreateDirectory(ProjectDirectory);
+            Directory.CreateDirectory(OutputDirectory);
+
+            var solutionRootDir = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../.."));
+            var messagePackProjectDir = Path.Combine(solutionRootDir, "src/MessagePack/MessagePack.csproj");
+            var annotationsProjectDir = Path.Combine(solutionRootDir, "src/MessagePack.Annotations/MessagePack.Annotations.csproj");
+
+            CsProjectPath = Path.Combine(ProjectDirectory, csprojFileName);
+            var csprojContents = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include=""" + messagePackProjectDir + @""" />
+    <ProjectReference Include=""" + annotationsProjectDir + @""" />
+  </ItemGroup>
+</Project>
+";
+            AddFileToProject(csprojFileName, csprojContents);
+        }
+
+        public void AddFileToProject(string fileName, string contents)
+        {
+            File.WriteAllText(Path.Combine(ProjectDirectory, fileName), contents.Trim());
+        }
+
+        public CompilationContainer GetOutputCompilation()
+        {
+            var compilation = CSharpCompilation.Create(Guid.NewGuid().ToString())
+                .AddSyntaxTrees(
+                    Directory.EnumerateFiles(ProjectDirectory, "*.cs", SearchOption.AllDirectories)
+                        .Concat(Directory.EnumerateFiles(OutputDirectory, "*.cs", SearchOption.AllDirectories))
+                        .Select(x => CSharpSyntaxTree.ParseText(File.ReadAllText(x), CSharpParseOptions.Default, x)))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(MessagePack.MessagePackObjectAttribute).Assembly.Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(IMessagePackFormatter<>).Assembly.Location));
+
+            return new CompilationContainer(compilation);
+        }
+
+        public void Dispose()
+        {
+            if (cleanOnDisposing)
+            {
+                Directory.Delete(tempDirPath, true);
+            }
+        }
+    }
+
+    public class CompilationContainer
+    {
+        public Compilation Compilation { get; }
+
+        public CompilationContainer(Compilation compilation)
+        {
+            this.Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
+        }
+
+        public INamedTypeSymbol[] GetNamedTypeSymbolsFromGenerated()
+        {
+            return Compilation.SyntaxTrees
+                .Select(x => Compilation.GetSemanticModel(x))
+                .SelectMany(semanticModel =>
+                {
+                    return semanticModel.SyntaxTree.GetRoot()
+                        .DescendantNodes()
+                        .Select(x => semanticModel.GetDeclaredSymbol(x))
+                        .OfType<INamedTypeSymbol>();
+                })
+                .ToArray();
+        }
+    }
+}

--- a/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
+++ b/tests/MessagePack.Generator.Tests/TemporaryProjectWorkarea.cs
@@ -70,14 +70,24 @@ namespace MessagePack.Generator.Tests
 
         public CompilationContainer GetOutputCompilation()
         {
+            var refAsmDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+
             var compilation = CSharpCompilation.Create(Guid.NewGuid().ToString())
                 .AddSyntaxTrees(
                     Directory.EnumerateFiles(ProjectDirectory, "*.cs", SearchOption.AllDirectories)
                         .Concat(Directory.EnumerateFiles(OutputDirectory, "*.cs", SearchOption.AllDirectories))
                         .Select(x => CSharpSyntaxTree.ParseText(File.ReadAllText(x), CSharpParseOptions.Default, x)))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Private.CoreLib.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Runtime.Extensions.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Collections.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Linq.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Console.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "System.Runtime.dll")))
+                .AddReferences(MetadataReference.CreateFromFile(Path.Combine(refAsmDir, "netstandard.dll")))
                 .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
                 .AddReferences(MetadataReference.CreateFromFile(typeof(MessagePack.MessagePackObjectAttribute).Assembly.Location))
-                .AddReferences(MetadataReference.CreateFromFile(typeof(IMessagePackFormatter<>).Assembly.Location));
+                .AddReferences(MetadataReference.CreateFromFile(typeof(IMessagePackFormatter<>).Assembly.Location))
+                .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
             return new CompilationContainer(compilation);
         }


### PR DESCRIPTION
When generating the formatter, the generator generates a formatter for each closed generics type.

In this PR will change this behavior to generate the formatter for open types. And resolver will use closed generics type formatter with type parameters.

The current generator generates the following close type formatters and resolver.

```csharp
...
internal static class GeneratedResolverGetFormatterHelper
{
    ...
    internal static object GetFormatter(Type t)
    {
        ...
        switch (key)
        {
            case 0: return new MessagePack.Formatters.TempProject.MyGenericObject_int_Formatter();
            case 1: return new MessagePack.Formatters.TempProject.MyGenericObject_long_Formatter();
            ...
        }
        ...
    }
    ...
}
...
public sealed class MyGenericObject_int_Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TempProject.MyGenericObject<int>>
{
    public void Serialize(ref MessagePackWriter writer, global::TempProject.MyGenericObject<int> value, global::MessagePack.MessagePackSerializerOptions options)
    ...
}
...
public sealed class MyGenericObject_long_Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TempProject.MyGenericObject<long>>
{
    public void Serialize(ref MessagePackWriter writer, global::TempProject.MyGenericObject<long> value, global::MessagePack.MessagePackSerializerOptions options)
    ...
}
```

This PR changes the generation of an open generics type formatter as follows.


```csharp
...
internal static class GeneratedResolverGetFormatterHelper
{
    ...
    internal static object GetFormatter(Type t)
    {
        ...
        switch (key)
        {
            case 0: return new MessagePack.Formatters.TempProject.MyGenericObjectFormatter<int>();
            case 1: return new MessagePack.Formatters.TempProject.MyGenericObjectFormatter<long>();
            ...
        }
        ...
    }
    ...
}
...
public sealed class MyGenericObjectFormatter<T> : global::MessagePack.Formatters.IMessagePackFormatter<global::TempProject.MyGenericObject<T>>
{
    public void Serialize(ref MessagePackWriter writer, global::TempProject.MyGenericObject<T> value, global::MessagePack.MessagePackSerializerOptions options)
    ...
}

```