### PR TITLE
fix(1011): Override references to load *.dll without autoReference:true

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
@@ -5,8 +5,14 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+      "System.Memory.dll"
+      ,"System.Buffers.dll"
+      ,"System.Threading.Tasks.Extensions.dll"
+      ,"System.Runtime.CompilerServices.Unsafe.dll"
+      ,"System.Runtime.Extensions.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": []


### PR DESCRIPTION
Fixes #1011 by using manual overrides and specifying all required *.dll