### PR TITLE
Run net472 tests on mono

### DIFF
--- a/azure-pipelines/build_nonWindows.yml
+++ b/azure-pipelines/build_nonWindows.yml
@@ -6,12 +6,15 @@ steps:
     arguments: --no-restore /p:platform=NoVSIX -c $(BuildConfiguration)
 
 - task: DotNetCoreCLI@2
-  displayName: Run MessagePack.Tests
+  displayName: Run MessagePack.Tests (netcoreapp2.1)
   inputs:
     command: test
     projects: tests/MessagePack.Tests/MessagePack.Tests.csproj
     arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
     testRunTitle: netcoreapp2.1-$(Agent.JobName)
+
+- bash: mono ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/MessagePack.Tests/$(BuildConfiguration)/net472/MessagePack.Tests.dll -parallel none -html $(BUILD.ARTIFACTSTAGINGDIRECTORY)/build_logs/mono_testrun.html
+  displayName: Run MessagePack.Tests (mono)
 
 - task: DotNetCoreCLI@2
   displayName: Run MessagePackAnalyzer.Tests

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FormatterTest.cs
@@ -291,10 +291,16 @@ namespace MessagePack.Tests
         }
 
         [Fact]
-        public void UriTest()
+        public void UriTest_Absolute()
         {
             var absolute = new Uri("http://google.com/");
             this.Convert(absolute).ToString().Is("http://google.com/");
+        }
+
+        [SkippableFact]
+        public void UriTest_Relative()
+        {
+            Skip.If(TestUtilities.IsRunningOnMono && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             var relative = new Uri("/me/", UriKind.Relative);
             this.Convert(relative).ToString().Is("/me/");

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
@@ -1,0 +1,18 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace MessagePack.Tests
+{
+    internal static class TestUtilities
+    {
+        /// <summary>
+        /// Gets a value indicating whether the mono runtime is executing this code.
+        /// </summary>
+        internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
@@ -14,6 +14,10 @@ namespace Xunit
         public string Skip { get; set; }
     }
 
+    public class SkippableFactAttribute : FactAttribute
+    {
+    }
+
     public class TheoryAttribute : FactAttribute
     {
     }
@@ -32,6 +36,21 @@ namespace Xunit
     {
         public MemberDataAttribute(string memberName)
             : base(memberName)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class TraitAttribute : Attribute
+    {
+        public TraitAttribute(string name, string value)
+        {
+        }
+    }
+
+    public static class Skip
+    {
+        public static void If(bool condition)
         {
         }
     }

--- a/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
+++ b/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
 

--- a/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
+++ b/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" version="0.9.0-beta2" />
     <PackageReference Include="xunit" version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -30,11 +30,10 @@
     <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
     <PackageReference Include="ReactiveProperty" version="4.2.2" />
     <PackageReference Include="xunit" version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" version="2.4.1">
-      <PrivateAssets>none</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
     <None Update="MessagePackReaderTests.ReadInt.tt">

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzer.Tests.csproj
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzer.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20304.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20304.1" />


### PR DESCRIPTION
We've taken significant dependencies on MessagePack and some of these scenarios will be running on mono on a mac. So we should have tests running on mono to verify that MessagePack works properly on that runtime.

At the moment, several tests fail, so I'm skipping those few for now in order to get the hundreds of tests that *do* pass running regularly. I'll circle around and investigate the tests that fail on mono to see which ones should/can be fixed.