### PR TITLE
DynamicObjectTypeFallbackFormatter prioritize PrimitiveObjectFormatter to keep primitive type

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DynamicObjectTypeFallbackFormatter.cs
@@ -42,6 +42,15 @@ namespace MessagePack.Formatters
                 return;
             }
 
+            if (PrimitiveObjectFormatter.IsSupportedType(type, ti, value))
+            {
+                if (!(value is System.Collections.IDictionary || value is System.Collections.ICollection))
+                {
+                    PrimitiveObjectFormatter.Instance.Serialize(ref writer, value, options);
+                    return;
+                }
+            }
+
             object formatter = options.Resolver.GetFormatterDynamicWithVerify(type);
             if (!SerializerDelegates.TryGetValue(type, out SerializeMethod serializerDelegate))
             {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs
@@ -37,8 +37,6 @@ namespace MessagePack.Formatters
         {
         }
 
-#if !UNITY_2018_3_OR_NEWER
-
         public static bool IsSupportedType(Type type, TypeInfo typeInfo, object value)
         {
             if (value == null)
@@ -68,8 +66,6 @@ namespace MessagePack.Formatters
 
             return false;
         }
-
-#endif
 
         public void Serialize(ref MessagePackWriter writer, object value, MessagePackSerializerOptions options)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs
@@ -44,6 +44,24 @@ namespace MessagePack.Tests
             json.Is(@"[[100,[""a"",""b"",""c""]],[300,{""Prop1"":10,""Prop2"":2,""Prop3"":99999}]]");
         }
 
+        [Fact]
+        public void FallbackObjectType()
+        {
+            var data = new DynamicObjectFallbackTestContainer
+            {
+                MyProperty = 3,
+                MoreObject = 10,
+            };
+
+            var bytes = MessagePackSerializer.Serialize(data);
+
+            dynamic obj = MessagePackSerializer.Deserialize<object>(bytes);
+
+            object v = obj[1];
+
+            v.GetType().Is(typeof(int));
+        }
+
         [MessagePackObject]
         public class DynamicObjectFallbackTestContainer
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs
@@ -62,6 +62,28 @@ namespace MessagePack.Tests
             v.GetType().Is(typeof(int));
         }
 
+        [Theory]
+        [InlineData((bool)true)]
+        [InlineData((byte)1)]
+        [InlineData((sbyte)1)]
+        [InlineData((short)-4)]
+        [InlineData((ushort)4)]
+        [InlineData((int)3)]
+        [InlineData((UInt32)4)]
+        [InlineData((long)2)]
+        [InlineData((UInt64)6)]
+        [InlineData((float)1f)]
+        [InlineData((double)12)]
+        [InlineData("hogehoge")]
+        public void SerializePrimitiveObjectShouldKeepType<T>(T value)
+        {
+            var bin = MessagePackSerializer.Serialize<object>(value);
+            var v = MessagePackSerializer.Deserialize<object>(bin);
+
+            v.GetType().Is(typeof(T));
+            v.ToString().Is(value.ToString());
+        }
+
         [MessagePackObject]
         public class DynamicObjectFallbackTestContainer
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/NonGenericCollectionTest.cs
@@ -22,8 +22,8 @@ namespace MessagePack.Tests
                 var bin = MessagePackSerializer.Serialize<IList>(xs);
                 IList v = MessagePackSerializer.Deserialize<IList>(bin);
 
-                ((byte)v[0]).Is((byte)1);
-                ((byte)v[1]).Is((byte)100);
+                Convert.ToInt32(v[0]).Is(1);
+                Convert.ToInt32(v[1]).Is(100);
                 ((string)v[2]).Is("hoge");
                 ((double)v[3]).Is(999.888);
             }
@@ -32,8 +32,8 @@ namespace MessagePack.Tests
                 var bin = MessagePackSerializer.Serialize(xs);
                 ArrayList v = MessagePackSerializer.Deserialize<ArrayList>(bin);
 
-                ((byte)v[0]).Is((byte)1);
-                ((byte)v[1]).Is((byte)100);
+                Convert.ToInt32(v[0]).Is(1);
+                Convert.ToInt32(v[1]).Is(100);
                 ((string)v[2]).Is("hoge");
                 ((double)v[3]).Is(999.888);
             }
@@ -47,8 +47,8 @@ namespace MessagePack.Tests
                 var bin = MessagePackSerializer.Serialize<IDictionary>(xs);
                 IDictionary v = MessagePackSerializer.Deserialize<IDictionary>(bin);
 
-                v["a"].Is((object)(byte)1);
-                v[(byte)100].Is((object)(string)"hoge");
+                Convert.ToInt32(v["a"]).Is(1);
+                v[100].Is((object)(string)"hoge");
                 v["foo"].Is((object)(double)999.888);
             }
 
@@ -57,8 +57,8 @@ namespace MessagePack.Tests
                 var bin = MessagePackSerializer.Serialize<Hashtable>(xs);
                 Hashtable v = MessagePackSerializer.Deserialize<Hashtable>(bin);
 
-                v["a"].Is((object)(byte)1);
-                v[(byte)100].Is((object)(string)"hoge");
+                Convert.ToInt32(v["a"]).Is(1);
+                v[100].Is((object)(string)"hoge");
                 v["foo"].Is((object)(double)999.888);
             }
         }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
@@ -14,29 +14,6 @@ namespace MessagePack.Tests
     {
 #if !ENABLE_IL2CPP
 
-        //[Theory]
-        //[InlineData((bool)true)]
-        //[InlineData((byte)10)]
-        //[InlineData((sbyte)123)]
-        //[InlineData((short)-4123)]
-        //[InlineData((ushort)42342)]
-        //[InlineData((int)int.MaxValue)]
-        //[InlineData((UInt32)432423)]
-        //[InlineData((long)235)]
-        //[InlineData((UInt64)65346464)]
-        //[InlineData((float)1241.42342f)]
-        //[InlineData((double)1241312.4242342)]
-        //[InlineData("hogehoge")]
-        //[InlineData(new byte[] { 1, 10, 100 })]
-        //public void PrimitiveObjectTest<T>(T x)
-        //{
-        //    //var bin = MessagePackSerializer.Serialize<object>(x);
-        //    //var bin2 = MessagePackSerializer.Serialize<T>(x);
-        //    //bin.Is(bin2);
-        //    ////var re1 = MessagePackSerializer.Deserialize<object>(bin);
-        //    ////((T)re1).Is(x);
-        //}
-
         [Fact]
         public void PrimitiveTest2()
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/PrimitiveResolverTest.cs
@@ -14,30 +14,28 @@ namespace MessagePack.Tests
     {
 #if !ENABLE_IL2CPP
 
-        [Theory]
-        [InlineData((bool)true)]
-        [InlineData((byte)10)]
-        [InlineData((sbyte)123)]
-        [InlineData((short)-4123)]
-        [InlineData((ushort)42342)]
-        [InlineData((int)int.MaxValue)]
-        [InlineData((UInt32)432423)]
-        [InlineData((long)235)]
-        [InlineData((UInt64)65346464)]
-        [InlineData((float)1241.42342f)]
-        [InlineData((double)1241312.4242342)]
-        [InlineData("hogehoge")]
-        [InlineData(new byte[] { 1, 10, 100 })]
-        public void PrimitiveObjectTest<T>(T x)
-        {
-            var bin = MessagePackSerializer.Serialize<object>(x);
-            var bin2 = MessagePackSerializer.Serialize<T>(x);
-
-            bin.Is(bin2);
-
-            ////var re1 = MessagePackSerializer.Deserialize<object>(bin);
-            ////((T)re1).Is(x);
-        }
+        //[Theory]
+        //[InlineData((bool)true)]
+        //[InlineData((byte)10)]
+        //[InlineData((sbyte)123)]
+        //[InlineData((short)-4123)]
+        //[InlineData((ushort)42342)]
+        //[InlineData((int)int.MaxValue)]
+        //[InlineData((UInt32)432423)]
+        //[InlineData((long)235)]
+        //[InlineData((UInt64)65346464)]
+        //[InlineData((float)1241.42342f)]
+        //[InlineData((double)1241312.4242342)]
+        //[InlineData("hogehoge")]
+        //[InlineData(new byte[] { 1, 10, 100 })]
+        //public void PrimitiveObjectTest<T>(T x)
+        //{
+        //    //var bin = MessagePackSerializer.Serialize<object>(x);
+        //    //var bin2 = MessagePackSerializer.Serialize<T>(x);
+        //    //bin.Is(bin2);
+        //    ////var re1 = MessagePackSerializer.Deserialize<object>(bin);
+        //    ////((T)re1).Is(x);
+        //}
 
         [Fact]
         public void PrimitiveTest2()
@@ -60,7 +58,7 @@ namespace MessagePack.Tests
                 SharedData.IntEnum x = SharedData.IntEnum.C;
                 var bin = MessagePackSerializer.Serialize<object>(x);
                 var re1 = MessagePackSerializer.Deserialize<object>(bin);
-                ((SharedData.IntEnum)(int)(byte)re1).Is(x);
+                ((SharedData.IntEnum)(int)re1).Is(x);
             }
 
             {
@@ -69,9 +67,9 @@ namespace MessagePack.Tests
                 var bin = MessagePackSerializer.Serialize<object>(x);
                 var re1 = (object[])MessagePackSerializer.Deserialize<object>(bin);
 
-                x[0].Is((int)(byte)re1[0]);
-                x[1].Is((int)(byte)re1[1]);
-                x[2].Is((int)(ushort)re1[2]);
+                x[0].Is((int)re1[0]);
+                x[1].Is((int)re1[1]);
+                x[2].Is((int)re1[2]);
                 x[5].Is(re1[5]);
 
                 ((int[])x[3])[0].Is((ushort)((object[])re1[3])[0]);


### PR DESCRIPTION
This change involves a breaking change so requires discussion.

Currently, when serialized/deserialized by the DynamicObjectTypeFallbackFormatter,
the primitive types lose their type information.
For example, an `int` type becomes a `byte` type.

most simple case:
```csharp
var bin = MessagePackSerializer.Serialize<object>((int)10);
var x = MessagePackSerializer.Deserialize<object>(bin);
Console.WriteLine(x.GetType().FullName); // System.Byte
```

The type changes with value, which sometimes causes problems when casting.
For example, `(int)x` raises an InvalidCastOperationException if the value is within the range of bytes, and so on. 

This is a simple example, but sometimes it can be frustrating when an object type in a class or a non-generic collection is included.

I think the type should not vary when dealing with object.
In fact, that's what the PrimitiveObjectFormatter's Serialize does.

But this is also a breaking change.
If you were writing a cast of (byte) and the return value was an int, you would get an InvalidCastOperationException.
In fact, some of our unit tests had that problem.

I thought it was odd when I needed to cast to the byte before, but I remembered it again when I was writing the test for #1063.
https://github.com/neuecc/MessagePack-CSharp/pull/1063/files#diff-fda56c144b3353ace58f3c4791039edcR148

However, it is a minor issue.
It's okay if this PR is unacceptable, but I thought it was worth considering.