### PR TITLE
Fix handling type parameter constraints in code generation

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/Definitions.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/Definitions.cs
@@ -26,7 +26,7 @@ namespace MessagePackCompiler.CodeAnalysis
 
         public string Namespace { get; set; }
 
-        public string[] GenericTypeParameters { get; set; }
+        public GenericTypeParameterInfo[] GenericTypeParameters { get; set; }
 
         public bool IsOpenGenericType { get; set; }
 
@@ -54,7 +54,7 @@ namespace MessagePackCompiler.CodeAnalysis
 
         public bool NeedsCastOnAfter { get; set; }
 
-        public string FormatterName => (this.Namespace == null ? this.Name : this.Namespace + "." + this.Name) + "Formatter" + (this.IsOpenGenericType ? $"<{string.Join(",", this.GenericTypeParameters)}>" : string.Empty);
+        public string FormatterName => (this.Namespace == null ? this.Name : this.Namespace + "." + this.Name) + "Formatter" + (this.IsOpenGenericType ? $"<{string.Join(",", this.GenericTypeParameters.Select(x => x.Name))}>" : string.Empty);
 
         public int WriteCount
         {
@@ -88,6 +88,22 @@ namespace MessagePackCompiler.CodeAnalysis
         {
             var args = string.Join(", ", this.ConstructorParameters.Select(x => "__" + x.Name + "__"));
             return $"{this.FullName}({args})";
+        }
+    }
+
+    public class GenericTypeParameterInfo
+    {
+        public string Name { get; }
+
+        public string Constraints { get; }
+
+        public bool HasConstraints { get; }
+
+        public GenericTypeParameterInfo(string name, string constraints)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Constraints = constraints ?? throw new ArgumentNullException(nameof(name));
+            HasConstraints = !string.IsNullOrEmpty(constraints);
         }
     }
 

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -48,10 +48,18 @@ namespace ");
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.Name));
             this.Write("Formatter");
-            this.Write(this.ToStringHelper.ToStringWithCulture((objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters)}>" : "")));
+            this.Write(this.ToStringHelper.ToStringWithCulture((objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "")));
             this.Write(" : global::MessagePack.Formatters.IMessagePackFormatter<");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
-            this.Write(">\r\n    {\r\n");
+            this.Write(">\r\n");
+ foreach(var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) { 
+            this.Write("        where ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Name));
+            this.Write(" : ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Constraints));
+            this.Write("\r\n");
+ } 
+            this.Write("    {\r\n");
  foreach(var item in objInfo.Members) { 
  if(item.CustomFormatterTypeName != null) { 
             this.Write("        ");

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -26,7 +26,10 @@ namespace <#= Namespace #>
     using MessagePack;
 <# foreach(var objInfo in ObjectSerializationInfos) { #>
 
-    public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters)}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
+    public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
+<# foreach(var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) { #>
+        where <#= typeArg.Name #> : <#= typeArg.Constraints #>
+<# } #>
     {
 <# foreach(var item in objInfo.Members) { #>
 <# if(item.CustomFormatterTypeName != null) { #>

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -7,8 +7,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.CodeAnalysis;
 using Xunit;
 using Xunit.Abstractions;
+using SymbolDisplayFormat = Microsoft.CodeAnalysis.SymbolDisplayFormat;
 
 namespace MessagePack.Generator.Tests
 {
@@ -357,6 +359,304 @@ namespace TempProject
 
             // The generated resolver doesn't know closed-type generic formatter.
             compilation.GetResolverKnownFormatterTypes().Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Generics_Constraints_Type(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T>
+        where T : IDisposable
+    {
+        [Key(0)]
+        public T Content { get; set; }
+    }
+}
+                ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T>");
+            formatterType.Should().NotBeNull();
+            // IDisposable
+            formatterType.TypeParameters[0].HasReferenceTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasValueTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasConstructorConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasNotNullConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasUnmanagedTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.IDisposable");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Generics_Constraints_NullableReferenceType(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T1, T2, T3, T4>
+        where T1 : MyClass?
+        where T2 : MyClass
+        where T3 : MyGenericClass<MyGenericClass<MyClass?>?>?
+        where T4 : MyClass, IMyInterface?
+    {
+        [Key(0)]
+        public T1 Content { get; set; }
+    }
+
+    public class MyClass {}
+    public class MyGenericClass<T> {}
+    public interface IMyInterface {}
+}
+                ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T1, T2, T3, T4>");
+            formatterType.Should().NotBeNull();
+            // MyClass?
+            formatterType.TypeParameters[0].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.MyClass");
+            formatterType.TypeParameters[0].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.Annotated);
+            // MyClass
+            formatterType.TypeParameters[1].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.MyClass");
+            formatterType.TypeParameters[1].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.None);
+            // MyGenericClass<MyGenericClass<MyClass?>?>?
+            formatterType.TypeParameters[2].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier)) == "global::TempProject.MyGenericClass<global::TempProject.MyGenericClass<global::TempProject.MyClass?>?>");
+            formatterType.TypeParameters[2].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.Annotated);
+            // MyClass, IMyInterface?
+            formatterType.TypeParameters[3].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.MyClass");
+            formatterType.TypeParameters[3].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.IMyInterface");
+            formatterType.TypeParameters[3].ConstraintNullableAnnotations[0].Should().Be(NullableAnnotation.None);
+            formatterType.TypeParameters[3].ConstraintNullableAnnotations[1].Should().Be(NullableAnnotation.Annotated);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Generics_Constraints_Struct(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T>
+        where T : struct
+    {
+        [Key(0)]
+        public T Content { get; set; }
+    }
+}
+                ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T>");
+            formatterType.Should().NotBeNull();
+            // struct
+            formatterType.TypeParameters[0].HasReferenceTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasValueTypeConstraint.Should().BeTrue();
+            formatterType.TypeParameters[0].HasConstructorConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasNotNullConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasUnmanagedTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].ConstraintTypes.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Generics_Constraints_Multiple(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T1, T2, T3, T4>
+        where T1 : struct
+        where T2 : IDisposable, new()
+        where T3 : notnull
+        where T4 : unmanaged
+    {
+        [Key(0)]
+        public T1 Content1 { get; set; }
+        [Key(1)]
+        public T2 Content2 { get; set; }
+        [Key(2)]
+        public T3 Content3 { get; set; }
+        [Key(3)]
+        public T4 Content4 { get; set; }
+    }
+}
+                ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T1, T2, T3, T4>");
+            formatterType.Should().NotBeNull();
+            // struct
+            formatterType.TypeParameters[0].HasReferenceTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasValueTypeConstraint.Should().BeTrue();
+            formatterType.TypeParameters[0].HasConstructorConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasNotNullConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].HasUnmanagedTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[0].ConstraintTypes.Should().BeEmpty();
+            // IDisposable, new()
+            formatterType.TypeParameters[1].HasReferenceTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[1].HasValueTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[1].HasConstructorConstraint.Should().BeTrue();
+            formatterType.TypeParameters[1].HasNotNullConstraint.Should().BeFalse();
+            formatterType.TypeParameters[1].HasUnmanagedTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[1].ConstraintTypes.Should().Contain(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.IDisposable");
+            // notnull
+            formatterType.TypeParameters[2].HasReferenceTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[2].HasValueTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[2].HasConstructorConstraint.Should().BeFalse();
+            formatterType.TypeParameters[2].HasNotNullConstraint.Should().BeTrue();
+            formatterType.TypeParameters[2].HasUnmanagedTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[2].ConstraintTypes.Should().BeEmpty();
+            // unmanaged
+            formatterType.TypeParameters[3].HasReferenceTypeConstraint.Should().BeFalse();
+            formatterType.TypeParameters[3].HasValueTypeConstraint.Should().BeTrue(); // unmanaged constraint includes value-type constraint
+            formatterType.TypeParameters[3].HasConstructorConstraint.Should().BeFalse();
+            formatterType.TypeParameters[3].HasNotNullConstraint.Should().BeFalse();
+            formatterType.TypeParameters[3].HasUnmanagedTypeConstraint.Should().BeTrue();
+            formatterType.TypeParameters[3].ConstraintTypes.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Generics_Constraints_ReferenceType_Nullable(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var contents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyGenericObject<T1, T2>
+        where T1 : class?
+        where T2 : class
+    {
+        [Key(0)]
+        public T1 Content1 { get; set; }
+        [Key(1)]
+        public T2 Content2 { get; set; }
+    }
+}
+                ";
+            tempWorkarea.AddFileToProject("MyMessagePackObject.cs", contents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.CsProjectPath,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                string.Empty,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty);
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            var formatterType = symbols.FirstOrDefault(x => x.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::TempProject.Generated.Formatters.TempProject.MyGenericObjectFormatter<T1, T2>");
+            formatterType.Should().NotBeNull();
+            // class?
+            formatterType.TypeParameters[0].HasReferenceTypeConstraint.Should().BeTrue();
+            formatterType.TypeParameters[0].ConstraintTypes.Should().BeEmpty();
+            formatterType.TypeParameters[0].ReferenceTypeConstraintNullableAnnotation.Should().Be(NullableAnnotation.Annotated);
+            // class
+            formatterType.TypeParameters[1].HasReferenceTypeConstraint.Should().BeTrue();
+            formatterType.TypeParameters[1].ConstraintTypes.Should().BeEmpty();
+            formatterType.TypeParameters[1].ReferenceTypeConstraintNullableAnnotation.Should().Be(NullableAnnotation.None);
         }
     }
 }


### PR DESCRIPTION
https://github.com/neuecc/MessagePack-CSharp/pull/1010#issuecomment-693377139

When generating Formatter, generic type-parameter constraints were being ignored.
This caused a problem that resulted in a compile error.

This PR fixes handling type parameter constraints in code generation.