### PR TITLE
Fix handling of `[DataMember]` that appears on virtual and override properties

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1617,8 +1617,14 @@ namespace MessagePack.Internal
                     if (isIntKey)
                     {
                         member.IntKey = key.IntKey.Value;
-                        if (intMembers.ContainsKey(member.IntKey))
+                        if (intMembers.TryGetValue(member.IntKey, out EmittableMember conflictingMember))
                         {
+                            // Quietly skip duplicate if this is an override property.
+                            if ((conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) || (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false))
+                            {
+                                continue;
+                            }
+
                             throw new MessagePackDynamicObjectResolverException("key is duplicated, all members key must be unique." + " type: " + type.FullName + " member:" + item.Name);
                         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1627,8 +1627,14 @@ namespace MessagePack.Internal
                     else
                     {
                         member.StringKey = key.StringKey;
-                        if (stringMembers.ContainsKey(member.StringKey))
+                        if (stringMembers.TryGetValue(member.StringKey, out EmittableMember conflictingMember))
                         {
+                            // Quietly skip duplicate if this is an override property.
+                            if ((conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) || (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false))
+                            {
+                                continue;
+                            }
+
                             throw new MessagePackDynamicObjectResolverException("key is duplicated, all members key must be unique." + " type: " + type.FullName + " member:" + item.Name);
                         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -61,6 +61,20 @@ namespace MessagePack.Tests
             Assert.Null(instance.Prop2);
         }
 
+        [Fact]
+        public void DeserializerSetsMissingPropertiesToDefaultValue_OrdinalKey()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write("Set");
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<TwoPropertiesOrdinalKey>(seq);
+            Assert.Equal("Set", instance.Prop1);
+            Assert.Null(instance.Prop2);
+        }
+
         /// <summary>
         /// Verifies that virtual and overridden properties do not cause the dynamic resolver to malfunction.
         /// </summary>
@@ -88,6 +102,36 @@ namespace MessagePack.Tests
             var obj = new DerivedClassThatOverridesPropertyDataMemberOnOverrideOnly { VirtualProperty = 100 };
             byte[] bin = MessagePackSerializer.Serialize(obj);
             var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesPropertyDataMemberOnOverrideOnly>(bin);
+            Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
+        }
+
+        /// <summary>
+        /// Verifies that virtual and overridden properties do not cause the dynamic resolver to malfunction.
+        /// </summary>
+        [Fact]
+        public void VirtualOverriddenProperties_OrdinalKey()
+        {
+            var obj = new DerivedClassThatOverridesPropertyOrdinalKey { VirtualProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(obj);
+            var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesPropertyOrdinalKey>(bin);
+            Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
+        }
+
+        [Fact]
+        public void VirtualOverriddenProperties_DataMemberOnBase_OrdinalKey()
+        {
+            var obj = new DerivedClassThatOverridesPropertyDataMemberOnVirtualOnlyOrdinalKey { VirtualProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(obj);
+            var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesPropertyDataMemberOnVirtualOnlyOrdinalKey>(bin);
+            Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
+        }
+
+        [Fact]
+        public void VirtualOverriddenProperties_DataMemberOnOverride_OrdinalKey()
+        {
+            var obj = new DerivedClassThatOverridesPropertyDataMemberOnOverrideOnlyOrdinalKey { VirtualProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(obj);
+            var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesPropertyDataMemberOnOverrideOnlyOrdinalKey>(bin);
             Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
         }
 
@@ -164,12 +208,74 @@ namespace MessagePack.Tests
         }
 
         [DataContract]
+        public class BaseClassWithVirtualPropertyOrdinalKey
+        {
+            [DataMember(Order = 0)]
+            public virtual int VirtualProperty { get; set; }
+        }
+
+        [DataContract]
+        public class DerivedClassThatOverridesPropertyOrdinalKey : BaseClassWithVirtualPropertyOrdinalKey
+        {
+            [DataMember(Order = 0)]
+            public override int VirtualProperty
+            {
+                get => base.VirtualProperty;
+                set => base.VirtualProperty = value;
+            }
+        }
+
+        [DataContract]
+        public class BaseClassWithVirtualPropertyDataMemberOnOverrideOnlyOrdinalKey
+        {
+            public virtual int VirtualProperty { get; set; }
+        }
+
+        [DataContract]
+        public class DerivedClassThatOverridesPropertyDataMemberOnOverrideOnlyOrdinalKey : BaseClassWithVirtualPropertyDataMemberOnOverrideOnlyOrdinalKey
+        {
+            [DataMember(Order = 0)]
+            public override int VirtualProperty
+            {
+                get => base.VirtualProperty;
+                set => base.VirtualProperty = value;
+            }
+        }
+
+        [DataContract]
+        public class BaseClassWithVirtualPropertyDataMemberOnVirtualOnlyOrdinalKey
+        {
+            [DataMember(Order = 0)]
+            public virtual int VirtualProperty { get; set; }
+        }
+
+        [DataContract]
+        public class DerivedClassThatOverridesPropertyDataMemberOnVirtualOnlyOrdinalKey : BaseClassWithVirtualPropertyDataMemberOnVirtualOnlyOrdinalKey
+        {
+            public override int VirtualProperty
+            {
+                get => base.VirtualProperty;
+                set => base.VirtualProperty = value;
+            }
+        }
+
+        [DataContract]
         public class TwoProperties
         {
             [DataMember]
             public string Prop1 { get; set; } = "Uninitialized";
 
             [DataMember]
+            public string Prop2 { get; set; } = "Uninitialized";
+        }
+
+        [DataContract]
+        public class TwoPropertiesOrdinalKey
+        {
+            [DataMember(Order = 0)]
+            public string Prop1 { get; set; } = "Uninitialized";
+
+            [DataMember(Order = 1)]
             public string Prop2 { get; set; } = "Uninitialized";
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -61,6 +61,36 @@ namespace MessagePack.Tests
             Assert.Null(instance.Prop2);
         }
 
+        /// <summary>
+        /// Verifies that virtual and overridden properties do not cause the dynamic resolver to malfunction.
+        /// </summary>
+        [Fact]
+        public void VirtualOverriddenProperties()
+        {
+            var obj = new DerivedClassThatOverridesProperty { VirtualProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(obj);
+            var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesProperty>(bin);
+            Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
+        }
+
+        [Fact]
+        public void VirtualOverriddenProperties_DataMemberOnBase()
+        {
+            var obj = new DerivedClassThatOverridesPropertyDataMemberOnVirtualOnly { VirtualProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(obj);
+            var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesPropertyDataMemberOnVirtualOnly>(bin);
+            Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
+        }
+
+        [Fact]
+        public void VirtualOverriddenProperties_DataMemberOnOverride()
+        {
+            var obj = new DerivedClassThatOverridesPropertyDataMemberOnOverrideOnly { VirtualProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(obj);
+            var obj2 = MessagePackSerializer.Deserialize<DerivedClassThatOverridesPropertyDataMemberOnOverrideOnly>(bin);
+            Assert.Equal(obj.VirtualProperty, obj2.VirtualProperty);
+        }
+
         private static void Assert3MemberClassSerializedContent(ReadOnlyMemory<byte> msgpack)
         {
             var reader = new MessagePackReader(msgpack);
@@ -79,6 +109,58 @@ namespace MessagePack.Tests
             Assert.Equal(obj.BaseClassFieldAccessor, obj2.BaseClassFieldAccessor);
             Assert.Equal(obj.BaseClassProperty, obj2.BaseClassProperty);
             Assert.Equal(obj.Name, obj2.Name);
+        }
+
+        [DataContract]
+        public class BaseClassWithVirtualProperty
+        {
+            [DataMember]
+            public virtual int VirtualProperty { get; set; }
+        }
+
+        [DataContract]
+        public class DerivedClassThatOverridesProperty : BaseClassWithVirtualProperty
+        {
+            [DataMember]
+            public override int VirtualProperty
+            {
+                get => base.VirtualProperty;
+                set => base.VirtualProperty = value;
+            }
+        }
+
+        [DataContract]
+        public class BaseClassWithVirtualPropertyDataMemberOnOverrideOnly
+        {
+            public virtual int VirtualProperty { get; set; }
+        }
+
+        [DataContract]
+        public class DerivedClassThatOverridesPropertyDataMemberOnOverrideOnly : BaseClassWithVirtualPropertyDataMemberOnOverrideOnly
+        {
+            [DataMember]
+            public override int VirtualProperty
+            {
+                get => base.VirtualProperty;
+                set => base.VirtualProperty = value;
+            }
+        }
+
+        [DataContract]
+        public class BaseClassWithVirtualPropertyDataMemberOnVirtualOnly
+        {
+            [DataMember]
+            public virtual int VirtualProperty { get; set; }
+        }
+
+        [DataContract]
+        public class DerivedClassThatOverridesPropertyDataMemberOnVirtualOnly : BaseClassWithVirtualPropertyDataMemberOnVirtualOnly
+        {
+            public override int VirtualProperty
+            {
+                get => base.VirtualProperty;
+                set => base.VirtualProperty = value;
+            }
         }
 
         [DataContract]


### PR DESCRIPTION
Fixes #886