### PR TITLE
Allow to change the name and output directory of a generated file

### DIFF
--- a/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
+++ b/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
@@ -20,15 +20,16 @@ namespace MessagePack.MSBuild.Tasks
 {
     public class MessagePackGenerator : Microsoft.Build.Utilities.Task, ICancelableTask
     {
-        private const string GeneratedFileName = "mpc_generated.cs";
-
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
 
         [Required]
         public ITaskItem[] Compile { get; set; } = null!;
 
         [Required]
-        public string IntermediateOutputPath { get; set; } = null!;
+        public string GeneratedFileName { get; set; } = null!;
+
+        [Required]
+        public string GeneratedOutputDirectory { get; set; } = null!;
 
         [Required]
         public ITaskItem[] ReferencePath { get; set; } = null!;
@@ -59,7 +60,7 @@ namespace MessagePack.MSBuild.Tasks
                 return false;
             }
 
-            this.GeneratedOutputPath = Path.Combine(this.IntermediateOutputPath, GeneratedFileName);
+            this.GeneratedOutputPath = Path.Combine(this.GeneratedOutputDirectory, GeneratedFileName);
 
             try
             {

--- a/src/MessagePack.MSBuild.Tasks/build/MessagePack.MSBuild.Tasks.props
+++ b/src/MessagePack.MSBuild.Tasks/build/MessagePack.MSBuild.Tasks.props
@@ -1,5 +1,11 @@
 ﻿<Project>
   <PropertyGroup>
+    <!-- This is the name of the generated file. -->
+    <MessagePackGeneratedFileName>mpc_generated.cs</MessagePackGeneratedFileName>
+
+    <!-- This is the output path of the generated file. If the path is empty, use 'IntermediateOutputPath' instead. -->
+    <MessagePackGeneratedOutputDirectory></MessagePackGeneratedOutputDirectory>
+
     <!-- This namespace, plus ".Formatters" is used for the generated type. -->
     <MessagePackGeneratedResolverNamespace>MessagePack</MessagePackGeneratedResolverNamespace>
 

--- a/src/MessagePack.MSBuild.Tasks/build/MessagePack.MSBuild.Tasks.targets
+++ b/src/MessagePack.MSBuild.Tasks/build/MessagePack.MSBuild.Tasks.targets
@@ -7,7 +7,8 @@
 
     <MessagePackGenerator
       Compile="@(Compile)"
-      IntermediateOutputPath="$(IntermediateOutputPath)"
+      GeneratedFileName="$(MessagePackGeneratedFileName)"
+      GeneratedOutputDirectory="$([MSBuild]::ValueOrDefault('$(MessagePackGeneratedOutputDirectory)', '$(IntermediateOutputPath)'))"
       ReferencePath="@(ReferencePath)"
       DefineConstants="$(DefineConstants)"
       Namespace="$(MessagePackGeneratedResolverNamespace)"


### PR DESCRIPTION
This PR allows to change the name and output directory of a generated file.

For most .NET projects, the new MSBuild Task (v2.2) generation will work fine.
However, our project uses Unity and shares the source codes as file link.

So, we need to be able to change the generated files to a different directory than the intermediate output path.

For example, I expect the following project structure.
```
- MyApp.Unity
  - Assets
    - Scripts
      - Shared
        - MyEnum.cs
        - MyMessagePackObject.cs
        - MyResponseObject.cs
        - mpc_generated.cs (<-- We need the file generated here)

- MyApp.Shared
  - Dependencies
    - MessagePack
    - MessagePack.MSBuild.Task
  - MyEnum.cs  (Linked file --> MyApp.Unity/../MyEnum.cs)
  - MyMessagePackObject.cs (Linked file --> MyApp.Unity/../MyMessagePackObject.cs)
  - MyResponseObject.cs (Linked file --> MyApp.Unity/../MyResponseObject.cs)

- MyApp.NetCore
  - Dependencies
    - MyApp.Shared
  - Program.cs
```