### PR TITLE
add MessagePack.Annotations.asmdef

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "MessagePack.Annotations"
+}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5a46ad82eac024e4fbb6a0516a5def17
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
@@ -1,17 +1,19 @@
 {
     "name": "MessagePack",
-    "references": [],
+    "references": [
+        "MessagePack.Annotations"
+    ],
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [
-      "System.Memory.dll"
-      ,"System.Buffers.dll"
-      ,"System.Threading.Tasks.Extensions.dll"
-      ,"System.Runtime.CompilerServices.Unsafe.dll"
-      ,"System.Runtime.Extensions.dll"
+        "System.Memory.dll",
+        "System.Buffers.dll",
+        "System.Threading.Tasks.Extensions.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll",
+        "System.Runtime.Extensions.dll"
     ],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef
@@ -2,6 +2,7 @@
     "name": "MessagePack.Tests",
     "references": [
         "MessagePack",
+        "MessagePack.Annotations",
         "RuntimeUnitTestToolkit"
     ],
     "optionalUnityReferences": [


### PR DESCRIPTION
Allow assembly references to be resolved correctly when copying a dll created in Visual Studio into the Assets folder.