### PR TITLE
mpc - add externalIgnoreTypeNames feature

### DIFF
--- a/src/MessagePack.Generator/MessagepackCompiler.cs
+++ b/src/MessagePack.Generator/MessagepackCompiler.cs
@@ -45,7 +45,8 @@ namespace MessagePack.Generator
             [Option("r", "Set resolver name.")] string resolverName = "GeneratedResolver",
             [Option("n", "Set namespace root name.")] string @namespace = "MessagePack",
             [Option("m", "Force use map mode serialization.")] bool useMapMode = false,
-            [Option("ms", "Generate #if-- files by symbols, split with ','.")] string? multipleIfDirectiveOutputSymbols = null)
+            [Option("ms", "Generate #if-- files by symbols, split with ','.")] string? multipleIfDirectiveOutputSymbols = null,
+            [Option("ei", "Ignore type names.")] string[]? externalIgnoreTypeNames = null)
         {
             Workspace? workspace = null;
             try
@@ -68,7 +69,8 @@ namespace MessagePack.Generator
                         resolverName,
                         @namespace,
                         useMapMode,
-                        multipleIfDirectiveOutputSymbols).ConfigureAwait(false);
+                        multipleIfDirectiveOutputSymbols,
+                        externalIgnoreTypeNames).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -265,6 +265,8 @@ namespace MessagePackCompiler.CodeAnalysis
 
         private readonly bool disallowInternal;
 
+        private HashSet<string> externalIgnoreTypeNames;
+
         // visitor workspace:
         private HashSet<ITypeSymbol> alreadyCollected;
         private List<ObjectSerializationInfo> collectedObjectInfo;
@@ -273,12 +275,13 @@ namespace MessagePackCompiler.CodeAnalysis
         private List<UnionSerializationInfo> collectedUnionInfo;
         private List<ObjectSerializationInfo> collectedClosedTypeGenericInfo;
 
-        public TypeCollector(Compilation compilation, bool disallowInternal, bool isForceUseMap, Action<string> logger)
+        public TypeCollector(Compilation compilation, bool disallowInternal, bool isForceUseMap, string[] ignoreTypeNames, Action<string> logger)
         {
             this.logger = logger;
             this.typeReferences = new ReferenceSymbols(compilation, logger);
             this.disallowInternal = disallowInternal;
             this.isForceUseMap = isForceUseMap;
+            this.externalIgnoreTypeNames = new HashSet<string>(ignoreTypeNames ?? Array.Empty<string>());
 
             targetTypes = compilation.GetNamedTypeSymbols()
                 .Where(x =>
@@ -340,6 +343,11 @@ namespace MessagePackCompiler.CodeAnalysis
             }
 
             if (this.embeddedTypes.Contains(typeSymbol.ToString()))
+            {
+                return;
+            }
+
+            if (this.externalIgnoreTypeNames.Contains(typeSymbol.ToString()))
             {
                 return;
             }

--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -36,6 +36,7 @@ namespace MessagePackCompiler
         /// <param name="namespace">The namespace for the generated type to be created in. May be null.</param>
         /// <param name="useMapMode">A boolean value that indicates whether all formatters should use property maps instead of more compact arrays.</param>
         /// <param name="multipleIfDirectiveOutputSymbols">A comma-delimited list of symbols that should surround redundant generated files. May be null.</param>
+        /// <param name="externalIgnoreTypeNames"> May be null.</param>
         /// <returns>A task that indicates when generation has completed.</returns>
         public async Task GenerateFileAsync(
            Compilation compilation,
@@ -43,7 +44,8 @@ namespace MessagePackCompiler
            string resolverName,
            string @namespace,
            bool useMapMode,
-           string multipleIfDirectiveOutputSymbols)
+           string multipleIfDirectiveOutputSymbols,
+           string[] externalIgnoreTypeNames)
         {
             var namespaceDot = string.IsNullOrWhiteSpace(@namespace) ? string.Empty : @namespace + ".";
             var multipleOutputSymbols = multipleIfDirectiveOutputSymbols?.Split(',') ?? Array.Empty<string>();
@@ -54,7 +56,7 @@ namespace MessagePackCompiler
             {
                 logger("Project Compilation Start:" + compilation.AssemblyName);
 
-                var collector = new TypeCollector(compilation, true, useMapMode, x => Console.WriteLine(x));
+                var collector = new TypeCollector(compilation, true, useMapMode, externalIgnoreTypeNames, x => Console.WriteLine(x));
 
                 logger("Project Compilation Complete:" + sw.Elapsed.ToString());
 

--- a/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
+++ b/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
@@ -42,7 +42,7 @@ namespace MessagePack.MSBuild.Tasks
 
         public bool UseMapMode { get; set; }
 
-        public string[] ExternalIgnoreTypeNames { get; set; }
+        public string[]? ExternalIgnoreTypeNames { get; set; }
 
         [Output]
         public string? GeneratedOutputPath { get; set; }

--- a/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
+++ b/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
@@ -42,6 +42,8 @@ namespace MessagePack.MSBuild.Tasks
 
         public bool UseMapMode { get; set; }
 
+        public string[] ExternalIgnoreTypeNames { get; set; }
+
         [Output]
         public string? GeneratedOutputPath { get; set; }
 
@@ -70,7 +72,8 @@ namespace MessagePack.MSBuild.Tasks
                     ResolverName,
                     Namespace,
                     UseMapMode,
-                    null).GetAwaiter().GetResult();
+                    null,
+                    ExternalIgnoreTypeNames).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
For example https://github.com/Cysharp/Ulid/issues/12
when third-party library provides external resolver, mpc should ignore there types.

I've added `string[]? externalIgnoreTypeNames` parameter that can set ignore type from mpc.