### PR TITLE
Create MonoProtection.cs.meta

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MonoProtection.cs.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MonoProtection.cs.meta
@@ -1,0 +1,10 @@
+guid: 593f3b742b875ea48943776d02f8d3a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixed an error caused by missing .meta file when importing with UPM

fix: #1035

#997