### PR TITLE
MessagePackSerializer.NonGeneric uses reflection directly on Unity IL2CPP

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.NonGeneric.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.NonGeneric.cs
@@ -127,7 +127,9 @@ namespace MessagePack
                 {
                     // public static byte[] Serialize<T>(T obj, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo serialize = GetMethod(nameof(Serialize), type, new Type[] { null, typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.Serialize_T_Options = (x, y, z) => (byte[])serialize.Invoke(null, new object[] { x, y, z });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(object), "obj");
                     ParameterExpression param2 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
                     ParameterExpression param3 = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
@@ -141,12 +143,15 @@ namespace MessagePack
                     Func<object, MessagePackSerializerOptions, CancellationToken, byte[]> lambda = Expression.Lambda<Func<object, MessagePackSerializerOptions, CancellationToken, byte[]>>(body, param1, param2, param3).Compile(PreferInterpretation);
 
                     this.Serialize_T_Options = lambda;
+#endif
                 }
 
                 {
                     // public static void Serialize<T>(Stream stream, T obj, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo serialize = GetMethod(nameof(Serialize), type, new Type[] { typeof(Stream), null, typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.Serialize_Stream_T_Options_CancellationToken = (x, y, z, a) => serialize.Invoke(null, new object[] { x, y, z, a });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(Stream), "stream");
                     ParameterExpression param2 = Expression.Parameter(typeof(object), "obj");
                     ParameterExpression param3 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
@@ -162,12 +167,15 @@ namespace MessagePack
                     Action<Stream, object, MessagePackSerializerOptions, CancellationToken> lambda = Expression.Lambda<Action<Stream, object, MessagePackSerializerOptions, CancellationToken>>(body, param1, param2, param3, param4).Compile(PreferInterpretation);
 
                     this.Serialize_Stream_T_Options_CancellationToken = lambda;
+#endif
                 }
 
                 {
                     // public static Task SerializeAsync<T>(Stream stream, T obj, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo serialize = GetMethod(nameof(SerializeAsync), type, new Type[] { typeof(Stream), null, typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.SerializeAsync_Stream_T_Options_CancellationToken = (x, y, z, a) => (Task)serialize.Invoke(null, new object[] { x, y, z, a });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(Stream), "stream");
                     ParameterExpression param2 = Expression.Parameter(typeof(object), "obj");
                     ParameterExpression param3 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
@@ -183,12 +191,15 @@ namespace MessagePack
                     Func<Stream, object, MessagePackSerializerOptions, CancellationToken, Task> lambda = Expression.Lambda<Func<Stream, object, MessagePackSerializerOptions, CancellationToken, Task>>(body, param1, param2, param3, param4).Compile(PreferInterpretation);
 
                     this.SerializeAsync_Stream_T_Options_CancellationToken = lambda;
+#endif
                 }
 
                 {
                     // public static Task Serialize<T>(IBufferWriter<byte> writer, T obj, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo serialize = GetMethod(nameof(Serialize), type, new Type[] { typeof(IBufferWriter<byte>), null, typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.Serialize_IBufferWriter_T_Options_CancellationToken = (x, y, z, a) => serialize.Invoke(null, new object[] { x, y, z, a });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(IBufferWriter<byte>), "writer");
                     ParameterExpression param2 = Expression.Parameter(typeof(object), "obj");
                     ParameterExpression param3 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
@@ -204,12 +215,15 @@ namespace MessagePack
                     Action<IBufferWriter<byte>, object, MessagePackSerializerOptions, CancellationToken> lambda = Expression.Lambda<Action<IBufferWriter<byte>, object, MessagePackSerializerOptions, CancellationToken>>(body, param1, param2, param3, param4).Compile(PreferInterpretation);
 
                     this.Serialize_IBufferWriter_T_Options_CancellationToken = lambda;
+#endif
                 }
 
                 {
                     // public static void Serialize<T>(ref MessagePackWriter writer, T obj, MessagePackSerializerOptions options)
                     MethodInfo serialize = GetMethod(nameof(Serialize), type, new Type[] { typeof(MessagePackWriter).MakeByRefType(), null, typeof(MessagePackSerializerOptions) });
-
+#if ENABLE_IL2CPP
+                    this.Serialize_MessagePackWriter_T_Options = (ref MessagePackWriter x, object y, MessagePackSerializerOptions z) => ThrowRefStructNotSupported();
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(MessagePackWriter).MakeByRefType(), "writer");
                     ParameterExpression param2 = Expression.Parameter(typeof(object), "obj");
                     ParameterExpression param3 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
@@ -223,24 +237,30 @@ namespace MessagePack
                     MessagePackWriterSerialize lambda = Expression.Lambda<MessagePackWriterSerialize>(body, param1, param2, param3).Compile(PreferInterpretation);
 
                     this.Serialize_MessagePackWriter_T_Options = lambda;
+#endif
                 }
 
                 {
                     // public static T Deserialize<T>(ref MessagePackReader reader, MessagePackSerializerOptions options)
                     MethodInfo deserialize = GetMethod(nameof(Deserialize), type, new Type[] { typeof(MessagePackReader).MakeByRefType(), typeof(MessagePackSerializerOptions) });
-
+#if ENABLE_IL2CPP
+                    this.Deserialize_MessagePackReader_Options = (ref MessagePackReader reader, MessagePackSerializerOptions options) => { ThrowRefStructNotSupported(); return null; };
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(MessagePackReader).MakeByRefType(), "reader");
                     ParameterExpression param2 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
                     UnaryExpression body = Expression.Convert(Expression.Call(null, deserialize, param1, param2), typeof(object));
                     MessagePackReaderDeserialize lambda = Expression.Lambda<MessagePackReaderDeserialize>(body, param1, param2).Compile();
 
                     this.Deserialize_MessagePackReader_Options = lambda;
+#endif
                 }
 
                 {
                     // public static T Deserialize<T>(Stream stream, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo deserialize = GetMethod(nameof(Deserialize), type, new Type[] { typeof(Stream), typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.Deserialize_Stream_Options_CancellationToken = (x, y, z) => deserialize.Invoke(null, new object[] { x, y, z });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(Stream), "stream");
                     ParameterExpression param2 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
                     ParameterExpression param3 = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
@@ -248,12 +268,15 @@ namespace MessagePack
                     Func<Stream, MessagePackSerializerOptions, CancellationToken, object> lambda = Expression.Lambda<Func<Stream, MessagePackSerializerOptions, CancellationToken, object>>(body, param1, param2, param3).Compile(PreferInterpretation);
 
                     this.Deserialize_Stream_Options_CancellationToken = lambda;
+#endif
                 }
 
                 {
                     // public static ValueTask<object> DeserializeObjectAsync<T>(Stream stream, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo deserialize = GetMethod(nameof(DeserializeObjectAsync), type, new Type[] { typeof(Stream), typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.DeserializeAsync_Stream_Options_CancellationToken = (x, y, z) => (ValueTask<object>)deserialize.Invoke(null, new object[] { x, y, z });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(Stream), "stream");
                     ParameterExpression param2 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
                     ParameterExpression param3 = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
@@ -261,12 +284,15 @@ namespace MessagePack
                     Func<Stream, MessagePackSerializerOptions, CancellationToken, ValueTask<object>> lambda = Expression.Lambda<Func<Stream, MessagePackSerializerOptions, CancellationToken, ValueTask<object>>>(body, param1, param2, param3).Compile(PreferInterpretation);
 
                     this.DeserializeAsync_Stream_Options_CancellationToken = lambda;
+#endif
                 }
 
                 {
                     // public static T Deserialize<T>(ReadOnlyMemory<byte> bytes, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo deserialize = GetMethod(nameof(Deserialize), type, new Type[] { typeof(ReadOnlyMemory<byte>), typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.Deserialize_ReadOnlyMemory_Options = (x, y, z) => deserialize.Invoke(null, new object[] { x, y, z });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(ReadOnlyMemory<byte>), "bytes");
                     ParameterExpression param2 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
                     ParameterExpression param3 = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
@@ -274,12 +300,15 @@ namespace MessagePack
                     Func<ReadOnlyMemory<byte>, MessagePackSerializerOptions, CancellationToken, object> lambda = Expression.Lambda<Func<ReadOnlyMemory<byte>, MessagePackSerializerOptions, CancellationToken, object>>(body, param1, param2, param3).Compile(PreferInterpretation);
 
                     this.Deserialize_ReadOnlyMemory_Options = lambda;
+#endif
                 }
 
                 {
                     // public static T Deserialize<T>(ReadOnlySequence<byte> bytes, MessagePackSerializerOptions options, CancellationToken cancellationToken)
                     MethodInfo deserialize = GetMethod(nameof(Deserialize), type, new Type[] { typeof(ReadOnlySequence<byte>).MakeByRefType(), typeof(MessagePackSerializerOptions), typeof(CancellationToken) });
-
+#if ENABLE_IL2CPP
+                    this.Deserialize_ReadOnlySequence_Options_CancellationToken = (x, y, z) => deserialize.Invoke(null, new object[] { x, y, z });
+#else
                     ParameterExpression param1 = Expression.Parameter(typeof(ReadOnlySequence<byte>), "bytes");
                     ParameterExpression param2 = Expression.Parameter(typeof(MessagePackSerializerOptions), "options");
                     ParameterExpression param3 = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
@@ -287,7 +316,14 @@ namespace MessagePack
                     Func<ReadOnlySequence<byte>, MessagePackSerializerOptions, CancellationToken, object> lambda = Expression.Lambda<Func<ReadOnlySequence<byte>, MessagePackSerializerOptions, CancellationToken, object>>(body, param1, param2, param3).Compile(PreferInterpretation);
 
                     this.Deserialize_ReadOnlySequence_Options_CancellationToken = lambda;
+#endif
                 }
+            }
+
+            private static void ThrowRefStructNotSupported()
+            {
+                // C# 8.0 is not supported call `ref struct` via reflection. (It is milestoned at .NET 6)
+                throw new NotSupportedException("MessagePackWriter/Reader overload is not supported in MessagePackSerializer.NonGenerics.");
             }
 
             // null is generic type marker.

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -16,7 +16,6 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
-
         public ContractlessStandardResolverTest()
         {
             this.logger = new NullTestOutputHelper();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -16,6 +16,12 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+
+        public ContractlessStandardResolverTest()
+        {
+            this.logger = new NullTestOutputHelper();
+        }
+
         public ContractlessStandardResolverTest(ITestOutputHelper logger)
         {
             this.logger = logger;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -16,10 +16,14 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+#if UNITY_2018_3_OR_NEWER
+
         public ContractlessStandardResolverTest()
         {
             this.logger = new NullTestOutputHelper();
         }
+
+#endif
 
         public ContractlessStandardResolverTest(ITestOutputHelper logger)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
@@ -17,6 +17,11 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+        public DynamicObjectResolverOrderTest()
+        {
+            this.logger = new NullTestOutputHelper();
+        }
+
         public DynamicObjectResolverOrderTest(ITestOutputHelper logger)
         {
             this.logger = logger;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverOrderTest.cs
@@ -17,10 +17,14 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+#if UNITY_2018_3_OR_NEWER
+
         public DynamicObjectResolverOrderTest()
         {
             this.logger = new NullTestOutputHelper();
         }
+
+#endif
 
         public DynamicObjectResolverOrderTest(ITestOutputHelper logger)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -15,6 +15,11 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+        public DynamicObjectResolverTests()
+        {
+            this.logger = new NullTestOutputHelper();
+        }
+
         public DynamicObjectResolverTests(ITestOutputHelper logger)
         {
             this.logger = logger;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -15,10 +15,14 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+#if UNITY_2018_3_OR_NEWER
+
         public DynamicObjectResolverTests()
         {
             this.logger = new NullTestOutputHelper();
         }
+
+#endif
 
         public DynamicObjectResolverTests(ITestOutputHelper logger)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExpandoObjectTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExpandoObjectTests.cs
@@ -13,6 +13,11 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+        public ExpandoObjectTests()
+        {
+            this.logger = new NullTestOutputHelper();
+        }
+
         public ExpandoObjectTests(ITestOutputHelper logger)
         {
             this.logger = logger;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExpandoObjectTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExpandoObjectTests.cs
@@ -13,10 +13,14 @@ namespace MessagePack.Tests
     {
         private readonly ITestOutputHelper logger;
 
+#if UNITY_2018_3_OR_NEWER
+
         public ExpandoObjectTests()
         {
             this.logger = new NullTestOutputHelper();
         }
+
+#endif
 
         public ExpandoObjectTests(ITestOutputHelper logger)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
@@ -241,4 +241,3 @@ public class MessagePackSecurityTests
     {
     }
 }
-

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
@@ -11,10 +11,14 @@ using Xunit.Abstractions;
 
 public class MessagePackSecurityTests
 {
+#if UNITY_2018_3_OR_NEWER
+
     public MessagePackSecurityTests()
     {
         Logger = new NullTestOutputHelper();
     }
+
+#endif
 
     public MessagePackSecurityTests(ITestOutputHelper logger)
     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
@@ -10,6 +10,11 @@ using Xunit.Abstractions;
 
 public class MessagePackSecurityTests
 {
+    public MessagePackSecurityTests()
+    {
+        Logger = new NullTestOutputHelper();
+    }
+
     public MessagePackSecurityTests(ITestOutputHelper logger)
     {
         Logger = logger;
@@ -231,3 +236,4 @@ public class MessagePackSecurityTests
     {
     }
 }
+

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSecurityTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using MessagePack;
+using MessagePack.Tests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTest.cs
@@ -21,8 +21,6 @@ namespace MessagePack.Tests
 {
     public class MessagePackSerializerTest
     {
-#if !ENABLE_IL2CPP
-
         [Fact]
         public void NonGeneric()
         {
@@ -33,21 +31,25 @@ namespace MessagePack.Tests
             var writer = new MessagePackWriter(writerBytes);
 
             var data1 = MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, data)) as FirstSimpleData;
-            var data2 = MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, data, StandardResolver.Options)) as FirstSimpleData;
+            var data2 = MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, data, MessagePackSerializer.DefaultOptions)) as FirstSimpleData;
 
             MessagePackSerializer.Serialize(t, ms, data);
             ms.Position = 0;
             var data3 = MessagePackSerializer.Deserialize(t, ms) as FirstSimpleData;
 
             ms = new MemoryStream();
-            MessagePackSerializer.Serialize(t, ms, data, StandardResolver.Options);
+            MessagePackSerializer.Serialize(t, ms, data, MessagePackSerializer.DefaultOptions);
             ms.Position = 0;
-            var data4 = MessagePackSerializer.Deserialize(t, ms, StandardResolver.Options) as FirstSimpleData;
+            var data4 = MessagePackSerializer.Deserialize(t, ms, MessagePackSerializer.DefaultOptions) as FirstSimpleData;
 
-            MessagePackSerializer.Serialize(t, ref writer, data, StandardResolver.Options);
+#if ENABLE_IL2CPP
+            var data5 = data4;
+#else
+            MessagePackSerializer.Serialize(t, ref writer, data, MessagePackSerializer.DefaultOptions);
             writer.Flush();
             var reader = new MessagePackReader(writerBytes.AsReadOnlySequence);
-            var data5 = MessagePackSerializer.Deserialize(t, ref reader, StandardResolver.Options) as FirstSimpleData;
+            var data5 = MessagePackSerializer.Deserialize(t, ref reader, MessagePackSerializer.DefaultOptions) as FirstSimpleData;
+#endif
 
             new[] { data1.Prop1, data2.Prop1, data3.Prop1, data4.Prop1, data5.Prop1 }.Distinct().Is(data.Prop1);
             new[] { data1.Prop2, data2.Prop2, data3.Prop2, data4.Prop2, data5.Prop2 }.Distinct().Is(data.Prop2);
@@ -63,26 +65,24 @@ namespace MessagePack.Tests
             var writerBytes = new Sequence<byte>();
 
             var data1 = MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, data)) as FirstSimpleData;
-            var data2 = MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, data, StandardResolver.Options)) as FirstSimpleData;
+            var data2 = MessagePackSerializer.Deserialize(t, MessagePackSerializer.Serialize(t, data, MessagePackSerializer.DefaultOptions)) as FirstSimpleData;
 
             MessagePackSerializer.Serialize(t, ms, data);
             ms.Position = 0;
             var data3 = MessagePackSerializer.Deserialize(t, ms) as FirstSimpleData;
 
             ms = new MemoryStream();
-            MessagePackSerializer.Serialize(t, ms, data, StandardResolver.Options);
+            MessagePackSerializer.Serialize(t, ms, data, MessagePackSerializer.DefaultOptions);
             ms.Position = 0;
-            var data4 = MessagePackSerializer.Deserialize(t, ms, StandardResolver.Options) as FirstSimpleData;
+            var data4 = MessagePackSerializer.Deserialize(t, ms, MessagePackSerializer.DefaultOptions) as FirstSimpleData;
 
-            MessagePackSerializer.Serialize(t, writerBytes, data, StandardResolver.Options);
-            var data5 = MessagePackSerializer.Deserialize(t, writerBytes.AsReadOnlySequence, StandardResolver.Options) as FirstSimpleData;
+            MessagePackSerializer.Serialize(t, writerBytes, data, MessagePackSerializer.DefaultOptions);
+            var data5 = MessagePackSerializer.Deserialize(t, writerBytes.AsReadOnlySequence, MessagePackSerializer.DefaultOptions) as FirstSimpleData;
 
             new[] { data1.Prop1, data2.Prop1, data3.Prop1, data4.Prop1, data5.Prop1 }.Distinct().Is(data.Prop1);
             new[] { data1.Prop2, data2.Prop2, data3.Prop2, data4.Prop2, data5.Prop2 }.Distinct().Is(data.Prop2);
             new[] { data1.Prop3, data2.Prop3, data3.Prop3, data4.Prop3, data5.Prop3 }.Distinct().Is(data.Prop3);
         }
-
-#endif
 
 #if !UNITY_2018_3_OR_NEWER
 
@@ -241,6 +241,8 @@ namespace MessagePack.Tests
             }
         }
 
+#if !ENABLE_IL2CPP
+
         [Fact]
         public void StackDepthCheck_DynamicObjectResolver()
         {
@@ -268,6 +270,8 @@ namespace MessagePack.Tests
             var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<RecursiveObjectGraph>(msgpack, options));
             Assert.IsType<InsufficientExecutionStackException>(ex.InnerException);
         }
+
+#endif
 
         private delegate void WriterHelper(ref MessagePackWriter writer);
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using Xunit.Abstractions;
 
 namespace MessagePack.Tests
 {
@@ -14,5 +15,16 @@ namespace MessagePack.Tests
         /// Gets a value indicating whether the mono runtime is executing this code.
         /// </summary>
         internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+    }
+
+    public class NullTestOutputHelper : ITestOutputHelper
+    {
+        public void WriteLine(string message)
+        {
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+        }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
@@ -144,15 +144,4 @@ namespace Xunit.Abstractions
         void WriteLine(String message);
         void WriteLine(String format, params Object[] args);
     }
-
-    public class NullTestOutputHelper : ITestOutputHelper
-    {
-        public void WriteLine(string message)
-        {
-        }
-
-        public void WriteLine(string format, params object[] args)
-        {
-        }
-    }
 }


### PR DESCRIPTION
Currently MessagePackSerializer.NonGeneric uses ExpressionTree.Compile to use Generics Serialize/Deserialize.
Compile does not work on AOT environment so uses `Compile(preferInterpretation:true)` on Unity IL2CPP(ENABLE_IL2CPP).

This PR changes `Compile(preferInterpreation:true)` to use reflection directly(MethodInfo.Invoke).

1. Expression interpreter is slow, uses many allocation and finally uses `MethodInfo.Invoke`, therefore, it is better to use direct reflection in this scenario
2. Moreover, it doesn't seem to work with IL2CPP, this is a promblem in the LightLambda (ExpressionTree Interpreter) implementation.

Fix for https://github.com/neuecc/MessagePack-CSharp/issues/869#issuecomment-714632361
and fix for blocking scenario of SignalR Unity support https://github.com/dotnet/aspnetcore/issues/12102#issuecomment-713193772

I've checked Windows IL2CPP build run succsessfully.
![image](https://user-images.githubusercontent.com/46207/96977272-cff1cb00-1557-11eb-9a7d-813452ae7cf5.png)

Limitation
---
`ref struct` can not use reflection(it will solve at .NET 6? https://github.com/dotnet/runtime/issues/10057 ) so `ref MessagePackWriter` and `ref MessagePackReader` overload throws `NotSupportedException`.
Note that this is not supported by ExpressionTree Interpreter either, so an exception will be throwed.