### PR TITLE
Add MSB4U support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,7 @@ Alternatively you may build from the command line using `msbuild.exe` or:
 
 ## Unity
 
-Unity Project requires several dependency DLL's. At first, run `copy_assets.bat` under `src\MessagePack.UnityClient`.
-Then open that directory in the Unity Editor.
+Then open `src\MessagePack.UnityClient` directory in the Unity Editor.
 
 ## Where to find our CI feed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Alternatively you may build from the command line using `msbuild.exe` or:
 
 ## Unity
 
-Then open `src\MessagePack.UnityClient` directory in the Unity Editor.
+Open `src\MessagePack.UnityClient` directory in the Unity Editor.
 
 ## Where to find our CI feed
 

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "3.1.301",
     "rollForward": "patch",
     "allowPrerelease": false
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "2.0.1"
   }
 }

--- a/src/MessagePack.UnityClient/.gitignore
+++ b/src/MessagePack.UnityClient/.gitignore
@@ -5,3 +5,11 @@
 # Unity wants to see binaries inside its Assets directory.
 # We link them in with make_unity_symlink.bat, but we don't want to actually commit them into git.
 Assets/*.dll
+
+# MSBuildForUnity
+!/Assets/**/*.csproj
+!/Assets/**/*.sln
+!/Packages/**/*.csproj
+!/Packages/**/*.sln
+/MSBuildForUnity.Common.props
+/MSBuild/

--- a/src/MessagePack.UnityClient/Assets/.gitignore
+++ b/src/MessagePack.UnityClient/Assets/.gitignore
@@ -1,1 +1,8 @@
-Plugins/
+/Plugins/
+/Plugins.meta
+
+# MSBuildForUnity
+/Dependencies/
+/Dependencies.meta
+.bin/
+.obj/

--- a/src/MessagePack.UnityClient/Assets/MessagePack.UnityClient.Dependencies.msb4u.csproj
+++ b/src/MessagePack.UnityClient/Assets/MessagePack.UnityClient.Dependencies.msb4u.csproj
@@ -1,0 +1,42 @@
+<Project ToolsVersion="15.0">
+  <!--GENERATED FILE-->
+  <!--
+    This file can be modified and checked in.
+
+    It is different from the other generated C# Projects in that it will be the one gathering all dependencies and placing them into the Unity asset folder.
+
+    You can add project level dependencies to this file, by placing them below:
+    - <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.props" />
+    and before:
+    - <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.targets" />
+
+    Do not add any source or compilation items.
+
+    Examples of how you can modify this file:
+    - Add NuGet package references:
+        <ItemGroup>
+          <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+        </ItemGroup>
+    - Add external C# project references:
+      <ItemGroup>
+        <ProjectReference Include="..\..\..\ExternalLib\ExternalLib.csproj" />
+      </ItemGroup>
+  -->
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
+
+  <PropertyGroup>
+    <UnityCurrentTargetFramework>net471</UnityCurrentTargetFramework>
+    <TargetFramework>net471</TargetFramework>
+  </PropertyGroup>
+
+  <!-- SDK.props is imported inside this props file -->
+  <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.props" />
+
+  <ItemGroup>
+    <!--Add NuGet or Project references here-->
+  </ItemGroup>
+
+  <!-- SDK.targets is imported inside this props file -->
+  <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.targets" />
+</Project>

--- a/src/MessagePack.UnityClient/Assets/MessagePack.UnityClient.Dependencies.msb4u.csproj
+++ b/src/MessagePack.UnityClient/Assets/MessagePack.UnityClient.Dependencies.msb4u.csproj
@@ -37,6 +37,11 @@
     <!--Add NuGet or Project references here-->
   </ItemGroup>
 
+  <ItemGroup>
+    <NuGetPackageIdExclusionList Include="System.Numerics.Vectors" />
+    <NuGetPackageIdExclusionList Include="System.Runtime.CompilerServices.Unsafe" />
+  </ItemGroup>
+
   <!-- SDK.targets is imported inside this props file -->
   <Import Project="$(MSBuildForUnityGeneratedProjectDirectory)\$(MSBuildProjectName).g.targets" />
 </Project>

--- a/src/MessagePack.UnityClient/Assets/MessagePack.UnityClient.Dependencies.msb4u.csproj.meta
+++ b/src/MessagePack.UnityClient/Assets/MessagePack.UnityClient.Dependencies.msb4u.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ef0d101d1b057ff4494775effe85df31
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/MessagePack.UnityClient/Assets/NuGet.config
+++ b/src/MessagePack.UnityClient/Assets/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="MSBuildForUnity" value="https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/MessagePack.UnityClient/Assets/NuGet.config.meta
+++ b/src/MessagePack.UnityClient/Assets/NuGet.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: e8996ba917b3c1e4890ff1a81f060c73
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Plugins.meta
+++ b/src/MessagePack.UnityClient/Assets/Plugins.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5fb5bfc38043b7444b650388190ea48f
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
@@ -12,8 +12,7 @@
         "System.Memory.dll",
         "System.Buffers.dll",
         "System.Threading.Tasks.Extensions.dll",
-        "System.Runtime.CompilerServices.Unsafe.dll",
-        "System.Runtime.Extensions.dll"
+        "System.Runtime.CompilerServices.Unsafe.dll"
     ],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj
@@ -11,12 +11,12 @@
     <OutputPath>.bin\</OutputPath>
   </PropertyGroup>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" Version="2.0.1" />
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" />
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" Version="2.0.1" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" />
 </Project>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj
@@ -1,0 +1,22 @@
+<Project>
+  <!-- Import the MSB4U generated common project as we will rely on it. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(MSBuildForUnity.Common.props))')" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>.obj\</BaseIntermediateOutputPath>
+    <OutputPath>.bin\</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.Build.NoTargets" Version="2.0.1" />
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.NoTargets" Version="2.0.1" />
+</Project>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: aa1f66b432c25de44b907f9b4b1c4eaf
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 0e4dca1acba66fd478b3854f09a32ec7, type: 3}
+  buildEngine: 0
+  profiles: []

--- a/src/MessagePack.UnityClient/Packages/manifest.json
+++ b/src/MessagePack.UnityClient/Packages/manifest.json
@@ -1,0 +1,17 @@
+{
+  "scopedRegistries": [
+    {
+      "name": "Microsoft",
+      "url": "https://pkgs.dev.azure.com/UnityDeveloperTools/MSBuildForUnity/_packaging/UnityDeveloperTools/npm/registry/",
+      "scopes": [
+        "com.microsoft"
+      ]
+    }
+  ],
+  "dependencies": {
+    "com.microsoft.msbuildforunity": "0.9.2-20200131.11",
+    "com.unity.modules.imgui": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.ui": "1.0.0"
+  }
+}

--- a/src/MessagePack.UnityClient/Packages/manifest.json
+++ b/src/MessagePack.UnityClient/Packages/manifest.json
@@ -10,6 +10,7 @@
   ],
   "dependencies": {
     "com.microsoft.msbuildforunity": "0.9.2-20200131.11",
+    "com.unity.collections": "0.1.1-preview",
     "com.unity.modules.imgui": "1.0.0",
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.unity.modules.ui": "1.0.0"


### PR DESCRIPTION
Add support for msb4u to resolve nuget dll references. (System.Memory & System.Threading.Tasks.Extensions)

https://github.com/neuecc/MessagePack-CSharp/blob/258b69d634c71deb9659273087e9179c00fe02e9/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef#L11-L16
↓
https://github.com/neuecc/MessagePack-CSharp/blob/258b69d634c71deb9659273087e9179c00fe02e9/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.csproj#L16-L19

https://github.com/microsoft/MSBuildForUnity/blob/master/Documentation/CoreScenarios.md#scenario-4-distribute-a-upm-package-w-nuget-dependency