### PR TITLE
Enable deserialization constructors to use parameter names that match their property names

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1772,7 +1772,8 @@ namespace MessagePack.Internal
             var constructorParameters = new List<EmittableMemberAndConstructorParameter>();
             if (ctor != null)
             {
-                ILookup<string, KeyValuePair<string, EmittableMember>> constructorLookupDictionary = stringMembers.ToLookup(x => x.Key, x => x, StringComparer.OrdinalIgnoreCase);
+                ILookup<string, KeyValuePair<string, EmittableMember>> constructorLookupByKeyDictionary = stringMembers.ToLookup(x => x.Key, x => x, StringComparer.OrdinalIgnoreCase);
+                ILookup<string, KeyValuePair<string, EmittableMember>> constructorLookupByMemberNameDictionary = stringMembers.ToLookup(x => x.Value.Name, x => x, StringComparer.OrdinalIgnoreCase);
                 do
                 {
                     constructorParameters.Clear();
@@ -1818,8 +1819,22 @@ namespace MessagePack.Internal
                         }
                         else
                         {
-                            IEnumerable<KeyValuePair<string, EmittableMember>> hasKey = constructorLookupDictionary[item.Name];
-                            var len = hasKey.Count();
+                            // Lookup by both string key name and member name
+                            IEnumerable<KeyValuePair<string, EmittableMember>> hasKey = constructorLookupByKeyDictionary[item.Name];
+                            IEnumerable<KeyValuePair<string, EmittableMember>> hasKeyByMemberName = constructorLookupByMemberNameDictionary[item.Name];
+
+                            var lenByKey = hasKey.Count();
+                            var lenByMemberName = hasKeyByMemberName.Count();
+
+                            var len = lenByKey;
+
+                            // Prefer to use string key name unless a matching string key is not found but a matching member name is
+                            if (lenByKey == 0 && lenByMemberName != 0)
+                            {
+                                len = lenByMemberName;
+                                hasKey = hasKeyByMemberName;
+                            }
+
                             if (len != 0)
                             {
                                 if (len != 1)

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs
@@ -181,6 +181,80 @@ namespace MessagePack.Tests
             }
         }
 
+        /// <summary>
+        /// This constructor tests the case where key names differ from property
+        /// names, to ensure that the correct ctor is still found using the member name.
+        /// (See issue #1016).
+        /// </summary>
+        [MessagePackObject]
+        public struct TestConstructor7
+        {
+            [Key("x_val")]
+            public int X { get; set; }
+
+            [Key("y_val")]
+            public int Y { get; set; }
+
+            [Key("z_val")]
+            public int Z { get; set; }
+
+            public TestConstructor7(int x, int y, int z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+        }
+
+        /// <summary>
+        /// This variation on 7 will check that the original behavior still
+        /// works (i.e. when users were forced to ensure that string key names
+        /// matched the constructor parameter names).
+        /// </summary>
+        [MessagePackObject]
+        public struct TestConstructor8
+        {
+            [Key("x_val")]
+            public int X { get; set; }
+
+            [Key("y_val")]
+            public int Y { get; set; }
+
+            [Key("z_val")]
+            public int Z { get; set; }
+
+            public TestConstructor8(int x_val, int y_val, int z_val)
+            {
+                X = x_val;
+                Y = y_val;
+                Z = z_val;
+            }
+        }
+
+        /// <summary>
+        /// Check the behavior that happens with a mix of ctor params matching
+        /// string keys and member names.
+        /// </summary>
+        [MessagePackObject]
+        public struct TestConstructor9
+        {
+            [Key("x_val")]
+            public int X { get; set; }
+
+            [Key("y")]
+            public int Y { get; set; }
+
+            [Key("Z")] // Capital Z
+            public int Z { get; set; }
+
+            public TestConstructor9(int x, int y, int z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+        }
+
         [Fact]
         public void StringKey()
         {
@@ -239,6 +313,42 @@ namespace MessagePack.Tests
             var r = MessagePackSerializer.Deserialize<TestConstructor6>(bin);
 
             r.X.Is(10);
+        }
+
+        [Fact]
+        public void MatchedStructCtorWorksEvenWhenKeyNameDifferentThanMember()
+        {
+            var ctor = new TestConstructor7(1, 2, 3);
+            var bin = MessagePackSerializer.Serialize(ctor);
+            var r = MessagePackSerializer.Deserialize<TestConstructor7>(bin);
+
+            r.X.Is(1);
+            r.Y.Is(2);
+            r.Z.Is(3);
+        }
+
+        [Fact]
+        public void MatchedStructCtorWorksWhenKeyNameSameAsCtorParameter()
+        {
+            var ctor = new TestConstructor8(4, 5, 6);
+            var bin = MessagePackSerializer.Serialize(ctor);
+            var r = MessagePackSerializer.Deserialize<TestConstructor8>(bin);
+
+            r.X.Is(4);
+            r.Y.Is(5);
+            r.Z.Is(6);
+        }
+
+        [Fact]
+        public void MatchedStructCtorFoundWithMixOfMemberNamesAndStringKeys()
+        {
+            var ctor = new TestConstructor9(7, 8, 9);
+            var bin = MessagePackSerializer.Serialize(ctor);
+            var r = MessagePackSerializer.Deserialize<TestConstructor9>(bin);
+
+            r.X.Is(7);
+            r.Y.Is(8);
+            r.Z.Is(9);
         }
     }
 }


### PR DESCRIPTION
Hi! I was able to clean up the commits for the fixes I developed for the issue where MPC wasn't able to de/serialize objects with string key names that weren't the same as the member names. I believe this fixes issue #1016, and indeed, in my own use case, I am now able to successfully de/serialize objects with these characteristics. These changes do not break any existing behavior (see screenshot of all tests passing), and I have written a new test to check coverage of this case as well, which passes.

Let me know if everything looks good or if there's anything you want me to change.

![image](https://user-images.githubusercontent.com/18300258/93898089-d541c880-fcc0-11ea-95ea-9ac832730870.png)
