### PR TITLE
Set additional property when opening a project in MessagePackGenerator

### DIFF
--- a/src/MessagePack.Generator/MessagepackCompiler.cs
+++ b/src/MessagePack.Generator/MessagepackCompiler.cs
@@ -85,7 +85,11 @@ namespace MessagePack.Generator
 
         private async Task<(Workspace Workspace, Compilation Compilation)> OpenMSBuildProjectAsync(string projectPath, CancellationToken cancellationToken)
         {
-            var workspace = MSBuildWorkspace.Create();
+            var workspace = MSBuildWorkspace.Create(new Dictionary<string, string>()
+            {
+                { "IsBuiltWithMessagePackGenerator", "true" },
+            });
+
             try
             {
                 var logger = new ConsoleLogger(Microsoft.Build.Framework.LoggerVerbosity.Quiet);


### PR DESCRIPTION
This PR changes MessagePackGenerator (mpc) to set additional property when opening the project.

## Problem / steps to reproduce
1. Create MyLibrary.csproj (.NET Standard class library)
2. Adds `Target` with `AfterTarget="Compile"` to MyLibrary.csproj.
3. In `Target`, use `Exec` task to run `dotnet run tool mpc -i MyLibrary.csproj -o ... /... /Generated.cs`.
4. `Target` is re-run when mpc opens this csproj.
5. `dotnet run tool mpc` is executed endlessly...

## Solution
Set the `IsBuiltWithMessagePackGenerator` property on opening with MSBuildWorkspace to enable switching by `Condition` in .csproj.

```xml
  <Target Name="GenerateMessagePack" AfterTargets="Compile" Condition="'$(IsBuiltWithMessagePackGenerator)' == ''">
    <Exec Command="dotnet tool restore" />
    <Exec Command="dotnet tool run mpc -i ./MyApp.Shared.csproj -o ../MyApp.Unity/Assets/Scripts/MessagePack.Generated.cs" />
  </Target>
```