### PR TITLE
Add support for Fluent EventTime fixext8(0), used by fluentd and fluent-sdk-*

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs
@@ -272,7 +272,8 @@ namespace MessagePack.Formatters
                     return reader.ReadBytes()?.ToArray();
                 case MessagePackType.Extension:
                     ExtensionHeader ext = reader.ReadExtensionFormatHeader();
-                    if (ext.TypeCode == ReservedMessagePackExtensionTypeCode.DateTime)
+                    if (ext.TypeCode == ReservedMessagePackExtensionTypeCode.DateTime ||
+                        ext.TypeCode == ReservedMessagePackExtensionTypeCode.DateTimeFluentForward)
                     {
                         return reader.ReadDateTime(ext);
                     }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackCode.cs
@@ -227,7 +227,10 @@ namespace MessagePack
 #endif
     static class ReservedMessagePackExtensionTypeCode
     {
+        // https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type
         public const sbyte DateTime = -1;
+        // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format
+        public const sbyte DateTimeFluentForward = 0;
     }
 
 #if MESSAGEPACK_INTERNAL

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackBinaryTest.cs
@@ -773,6 +773,33 @@ namespace MessagePack.Tests
             result.Is(target);
         }
 
+        // FixExt8(0) => seconds(32) + nanoseconds(32) | [1970-01-01 00:00:00.000000000 UTC, 2106-02-07 06:28:16.000000000 UTC) range
+        public static object[][] DateTimeFluentEventTimeTestData = new object[][]
+        {
+            new object[] { new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), 10 },
+            new object[] { new DateTime(2010, 12, 1, 3, 4, 57, 0, DateTimeKind.Utc), 10 },
+            new object[] { new DateTime(2106, 2, 7, 6, 28, 15, 0, DateTimeKind.Utc), 10 },
+        };
+
+        [Theory]
+        [MemberData(nameof(DateTimeFluentEventTimeTestData))]
+        public void DateTimeFluentEventTimeTest(DateTime target, int expectedLength)
+        {
+            var sequence = new Sequence<byte>();
+            var writer = new MessagePackWriter(sequence);
+            writer.EventTime = true;
+            writer.Write(target);
+            writer.Flush();
+            var returnLength = sequence.Length;
+            returnLength.Is(expectedLength);
+
+            var sequenceReader = new MessagePackReader(sequence.AsReadOnlySequence);
+            DateTime result = sequenceReader.ReadDateTime();
+            sequenceReader.End.IsTrue();
+
+            result.Is(target);
+        }
+
         [Fact]
         public void IntegerRangeTest()
         {

--- a/src/MessagePack/PublicAPI.Shipped.txt
+++ b/src/MessagePack/PublicAPI.Shipped.txt
@@ -589,6 +589,8 @@ MessagePack.MessagePackWriter.GetSpan(int length) -> System.Span<byte>
 MessagePack.MessagePackWriter.MessagePackWriter(System.Buffers.IBufferWriter<byte> writer) -> void
 MessagePack.MessagePackWriter.OldSpec.get -> bool
 MessagePack.MessagePackWriter.OldSpec.set -> void
+MessagePack.MessagePackWriter.EventTime.get -> bool
+MessagePack.MessagePackWriter.EventTime.set -> void
 MessagePack.MessagePackWriter.Write(System.DateTime dateTime) -> void
 MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<byte> src) -> void
 MessagePack.MessagePackWriter.Write(System.ReadOnlySpan<char> value) -> void

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿const MessagePack.ReservedMessagePackExtensionTypeCode.DateTimeFluentForward = 0 -> sbyte


### PR DESCRIPTION
Fluent forward protocol has a timestamp definition for nanosecond precision, which likely precedes the ext(-1) . It is documented in https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#eventtime-ext-format

I use fluent-sdk-{go, ruby} to send msgpack encoded messages to my C# application and need the reader to understand EventTime.