### PR TITLE
Fix support of custom implementation of ICollection<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ These types can serialize by default:
 * `ConcurrentBag<>`, `ConcurrentQueue<>`, `ConcurrentStack<>`, `ConcurrentDictionary<,>`
 * Immutable collections (`ImmutableList<>`, etc)
 * Custom implementations of `ICollection<>` or `IDictionary<,>` with a parameterless constructor
-* Custom implementations of `ICollection` or `IDictionary` with a  parameterless constructor
+* Custom implementations of `IList` or `IDictionary` with a parameterless constructor
 
 You can add support for custom types, and there are some official/third-party extension packages for:
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicGenericResolver.cs
@@ -266,25 +266,6 @@ namespace MessagePack.Internal
                     {
                         return CreateInstance(formatterType, ti.GenericTypeArguments);
                     }
-
-                    // generic collection
-                    else if (ti.GenericTypeArguments.Length == 1
-                          && ti.ImplementedInterfaces.Any(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(ICollection<>))
-                          && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
-                    {
-                        Type elemType = ti.GenericTypeArguments[0];
-                        return CreateInstance(typeof(GenericCollectionFormatter<,>), new[] { elemType, t });
-                    }
-
-                    // generic dictionary
-                    else if (ti.GenericTypeArguments.Length == 2
-                          && ti.ImplementedInterfaces.Any(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(IDictionary<,>))
-                          && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
-                    {
-                        Type keyType = ti.GenericTypeArguments[0];
-                        Type valueType = ti.GenericTypeArguments[1];
-                        return CreateInstance(typeof(GenericDictionaryFormatter<,,>), new[] { keyType, valueType, t });
-                    }
                 }
             }
             else if (ti.IsEnum)
@@ -294,7 +275,15 @@ namespace MessagePack.Internal
             else
             {
                 // NonGeneric Collection
-                if (t == typeof(IList))
+                if (t == typeof(IEnumerable))
+                {
+                    return NonGenericInterfaceEnumerableFormatter.Instance;
+                }
+                else if (t == typeof(ICollection))
+                {
+                    return NonGenericInterfaceCollectionFormatter.Instance;
+                }
+                else if (t == typeof(IList))
                 {
                     return NonGenericInterfaceListFormatter.Instance;
                 }
@@ -310,6 +299,26 @@ namespace MessagePack.Internal
                 else if (typeof(IDictionary).GetTypeInfo().IsAssignableFrom(ti) && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
                 {
                     return Activator.CreateInstance(typeof(NonGenericDictionaryFormatter<>).MakeGenericType(t));
+                }
+            }
+
+            // check inherited types(e.g. Foo : ICollection<>, Bar<T> : ICollection<T>)
+            {
+                // generic dictionary
+                var dictionaryDef = ti.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+                if (dictionaryDef != null && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
+                {
+                    Type keyType = dictionaryDef.GenericTypeArguments[0];
+                    Type valueType = dictionaryDef.GenericTypeArguments[1];
+                    return CreateInstance(typeof(GenericDictionaryFormatter<,,>), new[] { keyType, valueType, t });
+                }
+
+                // generic collection
+                var collectionDef = ti.ImplementedInterfaces.FirstOrDefault(x => x.GetTypeInfo().IsConstructedGenericType() && x.GetGenericTypeDefinition() == typeof(ICollection<>));
+                if (collectionDef != null && ti.DeclaredConstructors.Any(x => x.GetParameters().Length == 0))
+                {
+                    Type elemType = collectionDef.GenericTypeArguments[0];
+                    return CreateInstance(typeof(GenericCollectionFormatter<,>), new[] { elemType, t });
                 }
             }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/CollectionTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/CollectionTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -202,6 +203,304 @@ namespace MessagePack.Tests
             this.Convert(nullableTest).Value.ToArray().Is((byte)1, (byte)10, (byte)100);
             nullableTest = null;
             this.Convert(nullableTest).IsNull();
+        }
+
+        [Fact]
+        public void NonGenericInterfaceCollectionsTest()
+        {
+            var xs = new[] { 1, 2, 3 };
+            IEnumerable a = xs;
+            ICollection b = xs;
+            IList c = xs;
+            // in MessagePack v2.1, deserialized type is byte so can not use Cast<int>().
+            this.Convert(a).Cast<object>().Select(x => System.Convert.ToInt32(x)).Is(xs);
+            this.Convert(b).Cast<object>().Select(x => System.Convert.ToInt32(x)).Is(xs);
+            this.Convert(c).Cast<object>().Select(x => System.Convert.ToInt32(x)).Is(xs);
+        }
+
+        [Fact]
+        public void CustomNonGenericInterfaceListTest()
+        {
+            var xs = new ImplNonGenericList();
+            xs.Add(1);
+            xs.Add(2);
+            xs.Add(3);
+
+            this.Convert(xs).Cast<object>().Select(System.Convert.ToInt32).Is(1, 2, 3);
+        }
+
+        [Fact]
+        public void CustomGenericInterfaceCollectionTest()
+        {
+            {
+                var xs = new ImplGenericCollection();
+                xs.Add(1);
+                xs.Add(2);
+                xs.Add(3);
+
+                this.Convert(xs).Is(1, 2, 3);
+            }
+
+            {
+                var xs = new ImplGenericGenericCollection<int>();
+                xs.Add(1);
+                xs.Add(2);
+                xs.Add(3);
+
+                this.Convert(xs).Is(1, 2, 3);
+            }
+        }
+
+        [Fact]
+        public void CustomGenericDictionaryTest()
+        {
+            var d = new ImplDictionary();
+            d.Add("foo", 10);
+            d.Add("bar", 20);
+
+            var d2 = this.Convert(d);
+            d2["foo"].Is(10);
+            d2["bar"].Is(20);
+        }
+    }
+
+    public class ImplNonGenericList : IList
+    {
+        private readonly IList inner;
+
+        public ImplNonGenericList()
+        {
+            inner = new List<object>();
+        }
+
+        public object this[int index] { get => inner[index]; set => inner[index] = value; }
+
+        public bool IsReadOnly => inner.IsReadOnly;
+
+        public bool IsFixedSize => inner.IsFixedSize;
+
+        public int Count => inner.Count;
+
+        public object SyncRoot => inner.SyncRoot;
+
+        public bool IsSynchronized => inner.IsSynchronized;
+
+        public int Add(object value)
+        {
+            return inner.Add(value);
+        }
+
+        public void Clear()
+        {
+            inner.Clear();
+        }
+
+        public bool Contains(object value)
+        {
+            return inner.Contains(value);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            inner.CopyTo(array, index);
+        }
+
+        public IEnumerator GetEnumerator()
+        {
+            return inner.GetEnumerator();
+        }
+
+        public int IndexOf(object value)
+        {
+            return inner.IndexOf(value);
+        }
+
+        public void Insert(int index, object value)
+        {
+            inner.Insert(index, value);
+        }
+
+        public void Remove(object value)
+        {
+            inner.Remove(value);
+        }
+
+        public void RemoveAt(int index)
+        {
+            inner.RemoveAt(index);
+        }
+    }
+
+    public class ImplGenericCollection : ICollection<int>
+    {
+        private readonly ICollection<int> inner;
+
+        public ImplGenericCollection()
+        {
+            this.inner = new List<int>();
+        }
+
+        public int Count => inner.Count;
+
+        public bool IsReadOnly => inner.IsReadOnly;
+
+        public void Add(int item)
+        {
+            inner.Add(item);
+        }
+
+        public void Clear()
+        {
+            inner.Clear();
+        }
+
+        public bool Contains(int item)
+        {
+            return inner.Contains(item);
+        }
+
+        public void CopyTo(int[] array, int arrayIndex)
+        {
+            inner.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            return inner.GetEnumerator();
+        }
+
+        public bool Remove(int item)
+        {
+            return inner.Remove(item);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return inner.GetEnumerator();
+        }
+    }
+
+    public class ImplGenericGenericCollection<T> : ICollection<T>
+    {
+        private readonly ICollection<T> inner;
+
+        public ImplGenericGenericCollection()
+        {
+            this.inner = new List<T>();
+        }
+
+        public int Count => inner.Count;
+
+        public bool IsReadOnly => inner.IsReadOnly;
+
+        public void Add(T item)
+        {
+            inner.Add(item);
+        }
+
+        public void Clear()
+        {
+            inner.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return inner.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            inner.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return inner.GetEnumerator();
+        }
+
+        public bool Remove(T item)
+        {
+            return inner.Remove(item);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return inner.GetEnumerator();
+        }
+    }
+
+    public class ImplDictionary : IDictionary<string, int>
+    {
+        private readonly Dictionary<string, int> inner;
+
+        public ImplDictionary()
+        {
+            this.inner = new Dictionary<string, int>();
+        }
+
+        public int this[string key] { get => inner[key]; set => inner[key] = value; }
+
+        public ICollection<string> Keys => ((IDictionary<string, int>)inner).Keys;
+
+        public ICollection<int> Values => ((IDictionary<string, int>)inner).Values;
+
+        public int Count => inner.Count;
+
+        public bool IsReadOnly => ((IDictionary<string, int>)inner).IsReadOnly;
+
+        public void Add(string key, int value)
+        {
+            inner.Add(key, value);
+        }
+
+        public void Add(KeyValuePair<string, int> item)
+        {
+            ((IDictionary<string, int>)inner).Add(item);
+        }
+
+        public void Clear()
+        {
+            inner.Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, int> item)
+        {
+            return ((IDictionary<string, int>)inner).Contains(item);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return inner.ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<string, int>[] array, int arrayIndex)
+        {
+            ((IDictionary<string, int>)inner).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<string, int>> GetEnumerator()
+        {
+            return ((IDictionary<string, int>)inner).GetEnumerator();
+        }
+
+        public bool Remove(string key)
+        {
+            return inner.Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<string, int> item)
+        {
+            return ((IDictionary<string, int>)inner).Remove(item);
+        }
+
+        public bool TryGetValue(string key, out int value)
+        {
+            return inner.TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary<string, int>)inner).GetEnumerator();
         }
     }
 }

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿MessagePack.Formatters.ByteMemoryFormatter
+MessagePack.Formatters.ByteMemoryFormatter
 MessagePack.Formatters.ByteMemoryFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Memory<byte>
 MessagePack.Formatters.ByteMemoryFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Memory<byte> value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.Formatters.ByteReadOnlyMemoryFormatter
@@ -14,6 +14,12 @@ MessagePack.Formatters.MemoryFormatter<T>
 MessagePack.Formatters.MemoryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Memory<T>
 MessagePack.Formatters.MemoryFormatter<T>.MemoryFormatter() -> void
 MessagePack.Formatters.MemoryFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, System.Memory<T> value, MessagePack.MessagePackSerializerOptions options) -> void
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Collections.ICollection
+MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.ICollection value, MessagePack.MessagePackSerializerOptions options) -> void
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Collections.IEnumerable
+MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.Collections.IEnumerable value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.Formatters.PrimitiveObjectFormatter.PrimitiveObjectFormatter() -> void
 MessagePack.Formatters.ReadOnlyMemoryFormatter<T>
 MessagePack.Formatters.ReadOnlyMemoryFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.ReadOnlyMemory<T>
@@ -107,6 +113,8 @@ static readonly MessagePack.Formatters.ByteMemoryFormatter.Instance -> MessagePa
 static readonly MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Instance -> MessagePack.Formatters.ByteReadOnlyMemoryFormatter
 static readonly MessagePack.Formatters.ByteReadOnlySequenceFormatter.Instance -> MessagePack.Formatters.ByteReadOnlySequenceFormatter
 static readonly MessagePack.Formatters.ExpandoObjectFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Dynamic.ExpandoObject>
+static readonly MessagePack.Formatters.NonGenericInterfaceCollectionFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.ICollection>
+static readonly MessagePack.Formatters.NonGenericInterfaceEnumerableFormatter.Instance -> MessagePack.Formatters.IMessagePackFormatter<System.Collections.IEnumerable>
 static readonly MessagePack.Formatters.TypeFormatter<T>.Instance -> MessagePack.Formatters.IMessagePackFormatter<T>
 static readonly MessagePack.ImmutableCollection.ImmutableCollectionResolver.Instance -> MessagePack.ImmutableCollection.ImmutableCollectionResolver
 static readonly MessagePack.Resolvers.ExpandoObjectResolver.Instance -> MessagePack.IFormatterResolver


### PR DESCRIPTION
fix for #1062, #836
* Add non generic types support - `IEnumerable`, `ICollection`
* Fix to support non generics `ICollection<>`, `IDictioanry<,>` implemented custom type
* Fix ReadMe, changes support impl `ICollection` to `IList`. (`ICollection` does not have `Add` so can not support)
* Changing order, prioritize `IDictionary<,>` than `ICollection<>`, I don't think this will be a breaking change,until now priorities were determined by `<T>, <TKey, TValue>`, so the Dictionary was determined by the Dictionary.