### PR TITLE
Lock for all Ref.Emit code when on mono

### DIFF
--- a/azure-pipelines/build_nonWindows.yml
+++ b/azure-pipelines/build_nonWindows.yml
@@ -13,7 +13,7 @@ steps:
     arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
     testRunTitle: netcoreapp2.1-$(Agent.JobName)
 
-- bash: mono ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/MessagePack.Tests/$(BuildConfiguration)/net472/MessagePack.Tests.dll -parallel none -html $(BUILD.ARTIFACTSTAGINGDIRECTORY)/build_logs/mono_testrun.html
+- bash: mono ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/MessagePack.Tests/$(BuildConfiguration)/net472/MessagePack.Tests.dll -html $(BUILD.ARTIFACTSTAGINGDIRECTORY)/build_logs/mono_testrun.html
   displayName: Run MessagePack.Tests (mono)
 
 - task: DotNetCoreCLI@2

--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -75,6 +75,9 @@
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\MessagePackSecurity.cs">
       <Link>Code\MessagePackSecurity.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\MonoProtection.cs">
+      <Link>Code\MonoProtection.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\MessagePack.UnityClient\Assets\Scripts\MessagePack\HashCode.cs">
       <Link>Code\HashCode.cs</Link>
     </Compile>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
@@ -20,8 +20,6 @@ namespace MessagePack.Internal
         // don't expose ModuleBuilder
         //// public ModuleBuilder ModuleBuilder { get { return moduleBuilder; } }
 
-        private readonly object gate = new object();
-
         public DynamicAssembly(string moduleName)
         {
 #if NETFRAMEWORK // We don't ship a net472 target, but we might add one for debugging purposes
@@ -36,29 +34,11 @@ namespace MessagePack.Internal
 
         /* requires lock on mono environment. see: https://github.com/neuecc/MessagePack-CSharp/issues/161 */
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr)
-        {
-            lock (this.gate)
-            {
-                return this.moduleBuilder.DefineType(name, attr);
-            }
-        }
+        public TypeBuilder DefineType(string name, TypeAttributes attr) => this.moduleBuilder.DefineType(name, attr);
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent)
-        {
-            lock (this.gate)
-            {
-                return this.moduleBuilder.DefineType(name, attr, parent);
-            }
-        }
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent) => this.moduleBuilder.DefineType(name, attr, parent);
 
-        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, Type[] interfaces)
-        {
-            lock (this.gate)
-            {
-                return this.moduleBuilder.DefineType(name, attr, parent, interfaces);
-            }
-        }
+        public TypeBuilder DefineType(string name, TypeAttributes attr, Type parent, Type[] interfaces) => this.moduleBuilder.DefineType(name, attr, parent, interfaces);
 
 #if NETFRAMEWORK
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MonoProtection.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MonoProtection.cs
@@ -1,0 +1,54 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+namespace MessagePack
+{
+    /// <summary>
+    /// Special behavior for running on the mono runtime.
+    /// </summary>
+    internal struct MonoProtection
+    {
+        /// <summary>
+        /// Gets a value indicating whether the mono runtime is executing this code.
+        /// </summary>
+        internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+
+        /// <summary>
+        /// A lock that we enter on mono when generating dynamic types.
+        /// </summary>
+        private static readonly object RefEmitLock = new object();
+
+        /// <summary>
+        /// The method to call within the expression of a <c>using</c> statement whose block surrounds all Ref.Emit code.
+        /// </summary>
+        /// <returns>The value to be disposed of to exit the Ref.Emit lock.</returns>
+        /// <remarks>
+        /// This is a no-op except when running on Mono.
+        /// <see href="https://github.com/mono/mono/issues/20369#issuecomment-690316456">Mono's implementation of Ref.Emit is not thread-safe</see> so we have to lock around all use of it
+        /// when using that runtime.
+        /// </remarks>
+        internal static MonoProtectionDisposal EnterRefEmitLock() => IsRunningOnMono ? new MonoProtectionDisposal(RefEmitLock) : default;
+    }
+
+    internal struct MonoProtectionDisposal : IDisposable
+    {
+        private readonly object lockObject;
+
+        internal MonoProtectionDisposal(object lockObject)
+        {
+            this.lockObject = lockObject;
+            Monitor.Enter(lockObject);
+        }
+
+        public void Dispose()
+        {
+            if (this.lockObject is object)
+            {
+                Monitor.Exit(this.lockObject);
+            }
+        }
+    }
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicEnumResolver.cs
@@ -90,38 +90,41 @@ namespace MessagePack.Resolvers
             Type underlyingType = Enum.GetUnderlyingType(enumType);
             Type formatterType = typeof(IMessagePackFormatter<>).MakeGenericType(enumType);
 
-            TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + enumType.FullName.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
-
-            // void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
+            using (MonoProtection.EnterRefEmitLock())
             {
-                MethodBuilder method = typeBuilder.DefineMethod(
-                    "Serialize",
-                    MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
-                    null,
-                    new Type[] { typeof(MessagePackWriter).MakeByRefType(), enumType, typeof(MessagePackSerializerOptions) });
+                TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + enumType.FullName.Replace(".", "_") + "Formatter" + Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
 
-                ILGenerator il = method.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Ldarg_2);
-                il.Emit(OpCodes.Call, typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.Write), new[] { underlyingType }));
-                il.Emit(OpCodes.Ret);
+                // void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options);
+                {
+                    MethodBuilder method = typeBuilder.DefineMethod(
+                        "Serialize",
+                        MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
+                        null,
+                        new Type[] { typeof(MessagePackWriter).MakeByRefType(), enumType, typeof(MessagePackSerializerOptions) });
+
+                    ILGenerator il = method.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldarg_2);
+                    il.Emit(OpCodes.Call, typeof(MessagePackWriter).GetRuntimeMethod(nameof(MessagePackWriter.Write), new[] { underlyingType }));
+                    il.Emit(OpCodes.Ret);
+                }
+
+                // T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
+                {
+                    MethodBuilder method = typeBuilder.DefineMethod(
+                        "Deserialize",
+                        MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
+                        enumType,
+                        new Type[] { typeof(MessagePackReader).MakeByRefType(), typeof(MessagePackSerializerOptions) });
+
+                    ILGenerator il = method.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Call, typeof(MessagePackReader).GetRuntimeMethod("Read" + underlyingType.Name, Type.EmptyTypes));
+                    il.Emit(OpCodes.Ret);
+                }
+
+                return typeBuilder.CreateTypeInfo();
             }
-
-            // T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options);
-            {
-                MethodBuilder method = typeBuilder.DefineMethod(
-                    "Deserialize",
-                    MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual,
-                    enumType,
-                    new Type[] { typeof(MessagePackReader).MakeByRefType(), typeof(MessagePackSerializerOptions) });
-
-                ILGenerator il = method.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Call, typeof(MessagePackReader).GetRuntimeMethod("Read" + underlyingType.Name, Type.EmptyTypes));
-                il.Emit(OpCodes.Ret);
-            }
-
-            return typeBuilder.CreateTypeInfo();
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicUnionResolver.cs
@@ -132,44 +132,47 @@ namespace MessagePack.Resolvers
             }
 
             Type formatterType = typeof(IMessagePackFormatter<>).MakeGenericType(type);
-            TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + SubtractFullNameRegex.Replace(type.FullName, string.Empty).Replace(".", "_") + "Formatter" + +Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
-
-            FieldBuilder typeToKeyAndJumpMap = null; // Dictionary<RuntimeTypeHandle, KeyValuePair<int, int>>
-            FieldBuilder keyToJumpMap = null; // Dictionary<int, int>
-
-            // create map dictionary
+            using (MonoProtection.EnterRefEmitLock())
             {
-                ConstructorBuilder method = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
-                typeToKeyAndJumpMap = typeBuilder.DefineField("typeToKeyAndJumpMap", typeof(Dictionary<RuntimeTypeHandle, KeyValuePair<int, int>>), FieldAttributes.Private | FieldAttributes.InitOnly);
-                keyToJumpMap = typeBuilder.DefineField("keyToJumpMap", typeof(Dictionary<int, int>), FieldAttributes.Private | FieldAttributes.InitOnly);
+                TypeBuilder typeBuilder = DynamicAssembly.Value.DefineType("MessagePack.Formatters." + SubtractFullNameRegex.Replace(type.FullName, string.Empty).Replace(".", "_") + "Formatter" + +Interlocked.Increment(ref nameSequence), TypeAttributes.Public | TypeAttributes.Sealed, null, new[] { formatterType });
 
-                ILGenerator il = method.GetILGenerator();
-                BuildConstructor(type, unionAttrs, method, typeToKeyAndJumpMap, keyToJumpMap, il);
+                FieldBuilder typeToKeyAndJumpMap = null; // Dictionary<RuntimeTypeHandle, KeyValuePair<int, int>>
+                FieldBuilder keyToJumpMap = null; // Dictionary<int, int>
+
+                // create map dictionary
+                {
+                    ConstructorBuilder method = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+                    typeToKeyAndJumpMap = typeBuilder.DefineField("typeToKeyAndJumpMap", typeof(Dictionary<RuntimeTypeHandle, KeyValuePair<int, int>>), FieldAttributes.Private | FieldAttributes.InitOnly);
+                    keyToJumpMap = typeBuilder.DefineField("keyToJumpMap", typeof(Dictionary<int, int>), FieldAttributes.Private | FieldAttributes.InitOnly);
+
+                    ILGenerator il = method.GetILGenerator();
+                    BuildConstructor(type, unionAttrs, method, typeToKeyAndJumpMap, keyToJumpMap, il);
+                }
+
+                {
+                    MethodBuilder method = typeBuilder.DefineMethod(
+                        "Serialize",
+                        MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+                        null,
+                        new Type[] { typeof(MessagePackWriter).MakeByRefType(), type, typeof(MessagePackSerializerOptions) });
+
+                    ILGenerator il = method.GetILGenerator();
+                    BuildSerialize(type, unionAttrs, method, typeToKeyAndJumpMap, il);
+                }
+
+                {
+                    MethodBuilder method = typeBuilder.DefineMethod(
+                        "Deserialize",
+                        MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+                        type,
+                        new Type[] { refMessagePackReader, typeof(MessagePackSerializerOptions) });
+
+                    ILGenerator il = method.GetILGenerator();
+                    BuildDeserialize(type, unionAttrs, method, keyToJumpMap, il);
+                }
+
+                return typeBuilder.CreateTypeInfo();
             }
-
-            {
-                MethodBuilder method = typeBuilder.DefineMethod(
-                    "Serialize",
-                    MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
-                    null,
-                    new Type[] { typeof(MessagePackWriter).MakeByRefType(), type, typeof(MessagePackSerializerOptions) });
-
-                ILGenerator il = method.GetILGenerator();
-                BuildSerialize(type, unionAttrs, method, typeToKeyAndJumpMap, il);
-            }
-
-            {
-                MethodBuilder method = typeBuilder.DefineMethod(
-                    "Deserialize",
-                    MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
-                    type,
-                    new Type[] { refMessagePackReader, typeof(MessagePackSerializerOptions) });
-
-                ILGenerator il = method.GetILGenerator();
-                BuildDeserialize(type, unionAttrs, method, keyToJumpMap, il);
-            }
-
-            return typeBuilder.CreateTypeInfo();
         }
 
         private static void BuildConstructor(Type type, UnionAttribute[] infos, ConstructorInfo method, FieldBuilder typeToKeyAndJumpMap, FieldBuilder keyToJumpMap, ILGenerator il)


### PR DESCRIPTION
This allows us to resume running tests concurrently on mono.
I also remove a smaller lock that was there even for .NET Framework, since I don't know why we would need that and it simplified things slightly to remove it.

Workaround for https://github.com/mono/mono/issues/20369