### PR TITLE
Allow ctor parameter types to be anything assignable from their associated members

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1836,7 +1836,7 @@ namespace MessagePack.Internal
                                 }
 
                                 paramMember = hasKey.First().Value;
-                                if (item.ParameterType == paramMember.Type && paramMember.IsReadable)
+                                if (item.ParameterType.IsAssignableFrom(paramMember.Type) && paramMember.IsReadable)
                                 {
                                     constructorParameters.Add(new EmittableMemberAndConstructorParameter { ConstructorParameter = item, MemberInfo = paramMember });
                                 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverInterfaceTest.cs
@@ -12,25 +12,47 @@ namespace MessagePack.Tests
     public class DynamicObjectResolverInterfaceTest
     {
         [Fact]
-        public void TestConstructorWithParentInterface()
+        public void TestConstructorWithParentInterface_Array()
         {
-            var myClass = new ConstructorEnumerableTest(new[] { "0", "2", "3" });
+            var myClass = new ConstructorEnumerableTestArray(new[] { "0", "2", "3" });
             var serialized = MessagePackSerializer.Serialize(myClass);
-            ConstructorEnumerableTest deserialized = MessagePackSerializer.Deserialize<ConstructorEnumerableTest>(serialized);
+            var deserialized = MessagePackSerializer.Deserialize<ConstructorEnumerableTestArray>(serialized);
+            deserialized.Values.IsStructuralEqual(myClass.Values);
+        }
+
+        [Fact]
+        public void TestConstructorWithParentInterface_Map()
+        {
+            var myClass = new ConstructorEnumerableTestMap(new[] { "0", "2", "3" });
+            var serialized = MessagePackSerializer.Serialize(myClass);
+            var deserialized = MessagePackSerializer.Deserialize<ConstructorEnumerableTestMap>(serialized);
             deserialized.Values.IsStructuralEqual(myClass.Values);
         }
     }
 
     [MessagePackObject]
-    public class ConstructorEnumerableTest
+    public class ConstructorEnumerableTestArray
     {
         [SerializationConstructor]
-        public ConstructorEnumerableTest(IEnumerable<string> values)
+        public ConstructorEnumerableTestArray(IEnumerable<string> values)
         {
             this.Values = values.ToList().AsReadOnly();
         }
 
         [Key(0)]
+        public IReadOnlyList<string> Values { get; }
+    }
+
+    [MessagePackObject]
+    public class ConstructorEnumerableTestMap
+    {
+        [SerializationConstructor]
+        public ConstructorEnumerableTestMap(IEnumerable<string> values)
+        {
+            this.Values = values.ToList().AsReadOnly();
+        }
+
+        [Key("Values")]
         public IReadOnlyList<string> Values { get; }
     }
 


### PR DESCRIPTION
Fixes one issue identified by #1058