### PR TITLE
Draft PR: #1085 Solution for mpc.exe

### DIFF
--- a/MessagePack.sln
+++ b/MessagePack.sln
@@ -88,6 +88,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.Experimental", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.Experimental.Tests", "tests\MessagePack.Experimental.Tests\MessagePack.Experimental.Tests.csproj", "{8AB40D1C-1134-4D77-B39A-19AEDC729450}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePack.GeneratedCode.Tests", "tests\MessagePack.GeneratedCode.Tests\MessagePack.GeneratedCode.Tests.csproj", "{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -310,6 +312,14 @@ Global
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450}.Release|NoVSIX.ActiveCfg = Release|Any CPU
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450}.Release|NoVSIX.Build.0 = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|NoVSIX.ActiveCfg = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|NoVSIX.Build.0 = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|NoVSIX.ActiveCfg = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|NoVSIX.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -342,6 +352,7 @@ Global
 		{4C9BB260-62D8-49CD-9F9C-9AA6A8BFC637} = {51A614B0-E583-4DD2-AC7D-6A65634582E0}
 		{AC2503A7-736D-4AE6-9355-CF35D9DF6139} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3911209-2DBF-47F8-98F6-BBC0EDFE63DE}

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -1911,14 +1911,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback1(__X__);
-            if (length <= 0)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.X = __X__;
-
-        MEMBER_ASSIGNMENT_END:
             ____result.OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -1966,14 +1958,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback1_2(__X__);
-            if (length <= 0)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.X = __X__;
-
-        MEMBER_ASSIGNMENT_END:
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -2025,12 +2009,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor(__Prop1__);
-            if (length <= 0)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.Prop1 = __Prop1__;
             if (length <= 1)
             {
                 goto MEMBER_ASSIGNMENT_END;
@@ -2131,12 +2109,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor(__Prop1__);
-            if (length <= 0)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.Prop1 = __Prop1__;
             if (length <= 1)
             {
                 goto MEMBER_ASSIGNMENT_END;
@@ -3315,26 +3287,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Vector3Like(__x__, __y__, __z__);
-            if (length <= 0)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.x = __x__;
-            if (length <= 1)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.y = __y__;
-            if (length <= 2)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.z = __z__;
-
-        MEMBER_ASSIGNMENT_END:
             reader.Depth--;
             return ____result;
         }
@@ -3379,20 +3331,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.VectorLike2(__x__, __y__);
-            if (length <= 0)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.x = __x__;
-            if (length <= 1)
-            {
-                goto MEMBER_ASSIGNMENT_END;
-            }
-
-            ____result.y = __y__;
-
-        MEMBER_ASSIGNMENT_END:
             reader.Depth--;
             return ____result;
         }
@@ -3794,11 +3732,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback2(__X__);
-            if (__X__IsInitialized)
-            {
-                ____result.X = __X__;
-            }
-
             ____result.OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -3850,11 +3783,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback2_2(__X__);
-            if (__X__IsInitialized)
-            {
-                ____result.X = __X__;
-            }
-
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -3924,11 +3852,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor(__Prop1__);
-            if (__Prop1__IsInitialized)
-            {
-                ____result.Prop1 = __Prop1__;
-            }
-
             if (__Prop2__IsInitialized)
             {
                 ____result.Prop2 = __Prop2__;
@@ -4058,11 +3981,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor(__Prop1__);
-            if (__Prop1__IsInitialized)
-            {
-                ____result.Prop1 = __Prop1__;
-            }
-
             if (__Prop2__IsInitialized)
             {
                 ____result.Prop2 = __Prop2__;

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -937,7 +937,7 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1031,7 +1031,7 @@ namespace MessagePack.Formatters
             var __MyProperty5__ = default(global::GlobalMyEnum[]);
             var __MyProperty6__ = default(global::QuestMessageBody[]);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1101,7 +1101,7 @@ namespace MessagePack.Formatters
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1155,7 +1155,7 @@ namespace MessagePack.Formatters
             var __PostTime__ = default(global::System.DateTime);
             var __Body__ = default(global::IMessageBody);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1217,7 +1217,7 @@ namespace MessagePack.Formatters
             var __QuestId__ = default(int);
             var __Text__ = default(string);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1267,7 +1267,7 @@ namespace MessagePack.Formatters
             var length = reader.ReadArrayHeader();
             var __StampId__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1315,7 +1315,7 @@ namespace MessagePack.Formatters
             var length = reader.ReadArrayHeader();
             var __Text__ = default(string);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1850,7 +1850,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty14__ = default(int);
             var __MyProperty15__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1958,7 +1958,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __OPQ__ = default(string);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2005,7 +2005,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __X__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2053,7 +2053,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __X__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2112,7 +2112,7 @@ namespace MessagePack.Formatters.SharedData
             var __Item8__ = default(T8);
             var __Item9__ = default(T9);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2179,7 +2179,7 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2219,7 +2219,7 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2253,7 +2253,7 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2301,7 +2301,7 @@ namespace MessagePack.Formatters.SharedData
             var __Prop2__ = default(string);
             var __Prop3__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2355,7 +2355,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __XYZ__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2405,7 +2405,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2453,7 +2453,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2507,7 +2507,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty1__ = default(global::SharedData.Version0);
             var __After__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2561,7 +2561,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty1__ = default(global::SharedData.Version1);
             var __After__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2615,7 +2615,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty1__ = default(global::SharedData.Version2);
             var __After__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2669,7 +2669,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty2__ = default(int);
             var __MyProperty3__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2726,7 +2726,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __One__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2771,7 +2771,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __Two__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2819,7 +2819,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __Three__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2866,7 +2866,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __Four__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2912,7 +2912,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2958,7 +2958,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3018,7 +3018,7 @@ namespace MessagePack.Formatters.SharedData
             var __Prop6__ = default(global::SharedData.SimpleStructStringKeyData);
             var __BytesSpecial__ = default(byte[]);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3086,7 +3086,7 @@ namespace MessagePack.Formatters.SharedData
             var __Y__ = default(int);
             var __BytesSpecial__ = default(byte[]);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3142,15 +3142,15 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty1__ = default(int);
             var __MyProperty__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
-                    case 1:
-                        __MyProperty1__ = reader.ReadInt32();
-                        break;
                     case 0:
                         __MyProperty__ = reader.ReadInt32();
+                        break;
+                    case 1:
+                        __MyProperty1__ = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3194,15 +3194,15 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty2__ = default(int);
             var __MyProperty__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
-                    case 1:
-                        __MyProperty2__ = reader.ReadInt32();
-                        break;
                     case 0:
                         __MyProperty__ = reader.ReadInt32();
+                        break;
+                    case 1:
+                        __MyProperty2__ = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3247,7 +3247,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty__ = default(int);
             var __MyProperty2__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3293,7 +3293,7 @@ namespace MessagePack.Formatters.SharedData
             var __X__ = default(float);
             var __Y__ = default(float);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3339,7 +3339,7 @@ namespace MessagePack.Formatters.SharedData
             var __y__ = default(float);
             var __z__ = default(float);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3389,7 +3389,7 @@ namespace MessagePack.Formatters.SharedData
             var __x__ = default(float);
             var __y__ = default(float);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3442,7 +3442,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3495,7 +3495,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty2__ = default(int);
             var __MyProperty3__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3559,7 +3559,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty3__ = default(int);
             var __MyProperty5__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3623,7 +3623,7 @@ namespace MessagePack.Formatters.SharedData
             var __UnknownBlock__ = default(global::SharedData.MyClass);
             var __MyProperty2__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3684,7 +3684,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __FV__ = default(int);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3734,7 +3734,7 @@ namespace MessagePack.Formatters.SharedData
             var __Data1__ = default(int);
             var __Data2__ = default(string);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -3710,7 +3710,6 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
             var __X__ = default(int);
-            var __X__IsInitialized = false;
 
             for (int i = 0; i < length; i++)
             {
@@ -3724,7 +3723,6 @@ namespace MessagePack.Formatters.SharedData
                     case 1:
                         if (stringKey[0] != 88) { goto FAIL; }
 
-                        __X__IsInitialized = true;
                         __X__ = reader.ReadInt32();
                         continue;
 
@@ -3761,7 +3759,6 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
             var __X__ = default(int);
-            var __X__IsInitialized = false;
 
             for (int i = 0; i < length; i++)
             {
@@ -3775,7 +3772,6 @@ namespace MessagePack.Formatters.SharedData
                     case 1:
                         if (stringKey[0] != 88) { goto FAIL; }
 
-                        __X__IsInitialized = true;
                         __X__ = reader.ReadInt32();
                         continue;
 
@@ -3821,9 +3817,8 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
             var __Prop1__ = default(int);
-            var __Prop1__IsInitialized = false;
-            var __Prop2__ = default(int);
             var __Prop2__IsInitialized = false;
+            var __Prop2__ = default(int);
 
             for (int i = 0; i < length; i++)
             {
@@ -3839,7 +3834,6 @@ namespace MessagePack.Formatters.SharedData
                         {
                             default: goto FAIL;
                             case 212339749456UL:
-                                __Prop1__IsInitialized = true;
                                 __Prop1__ = reader.ReadInt32();
                                 continue;
                             case 216634716752UL:
@@ -3950,9 +3944,8 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
             var __Prop1__ = default(int);
-            var __Prop1__IsInitialized = false;
-            var __Prop2__ = default(int);
             var __Prop2__IsInitialized = false;
+            var __Prop2__ = default(int);
 
             for (int i = 0; i < length; i++)
             {
@@ -3968,7 +3961,6 @@ namespace MessagePack.Formatters.SharedData
                         {
                             default: goto FAIL;
                             case 212339749456UL:
-                                __Prop1__IsInitialized = true;
                                 __Prop1__ = reader.ReadInt32();
                                 continue;
                             case 216634716752UL:

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -49,7 +49,7 @@ namespace MessagePack.Resolvers
 
         static GeneratedResolverGetFormatterHelper()
         {
-            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(65)
+            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(71)
             {
                 { typeof(global::GlobalMyEnum[,]), 0 },
                 { typeof(global::GlobalMyEnum[]), 1 },
@@ -80,42 +80,48 @@ namespace MessagePack.Resolvers
                 { typeof(global::SharedData.Callback1_2), 26 },
                 { typeof(global::SharedData.Callback2), 27 },
                 { typeof(global::SharedData.Callback2_2), 28 },
-                { typeof(global::SharedData.Empty1), 29 },
-                { typeof(global::SharedData.Empty2), 30 },
-                { typeof(global::SharedData.EmptyClass), 31 },
-                { typeof(global::SharedData.EmptyStruct), 32 },
-                { typeof(global::SharedData.FirstSimpleData), 33 },
-                { typeof(global::SharedData.FooClass), 34 },
-                { typeof(global::SharedData.HolderV0), 35 },
-                { typeof(global::SharedData.HolderV1), 36 },
-                { typeof(global::SharedData.HolderV2), 37 },
-                { typeof(global::SharedData.MyClass), 38 },
-                { typeof(global::SharedData.MySubUnion1), 39 },
-                { typeof(global::SharedData.MySubUnion2), 40 },
-                { typeof(global::SharedData.MySubUnion3), 41 },
-                { typeof(global::SharedData.MySubUnion4), 42 },
-                { typeof(global::SharedData.NestParent.NestContract), 43 },
-                { typeof(global::SharedData.NonEmpty1), 44 },
-                { typeof(global::SharedData.NonEmpty2), 45 },
-                { typeof(global::SharedData.SimpleIntKeyData), 46 },
-                { typeof(global::SharedData.SimpleStringKeyData), 47 },
-                { typeof(global::SharedData.SimpleStructIntKeyData), 48 },
-                { typeof(global::SharedData.SimpleStructStringKeyData), 49 },
-                { typeof(global::SharedData.SubUnionType1), 50 },
-                { typeof(global::SharedData.SubUnionType2), 51 },
-                { typeof(global::SharedData.UnVersionBlockTest), 52 },
-                { typeof(global::SharedData.Vector2), 53 },
-                { typeof(global::SharedData.Vector3Like), 54 },
-                { typeof(global::SharedData.VectorLike2), 55 },
-                { typeof(global::SharedData.Version0), 56 },
-                { typeof(global::SharedData.Version1), 57 },
-                { typeof(global::SharedData.Version2), 58 },
-                { typeof(global::SharedData.VersionBlockTest), 59 },
-                { typeof(global::SharedData.VersioningUnion), 60 },
-                { typeof(global::SharedData.WithIndexer), 61 },
-                { typeof(global::SimpleModel), 62 },
-                { typeof(global::StampMessageBody), 63 },
-                { typeof(global::TextMessageBody), 64 },
+                { typeof(global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor), 29 },
+                { typeof(global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor), 30 },
+                { typeof(global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor), 31 },
+                { typeof(global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor), 32 },
+                { typeof(global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor), 33 },
+                { typeof(global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor), 34 },
+                { typeof(global::SharedData.Empty1), 35 },
+                { typeof(global::SharedData.Empty2), 36 },
+                { typeof(global::SharedData.EmptyClass), 37 },
+                { typeof(global::SharedData.EmptyStruct), 38 },
+                { typeof(global::SharedData.FirstSimpleData), 39 },
+                { typeof(global::SharedData.FooClass), 40 },
+                { typeof(global::SharedData.HolderV0), 41 },
+                { typeof(global::SharedData.HolderV1), 42 },
+                { typeof(global::SharedData.HolderV2), 43 },
+                { typeof(global::SharedData.MyClass), 44 },
+                { typeof(global::SharedData.MySubUnion1), 45 },
+                { typeof(global::SharedData.MySubUnion2), 46 },
+                { typeof(global::SharedData.MySubUnion3), 47 },
+                { typeof(global::SharedData.MySubUnion4), 48 },
+                { typeof(global::SharedData.NestParent.NestContract), 49 },
+                { typeof(global::SharedData.NonEmpty1), 50 },
+                { typeof(global::SharedData.NonEmpty2), 51 },
+                { typeof(global::SharedData.SimpleIntKeyData), 52 },
+                { typeof(global::SharedData.SimpleStringKeyData), 53 },
+                { typeof(global::SharedData.SimpleStructIntKeyData), 54 },
+                { typeof(global::SharedData.SimpleStructStringKeyData), 55 },
+                { typeof(global::SharedData.SubUnionType1), 56 },
+                { typeof(global::SharedData.SubUnionType2), 57 },
+                { typeof(global::SharedData.UnVersionBlockTest), 58 },
+                { typeof(global::SharedData.Vector2), 59 },
+                { typeof(global::SharedData.Vector3Like), 60 },
+                { typeof(global::SharedData.VectorLike2), 61 },
+                { typeof(global::SharedData.Version0), 62 },
+                { typeof(global::SharedData.Version1), 63 },
+                { typeof(global::SharedData.Version2), 64 },
+                { typeof(global::SharedData.VersionBlockTest), 65 },
+                { typeof(global::SharedData.VersioningUnion), 66 },
+                { typeof(global::SharedData.WithIndexer), 67 },
+                { typeof(global::SimpleModel), 68 },
+                { typeof(global::StampMessageBody), 69 },
+                { typeof(global::TextMessageBody), 70 },
             };
         }
 
@@ -158,42 +164,48 @@ namespace MessagePack.Resolvers
                 case 26: return new MessagePack.Formatters.SharedData.Callback1_2Formatter();
                 case 27: return new MessagePack.Formatters.SharedData.Callback2Formatter();
                 case 28: return new MessagePack.Formatters.SharedData.Callback2_2Formatter();
-                case 29: return new MessagePack.Formatters.SharedData.Empty1Formatter();
-                case 30: return new MessagePack.Formatters.SharedData.Empty2Formatter();
-                case 31: return new MessagePack.Formatters.SharedData.EmptyClassFormatter();
-                case 32: return new MessagePack.Formatters.SharedData.EmptyStructFormatter();
-                case 33: return new MessagePack.Formatters.SharedData.FirstSimpleDataFormatter();
-                case 34: return new MessagePack.Formatters.SharedData.FooClassFormatter();
-                case 35: return new MessagePack.Formatters.SharedData.HolderV0Formatter();
-                case 36: return new MessagePack.Formatters.SharedData.HolderV1Formatter();
-                case 37: return new MessagePack.Formatters.SharedData.HolderV2Formatter();
-                case 38: return new MessagePack.Formatters.SharedData.MyClassFormatter();
-                case 39: return new MessagePack.Formatters.SharedData.MySubUnion1Formatter();
-                case 40: return new MessagePack.Formatters.SharedData.MySubUnion2Formatter();
-                case 41: return new MessagePack.Formatters.SharedData.MySubUnion3Formatter();
-                case 42: return new MessagePack.Formatters.SharedData.MySubUnion4Formatter();
-                case 43: return new MessagePack.Formatters.SharedData.NestParent_NestContractFormatter();
-                case 44: return new MessagePack.Formatters.SharedData.NonEmpty1Formatter();
-                case 45: return new MessagePack.Formatters.SharedData.NonEmpty2Formatter();
-                case 46: return new MessagePack.Formatters.SharedData.SimpleIntKeyDataFormatter();
-                case 47: return new MessagePack.Formatters.SharedData.SimpleStringKeyDataFormatter();
-                case 48: return new MessagePack.Formatters.SharedData.SimpleStructIntKeyDataFormatter();
-                case 49: return new MessagePack.Formatters.SharedData.SimpleStructStringKeyDataFormatter();
-                case 50: return new MessagePack.Formatters.SharedData.SubUnionType1Formatter();
-                case 51: return new MessagePack.Formatters.SharedData.SubUnionType2Formatter();
-                case 52: return new MessagePack.Formatters.SharedData.UnVersionBlockTestFormatter();
-                case 53: return new MessagePack.Formatters.SharedData.Vector2Formatter();
-                case 54: return new MessagePack.Formatters.SharedData.Vector3LikeFormatter();
-                case 55: return new MessagePack.Formatters.SharedData.VectorLike2Formatter();
-                case 56: return new MessagePack.Formatters.SharedData.Version0Formatter();
-                case 57: return new MessagePack.Formatters.SharedData.Version1Formatter();
-                case 58: return new MessagePack.Formatters.SharedData.Version2Formatter();
-                case 59: return new MessagePack.Formatters.SharedData.VersionBlockTestFormatter();
-                case 60: return new MessagePack.Formatters.SharedData.VersioningUnionFormatter();
-                case 61: return new MessagePack.Formatters.SharedData.WithIndexerFormatter();
-                case 62: return new MessagePack.Formatters.SimpleModelFormatter();
-                case 63: return new MessagePack.Formatters.StampMessageBodyFormatter();
-                case 64: return new MessagePack.Formatters.TextMessageBodyFormatter();
+                case 29: return new MessagePack.Formatters.SharedData.DefaultValueIntKeyClassWithExplicitConstructorFormatter();
+                case 30: return new MessagePack.Formatters.SharedData.DefaultValueIntKeyClassWithoutExplicitConstructorFormatter();
+                case 31: return new MessagePack.Formatters.SharedData.DefaultValueIntKeyStructWithExplicitConstructorFormatter();
+                case 32: return new MessagePack.Formatters.SharedData.DefaultValueStringKeyClassWithExplicitConstructorFormatter();
+                case 33: return new MessagePack.Formatters.SharedData.DefaultValueStringKeyClassWithoutExplicitConstructorFormatter();
+                case 34: return new MessagePack.Formatters.SharedData.DefaultValueStringKeyStructWithExplicitConstructorFormatter();
+                case 35: return new MessagePack.Formatters.SharedData.Empty1Formatter();
+                case 36: return new MessagePack.Formatters.SharedData.Empty2Formatter();
+                case 37: return new MessagePack.Formatters.SharedData.EmptyClassFormatter();
+                case 38: return new MessagePack.Formatters.SharedData.EmptyStructFormatter();
+                case 39: return new MessagePack.Formatters.SharedData.FirstSimpleDataFormatter();
+                case 40: return new MessagePack.Formatters.SharedData.FooClassFormatter();
+                case 41: return new MessagePack.Formatters.SharedData.HolderV0Formatter();
+                case 42: return new MessagePack.Formatters.SharedData.HolderV1Formatter();
+                case 43: return new MessagePack.Formatters.SharedData.HolderV2Formatter();
+                case 44: return new MessagePack.Formatters.SharedData.MyClassFormatter();
+                case 45: return new MessagePack.Formatters.SharedData.MySubUnion1Formatter();
+                case 46: return new MessagePack.Formatters.SharedData.MySubUnion2Formatter();
+                case 47: return new MessagePack.Formatters.SharedData.MySubUnion3Formatter();
+                case 48: return new MessagePack.Formatters.SharedData.MySubUnion4Formatter();
+                case 49: return new MessagePack.Formatters.SharedData.NestParent_NestContractFormatter();
+                case 50: return new MessagePack.Formatters.SharedData.NonEmpty1Formatter();
+                case 51: return new MessagePack.Formatters.SharedData.NonEmpty2Formatter();
+                case 52: return new MessagePack.Formatters.SharedData.SimpleIntKeyDataFormatter();
+                case 53: return new MessagePack.Formatters.SharedData.SimpleStringKeyDataFormatter();
+                case 54: return new MessagePack.Formatters.SharedData.SimpleStructIntKeyDataFormatter();
+                case 55: return new MessagePack.Formatters.SharedData.SimpleStructStringKeyDataFormatter();
+                case 56: return new MessagePack.Formatters.SharedData.SubUnionType1Formatter();
+                case 57: return new MessagePack.Formatters.SharedData.SubUnionType2Formatter();
+                case 58: return new MessagePack.Formatters.SharedData.UnVersionBlockTestFormatter();
+                case 59: return new MessagePack.Formatters.SharedData.Vector2Formatter();
+                case 60: return new MessagePack.Formatters.SharedData.Vector3LikeFormatter();
+                case 61: return new MessagePack.Formatters.SharedData.VectorLike2Formatter();
+                case 62: return new MessagePack.Formatters.SharedData.Version0Formatter();
+                case 63: return new MessagePack.Formatters.SharedData.Version1Formatter();
+                case 64: return new MessagePack.Formatters.SharedData.Version2Formatter();
+                case 65: return new MessagePack.Formatters.SharedData.VersionBlockTestFormatter();
+                case 66: return new MessagePack.Formatters.SharedData.VersioningUnionFormatter();
+                case 67: return new MessagePack.Formatters.SharedData.WithIndexerFormatter();
+                case 68: return new MessagePack.Formatters.SimpleModelFormatter();
+                case 69: return new MessagePack.Formatters.StampMessageBodyFormatter();
+                case 70: return new MessagePack.Formatters.TextMessageBodyFormatter();
                 default: return null;
             }
         }
@@ -1968,6 +1980,176 @@ namespace MessagePack.Formatters.SharedData
         }
     }
 
+    public sealed class DefaultValueIntKeyClassWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteArrayHeader(2);
+            writer.Write(value.Prop1);
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadArrayHeader();
+            var __Prop1__ = default(int);
+            var __Prop2__ = default(int);
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        __Prop1__ = reader.ReadInt32();
+                        break;
+                    case 1:
+                        __Prop2__ = reader.ReadInt32();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor(__Prop1__);
+            if (length <= 0)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop1 = __Prop1__;
+            if (length <= 1)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop2 = __Prop2__;
+
+        MEMBER_ASSIGNMENT_END:
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueIntKeyClassWithoutExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteArrayHeader(2);
+            writer.Write(value.Prop1);
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadArrayHeader();
+            var ____result = new global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor();
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        ____result.Prop1 = reader.ReadInt32();
+                        break;
+                    case 1:
+                        ____result.Prop2 = reader.ReadInt32();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueIntKeyStructWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            writer.WriteArrayHeader(2);
+            writer.Write(value.Prop1);
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadArrayHeader();
+            var __Prop1__ = default(int);
+            var __Prop2__ = default(int);
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        __Prop1__ = reader.ReadInt32();
+                        break;
+                    case 1:
+                        __Prop2__ = reader.ReadInt32();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor(__Prop1__);
+            if (length <= 0)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop1 = __Prop1__;
+            if (length <= 1)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop2 = __Prop2__;
+
+        MEMBER_ASSIGNMENT_END:
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
     public sealed class DynamicArgumentTupleFormatter<T1, T2, T3, T4, T5, T6, T7, T8, T9> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
 
@@ -3674,6 +3856,218 @@ namespace MessagePack.Formatters.SharedData
             }
 
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueStringKeyClassWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor>
+    {
+        // Prop1
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop1() => new byte[1 + 5] { 165, 80, 114, 111, 112, 49 };
+        // Prop2
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop2() => new byte[1 + 5] { 165, 80, 114, 111, 112, 50 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_Prop1());
+            writer.Write(value.Prop1);
+            writer.WriteRaw(GetSpan_Prop2());
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadMapHeader();
+            var __Prop1__ = default(int);
+            var __Prop1__IsInitialized = false;
+            var __Prop2__ = default(int);
+            var __Prop2__IsInitialized = false;
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 212339749456UL:
+                                __Prop1__IsInitialized = true;
+                                __Prop1__ = reader.ReadInt32();
+                                continue;
+                            case 216634716752UL:
+                                __Prop2__IsInitialized = true;
+                                __Prop2__ = reader.ReadInt32();
+                                continue;
+                        }
+
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor(__Prop1__);
+            if (__Prop1__IsInitialized)
+            {
+                ____result.Prop1 = __Prop1__;
+            }
+
+            if (__Prop2__IsInitialized)
+            {
+                ____result.Prop2 = __Prop2__;
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueStringKeyClassWithoutExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor>
+    {
+        // Prop1
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop1() => new byte[1 + 5] { 165, 80, 114, 111, 112, 49 };
+        // Prop2
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop2() => new byte[1 + 5] { 165, 80, 114, 111, 112, 50 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_Prop1());
+            writer.Write(value.Prop1);
+            writer.WriteRaw(GetSpan_Prop2());
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadMapHeader();
+            var ____result = new global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor();
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 212339749456UL:
+                                ____result.Prop1 = reader.ReadInt32();
+                                continue;
+                            case 216634716752UL:
+                                ____result.Prop2 = reader.ReadInt32();
+                                continue;
+                        }
+
+                }
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueStringKeyStructWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor>
+    {
+        // Prop1
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop1() => new byte[1 + 5] { 165, 80, 114, 111, 112, 49 };
+        // Prop2
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop2() => new byte[1 + 5] { 165, 80, 114, 111, 112, 50 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_Prop1());
+            writer.Write(value.Prop1);
+            writer.WriteRaw(GetSpan_Prop2());
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadMapHeader();
+            var __Prop1__ = default(int);
+            var __Prop1__IsInitialized = false;
+            var __Prop2__ = default(int);
+            var __Prop2__IsInitialized = false;
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 212339749456UL:
+                                __Prop1__IsInitialized = true;
+                                __Prop1__ = reader.ReadInt32();
+                                continue;
+                            case 216634716752UL:
+                                __Prop2__IsInitialized = true;
+                                __Prop2__ = reader.ReadInt32();
+                                continue;
+                        }
+
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor(__Prop1__);
+            if (__Prop1__IsInitialized)
+            {
+                ____result.Prop1 = __Prop1__;
+            }
+
+            if (__Prop2__IsInitialized)
+            {
+                ____result.Prop2 = __Prop2__;
+            }
+
             reader.Depth--;
             return ____result;
         }

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -1410,7 +1410,7 @@ namespace MessagePack.Formatters
                     case 18:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_AdditionalProperty().Slice(1))) { goto FAIL; }
 
-                        formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IDictionary<string, string>>().Deserialize(ref reader, options);
+                        reader.Skip();
                         continue;
                     case 9:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
@@ -1442,7 +1442,7 @@ namespace MessagePack.Formatters
                     case 12:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_SimpleModels().Slice(1))) { goto FAIL; }
 
-                        formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IList<global::SimpleModel>>().Deserialize(ref reader, options);
+                        reader.Skip();
                         continue;
 
                 }
@@ -1548,7 +1548,7 @@ namespace MessagePack.Formatters
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 128017765461313UL) { goto FAIL; }
 
-                        reader.ReadInt64();
+                        reader.Skip();
                         continue;
 
                 }
@@ -1975,9 +1975,12 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            writer.WriteArrayHeader(2);
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
+            writer.WriteArrayHeader(4);
             writer.Write(value.Prop1);
             writer.Write(value.Prop2);
+            formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop3, options);
+            formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop4, options);
         }
 
         public global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -1988,9 +1991,12 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(int);
+            var __Prop3__ = default(string);
+            var __Prop4__ = default(string);
 
             for (int i = 0; i < length; i++)
             {
@@ -2001,6 +2007,12 @@ namespace MessagePack.Formatters.SharedData
                         break;
                     case 1:
                         __Prop2__ = reader.ReadInt32();
+                        break;
+                    case 2:
+                        __Prop3__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        break;
+                    case 3:
+                        __Prop4__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2015,6 +2027,18 @@ namespace MessagePack.Formatters.SharedData
             }
 
             ____result.Prop2 = __Prop2__;
+            if (length <= 2)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop3 = __Prop3__;
+            if (length <= 3)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop4 = __Prop4__;
 
         MEMBER_ASSIGNMENT_END:
             reader.Depth--;

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -1021,7 +1021,7 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(int[]);
             var __MyProperty1__ = default(int[,]);
@@ -1148,7 +1148,7 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __UserId__ = default(int);
             var __RoomId__ = default(int);
@@ -1212,7 +1212,7 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __QuestId__ = default(int);
             var __Text__ = default(string);
@@ -1311,7 +1311,7 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Text__ = default(string);
 
@@ -1954,7 +1954,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __OPQ__ = default(string);
 
@@ -2100,7 +2100,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Item1__ = default(T1);
             var __Item2__ = default(T2);
@@ -2295,7 +2295,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(string);
@@ -2400,7 +2400,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
@@ -2448,7 +2448,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
@@ -2502,7 +2502,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version0);
             var __After__ = default(int);
@@ -2556,7 +2556,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version1);
             var __After__ = default(int);
@@ -2610,7 +2610,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version2);
             var __After__ = default(int);
@@ -3008,7 +3008,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(global::SharedData.ByteEnum);
@@ -3617,7 +3617,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
             var __UnknownBlock__ = default(global::SharedData.MyClass);
@@ -3729,7 +3729,7 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Data1__ = default(int);
             var __Data2__ = default(string);

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -908,14 +908,13 @@ namespace MessagePack.Formatters.SharedData
 
 namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
 {
-    using System;
-    using System.Buffers;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class TnonodsfarnoiuAtatqagaFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -927,7 +926,7 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
             writer.Write(value.MyProperty);
         }
 
-        public global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -989,14 +988,13 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
 
 namespace MessagePack.Formatters
 {
-    using System;
-    using System.Buffers;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class ArrayTestTestFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::ArrayTestTest>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::ArrayTestTest value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::ArrayTestTest value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1004,7 +1002,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(7);
             formatterResolver.GetFormatterWithVerify<int[]>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<int[,]>().Serialize(ref writer, value.MyProperty1, options);
@@ -1015,15 +1013,15 @@ namespace MessagePack.Formatters
             formatterResolver.GetFormatterWithVerify<global::QuestMessageBody[]>().Serialize(ref writer, value.MyProperty6, options);
         }
 
-        public global::ArrayTestTest Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::ArrayTestTest Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(int[]);
             var __MyProperty1__ = default(int[,]);
@@ -1080,7 +1078,7 @@ namespace MessagePack.Formatters
     public sealed class GlobalManFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::GlobalMan>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::GlobalMan value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::GlobalMan value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1092,7 +1090,7 @@ namespace MessagePack.Formatters
             writer.Write(value.MyProperty);
         }
 
-        public global::GlobalMan Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::GlobalMan Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -1126,7 +1124,7 @@ namespace MessagePack.Formatters
     public sealed class MessageFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::Message>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::Message value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::Message value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1134,7 +1132,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(4);
             writer.Write(value.UserId);
             writer.Write(value.RoomId);
@@ -1142,15 +1140,15 @@ namespace MessagePack.Formatters
             formatterResolver.GetFormatterWithVerify<global::IMessageBody>().Serialize(ref writer, value.Body, options);
         }
 
-        public global::Message Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::Message Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __UserId__ = default(int);
             var __RoomId__ = default(int);
@@ -1192,7 +1190,7 @@ namespace MessagePack.Formatters
     public sealed class QuestMessageBodyFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::QuestMessageBody>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::QuestMessageBody value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::QuestMessageBody value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1200,21 +1198,21 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             writer.Write(value.QuestId);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Text, options);
         }
 
-        public global::QuestMessageBody Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::QuestMessageBody Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __QuestId__ = default(int);
             var __Text__ = default(string);
@@ -1246,7 +1244,7 @@ namespace MessagePack.Formatters
     public sealed class StampMessageBodyFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::StampMessageBody>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::StampMessageBody value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::StampMessageBody value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1258,7 +1256,7 @@ namespace MessagePack.Formatters
             writer.Write(value.StampId);
         }
 
-        public global::StampMessageBody Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::StampMessageBody Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -1292,7 +1290,7 @@ namespace MessagePack.Formatters
     public sealed class TextMessageBodyFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TextMessageBody>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::TextMessageBody value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TextMessageBody value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1300,20 +1298,20 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Text, options);
         }
 
-        public global::TextMessageBody Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::TextMessageBody Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Text__ = default(string);
 
@@ -1793,14 +1791,13 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
 
 namespace MessagePack.Formatters.SharedData
 {
-    using System;
-    using System.Buffers;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class ArrayOptimizeClassFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.ArrayOptimizeClass>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.ArrayOptimizeClass value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.ArrayOptimizeClass value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1827,7 +1824,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty15);
         }
 
-        public global::SharedData.ArrayOptimizeClass Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.ArrayOptimizeClass Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -1936,7 +1933,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class BarClassFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.BarClass>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.BarClass value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.BarClass value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1944,20 +1941,20 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.OPQ, options);
         }
 
-        public global::SharedData.BarClass Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.BarClass Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __OPQ__ = default(string);
 
@@ -1984,7 +1981,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Callback1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Callback1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Callback1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Callback1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -1997,7 +1994,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.X);
         }
 
-        public global::SharedData.Callback1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Callback1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2032,7 +2029,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Callback1_2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Callback1_2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Callback1_2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Callback1_2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2040,12 +2037,12 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            ((IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
+            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
             writer.WriteArrayHeader(1);
             writer.Write(value.X);
         }
 
-        public global::SharedData.Callback1_2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Callback1_2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2071,7 +2068,7 @@ namespace MessagePack.Formatters.SharedData
 
             var ____result = new global::SharedData.Callback1_2(__X__);
             ____result.X = __X__;
-            ((IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
+            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
             reader.Depth--;
             return ____result;
         }
@@ -2080,9 +2077,9 @@ namespace MessagePack.Formatters.SharedData
     public sealed class DynamicArgumentTupleFormatter<T1,T2,T3,T4,T5,T6,T7,T8,T9> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(9);
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.Item1, options);
             formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.Item2, options);
@@ -2095,15 +2092,15 @@ namespace MessagePack.Formatters.SharedData
             formatterResolver.GetFormatterWithVerify<T9>().Serialize(ref writer, value.Item9, options);
         }
 
-        public global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Item1__ = default(T1);
             var __Item2__ = default(T2);
@@ -2161,7 +2158,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Empty1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Empty1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Empty1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Empty1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2172,7 +2169,7 @@ namespace MessagePack.Formatters.SharedData
             writer.WriteArrayHeader(0);
         }
 
-        public global::SharedData.Empty1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Empty1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2201,7 +2198,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class EmptyClassFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.EmptyClass>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.EmptyClass value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.EmptyClass value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2212,7 +2209,7 @@ namespace MessagePack.Formatters.SharedData
             writer.WriteArrayHeader(0);
         }
 
-        public global::SharedData.EmptyClass Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.EmptyClass Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2241,16 +2238,16 @@ namespace MessagePack.Formatters.SharedData
     public sealed class EmptyStructFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.EmptyStruct>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.EmptyStruct value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.EmptyStruct value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(0);
         }
 
-        public global::SharedData.EmptyStruct Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.EmptyStruct Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -2275,7 +2272,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class FirstSimpleDataFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.FirstSimpleData>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.FirstSimpleData value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.FirstSimpleData value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2283,22 +2280,22 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(3);
             writer.Write(value.Prop1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop2, options);
             writer.Write(value.Prop3);
         }
 
-        public global::SharedData.FirstSimpleData Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.FirstSimpleData Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(string);
@@ -2335,7 +2332,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class FooClassFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.FooClass>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.FooClass value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.FooClass value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2347,7 +2344,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.XYZ);
         }
 
-        public global::SharedData.FooClass Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.FooClass Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2381,7 +2378,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class GenericClassFormatter<T1,T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericClass<T1, T2>>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.GenericClass<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.GenericClass<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2389,21 +2386,21 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.MyProperty1, options);
         }
 
-        public global::SharedData.GenericClass<T1, T2> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.GenericClass<T1, T2> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
@@ -2435,23 +2432,23 @@ namespace MessagePack.Formatters.SharedData
     public sealed class GenericStructFormatter<T1,T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericStruct<T1, T2>>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.GenericStruct<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.GenericStruct<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.MyProperty1, options);
         }
 
-        public global::SharedData.GenericStruct<T1, T2> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.GenericStruct<T1, T2> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
@@ -2483,7 +2480,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class HolderV0Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.HolderV0>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.HolderV0 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.HolderV0 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2491,21 +2488,21 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
         }
 
-        public global::SharedData.HolderV0 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.HolderV0 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version0);
             var __After__ = default(int);
@@ -2537,7 +2534,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class HolderV1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.HolderV1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.HolderV1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.HolderV1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2545,21 +2542,21 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
         }
 
-        public global::SharedData.HolderV1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.HolderV1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version1);
             var __After__ = default(int);
@@ -2591,7 +2588,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class HolderV2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.HolderV2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.HolderV2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.HolderV2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2599,21 +2596,21 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
         }
 
-        public global::SharedData.HolderV2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.HolderV2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version2);
             var __After__ = default(int);
@@ -2645,7 +2642,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class MyClassFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.MyClass>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.MyClass value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.MyClass value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2659,7 +2656,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty3);
         }
 
-        public global::SharedData.MyClass Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.MyClass Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2703,7 +2700,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class MySubUnion1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.MySubUnion1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.MySubUnion1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.MySubUnion1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2718,7 +2715,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.One);
         }
 
-        public global::SharedData.MySubUnion1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.MySubUnion1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2752,7 +2749,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class MySubUnion2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.MySubUnion2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.MySubUnion2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.MySubUnion2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(6);
             writer.WriteNil();
@@ -2763,11 +2760,11 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.Two);
         }
 
-        public global::SharedData.MySubUnion2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.MySubUnion2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -2797,7 +2794,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class MySubUnion3Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.MySubUnion3>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.MySubUnion3 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.MySubUnion3 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2811,7 +2808,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.Three);
         }
 
-        public global::SharedData.MySubUnion3 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.MySubUnion3 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2845,7 +2842,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class MySubUnion4Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.MySubUnion4>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.MySubUnion4 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.MySubUnion4 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(8);
             writer.WriteNil();
@@ -2858,11 +2855,11 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.Four);
         }
 
-        public global::SharedData.MySubUnion4 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.MySubUnion4 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -2892,7 +2889,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class NestParent_NestContractFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.NestParent.NestContract>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.NestParent.NestContract value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.NestParent.NestContract value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2904,7 +2901,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty);
         }
 
-        public global::SharedData.NestParent.NestContract Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.NestParent.NestContract Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2938,7 +2935,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class NonEmpty1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.NonEmpty1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.NonEmpty1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.NonEmpty1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2950,7 +2947,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty);
         }
 
-        public global::SharedData.NonEmpty1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.NonEmpty1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -2984,7 +2981,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class SimpleIntKeyDataFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.SimpleIntKeyData>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.SimpleIntKeyData value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SimpleIntKeyData value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -2992,7 +2989,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(7);
             writer.Write(value.Prop1);
             formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Serialize(ref writer, value.Prop2, options);
@@ -3003,15 +3000,15 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.BytesSpecial);
         }
 
-        public global::SharedData.SimpleIntKeyData Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.SimpleIntKeyData Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(global::SharedData.ByteEnum);
@@ -3068,7 +3065,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class SimpleStructIntKeyDataFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.SimpleStructIntKeyData>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.SimpleStructIntKeyData value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SimpleStructIntKeyData value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(3);
             writer.Write(value.X);
@@ -3076,11 +3073,11 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.BytesSpecial);
         }
 
-        public global::SharedData.SimpleStructIntKeyData Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.SimpleStructIntKeyData Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -3120,7 +3117,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class SubUnionType1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.SubUnionType1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.SubUnionType1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SubUnionType1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3133,7 +3130,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty1);
         }
 
-        public global::SharedData.SubUnionType1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.SubUnionType1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3162,8 +3159,8 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.SubUnionType1();
-            ____result.MyProperty1 = __MyProperty1__;
             ____result.MyProperty = __MyProperty__;
+            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -3172,7 +3169,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class SubUnionType2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.SubUnionType2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.SubUnionType2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SubUnionType2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3185,7 +3182,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty2);
         }
 
-        public global::SharedData.SubUnionType2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.SubUnionType2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3214,8 +3211,8 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.SubUnionType2();
-            ____result.MyProperty2 = __MyProperty2__;
             ____result.MyProperty = __MyProperty__;
+            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3224,7 +3221,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class UnVersionBlockTestFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.UnVersionBlockTest>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.UnVersionBlockTest value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.UnVersionBlockTest value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3238,7 +3235,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty2);
         }
 
-        public global::SharedData.UnVersionBlockTest Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.UnVersionBlockTest Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3277,18 +3274,18 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Vector2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Vector2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Vector2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Vector2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(2);
             writer.Write(value.X);
             writer.Write(value.Y);
         }
 
-        public global::SharedData.Vector2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Vector2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -3321,7 +3318,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Vector3LikeFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Vector3Like>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Vector3Like value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Vector3Like value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(3);
             writer.Write(value.x);
@@ -3329,11 +3326,11 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.z);
         }
 
-        public global::SharedData.Vector3Like Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Vector3Like Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -3373,18 +3370,18 @@ namespace MessagePack.Formatters.SharedData
     public sealed class VectorLike2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.VectorLike2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.VectorLike2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.VectorLike2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             writer.WriteArrayHeader(2);
             writer.Write(value.x);
             writer.Write(value.y);
         }
 
-        public global::SharedData.VectorLike2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.VectorLike2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-                throw new InvalidOperationException("typecode is null, struct not supported");
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
             options.Security.DepthStep(ref reader);
@@ -3419,7 +3416,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Version0Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Version0>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Version0 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Version0 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3434,7 +3431,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty1);
         }
 
-        public global::SharedData.Version0 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Version0 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3468,7 +3465,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Version1Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Version1>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Version1 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Version1 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3485,7 +3482,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty3);
         }
 
-        public global::SharedData.Version1 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Version1 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3529,7 +3526,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class Version2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Version2>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.Version2 value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Version2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3548,7 +3545,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.MyProperty5);
         }
 
-        public global::SharedData.Version2 Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.Version2 Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3597,7 +3594,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class VersionBlockTestFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.VersionBlockTest>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.VersionBlockTest value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.VersionBlockTest value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3605,22 +3602,22 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(3);
             writer.Write(value.MyProperty);
             formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Serialize(ref writer, value.UnknownBlock, options);
             writer.Write(value.MyProperty2);
         }
 
-        public global::SharedData.VersionBlockTest Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.VersionBlockTest Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
             var __UnknownBlock__ = default(global::SharedData.MyClass);
@@ -3657,7 +3654,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class VersioningUnionFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.VersioningUnion>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.VersioningUnion value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.VersioningUnion value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3676,7 +3673,7 @@ namespace MessagePack.Formatters.SharedData
             writer.Write(value.FV);
         }
 
-        public global::SharedData.VersioningUnion Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.VersioningUnion Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
@@ -3710,7 +3707,7 @@ namespace MessagePack.Formatters.SharedData
     public sealed class WithIndexerFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.WithIndexer>
     {
 
-        public void Serialize(ref MessagePackWriter writer, global::SharedData.WithIndexer value, global::MessagePack.MessagePackSerializerOptions options)
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.WithIndexer value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value == null)
             {
@@ -3718,21 +3715,21 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             writer.Write(value.Data1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Data2, options);
         }
 
-        public global::SharedData.WithIndexer Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public global::SharedData.WithIndexer Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
                 return null;
             }
 
+            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Data1__ = default(int);
             var __Data2__ = default(string);

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -937,7 +937,7 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1002,7 +1002,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(7);
             formatterResolver.GetFormatterWithVerify<int[]>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<int[,]>().Serialize(ref writer, value.MyProperty1, options);
@@ -1020,8 +1020,8 @@ namespace MessagePack.Formatters
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(int[]);
             var __MyProperty1__ = default(int[,]);
@@ -1031,7 +1031,7 @@ namespace MessagePack.Formatters
             var __MyProperty5__ = default(global::GlobalMyEnum[]);
             var __MyProperty6__ = default(global::QuestMessageBody[]);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1101,7 +1101,7 @@ namespace MessagePack.Formatters
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1132,7 +1132,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(4);
             writer.Write(value.UserId);
             writer.Write(value.RoomId);
@@ -1147,15 +1147,15 @@ namespace MessagePack.Formatters
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __UserId__ = default(int);
             var __RoomId__ = default(int);
             var __PostTime__ = default(global::System.DateTime);
             var __Body__ = default(global::IMessageBody);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1198,7 +1198,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             writer.Write(value.QuestId);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Text, options);
@@ -1211,13 +1211,13 @@ namespace MessagePack.Formatters
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __QuestId__ = default(int);
             var __Text__ = default(string);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1267,7 +1267,7 @@ namespace MessagePack.Formatters
             var length = reader.ReadArrayHeader();
             var __StampId__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1298,7 +1298,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Text, options);
         }
@@ -1310,12 +1310,12 @@ namespace MessagePack.Formatters
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Text__ = default(string);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1850,7 +1850,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty14__ = default(int);
             var __MyProperty15__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -1941,7 +1941,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.OPQ, options);
         }
@@ -1953,12 +1953,12 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __OPQ__ = default(string);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2005,7 +2005,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __X__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2053,7 +2053,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __X__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2074,12 +2074,12 @@ namespace MessagePack.Formatters.SharedData
         }
     }
 
-    public sealed class DynamicArgumentTupleFormatter<T1,T2,T3,T4,T5,T6,T7,T8,T9> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
+    public sealed class DynamicArgumentTupleFormatter<T1, T2, T3, T4, T5, T6, T7, T8, T9> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>>
     {
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DynamicArgumentTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(9);
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.Item1, options);
             formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.Item2, options);
@@ -2099,8 +2099,8 @@ namespace MessagePack.Formatters.SharedData
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Item1__ = default(T1);
             var __Item2__ = default(T2);
@@ -2112,7 +2112,7 @@ namespace MessagePack.Formatters.SharedData
             var __Item8__ = default(T8);
             var __Item9__ = default(T9);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2179,7 +2179,7 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2219,7 +2219,7 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2253,7 +2253,7 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2280,7 +2280,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(3);
             writer.Write(value.Prop1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop2, options);
@@ -2294,14 +2294,14 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(string);
             var __Prop3__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2355,7 +2355,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __XYZ__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2375,7 +2375,7 @@ namespace MessagePack.Formatters.SharedData
         }
     }
 
-    public sealed class GenericClassFormatter<T1,T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericClass<T1, T2>>
+    public sealed class GenericClassFormatter<T1, T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericClass<T1, T2>>
     {
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.GenericClass<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
@@ -2386,7 +2386,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.MyProperty1, options);
@@ -2399,13 +2399,13 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2429,12 +2429,12 @@ namespace MessagePack.Formatters.SharedData
         }
     }
 
-    public sealed class GenericStructFormatter<T1,T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericStruct<T1, T2>>
+    public sealed class GenericStructFormatter<T1, T2> : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.GenericStruct<T1, T2>>
     {
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.GenericStruct<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
             formatterResolver.GetFormatterWithVerify<T2>().Serialize(ref writer, value.MyProperty1, options);
@@ -2447,13 +2447,13 @@ namespace MessagePack.Formatters.SharedData
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty0__ = default(T1);
             var __MyProperty1__ = default(T2);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2488,7 +2488,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
@@ -2501,13 +2501,13 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version0);
             var __After__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2542,7 +2542,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
@@ -2555,13 +2555,13 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version1);
             var __After__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2596,7 +2596,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Serialize(ref writer, value.MyProperty1, options);
             writer.Write(value.After);
@@ -2609,13 +2609,13 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(global::SharedData.Version2);
             var __After__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2669,7 +2669,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty2__ = default(int);
             var __MyProperty3__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2726,7 +2726,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __One__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2771,7 +2771,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __Two__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2819,7 +2819,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __Three__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2866,7 +2866,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __Four__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2912,7 +2912,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2958,7 +2958,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -2989,7 +2989,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(7);
             writer.Write(value.Prop1);
             formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Serialize(ref writer, value.Prop2, options);
@@ -3007,8 +3007,8 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Prop1__ = default(int);
             var __Prop2__ = default(global::SharedData.ByteEnum);
@@ -3018,7 +3018,7 @@ namespace MessagePack.Formatters.SharedData
             var __Prop6__ = default(global::SharedData.SimpleStructStringKeyData);
             var __BytesSpecial__ = default(byte[]);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3086,7 +3086,7 @@ namespace MessagePack.Formatters.SharedData
             var __Y__ = default(int);
             var __BytesSpecial__ = default(byte[]);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3142,7 +3142,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty1__ = default(int);
             var __MyProperty__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3194,7 +3194,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty2__ = default(int);
             var __MyProperty__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3247,7 +3247,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty__ = default(int);
             var __MyProperty2__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3293,7 +3293,7 @@ namespace MessagePack.Formatters.SharedData
             var __X__ = default(float);
             var __Y__ = default(float);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3339,7 +3339,7 @@ namespace MessagePack.Formatters.SharedData
             var __y__ = default(float);
             var __z__ = default(float);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3389,7 +3389,7 @@ namespace MessagePack.Formatters.SharedData
             var __x__ = default(float);
             var __y__ = default(float);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3442,7 +3442,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __MyProperty1__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3495,7 +3495,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty2__ = default(int);
             var __MyProperty3__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3559,7 +3559,7 @@ namespace MessagePack.Formatters.SharedData
             var __MyProperty3__ = default(int);
             var __MyProperty5__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3602,7 +3602,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(3);
             writer.Write(value.MyProperty);
             formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Serialize(ref writer, value.UnknownBlock, options);
@@ -3616,14 +3616,14 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __MyProperty__ = default(int);
             var __UnknownBlock__ = default(global::SharedData.MyClass);
             var __MyProperty2__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3684,7 +3684,7 @@ namespace MessagePack.Formatters.SharedData
             var length = reader.ReadArrayHeader();
             var __FV__ = default(int);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -3715,7 +3715,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             writer.WriteArrayHeader(2);
             writer.Write(value.Data1);
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Data2, options);
@@ -3728,13 +3728,13 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            var formatterResolver = options.Resolver;
             options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
             var __Data1__ = default(int);
             var __Data2__ = default(string);
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -1332,10 +1332,8 @@ namespace MessagePack.Formatters
 
 namespace MessagePack.Formatters
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class ComplexModelFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::ComplexModel>
     {
@@ -1360,7 +1358,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(6);
             writer.WriteRaw(GetSpan_AdditionalProperty());
             formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IDictionary<string, string>>().Serialize(ref writer, value.AdditionalProperty, options);
@@ -1384,18 +1382,13 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __AdditionalProperty__ = default(global::System.Collections.Generic.IDictionary<string, string>);
-            var __CreatedOn__ = default(global::System.DateTimeOffset);
-            var __Id__ = default(global::System.Guid);
-            var __Name__ = default(string);
-            var __UpdatedOn__ = default(global::System.DateTimeOffset);
-            var __SimpleModels__ = default(global::System.Collections.Generic.IList<global::SimpleModel>);
+            var ____result = new global::ComplexModel();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -1405,7 +1398,7 @@ namespace MessagePack.Formatters
                     case 18:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_AdditionalProperty().Slice(1))) { goto FAIL; }
 
-                        __AdditionalProperty__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IDictionary<string, string>>().Deserialize(ref reader, options);
+                        formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IDictionary<string, string>>().Deserialize(ref reader, options);
                         continue;
                     case 9:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
@@ -1414,42 +1407,34 @@ namespace MessagePack.Formatters
                             case 5720808977192022595UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __CreatedOn__ = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
+                                ____result.CreatedOn = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
                                 continue;
 
                             case 5720808977191956565UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __UpdatedOn__ = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
+                                ____result.UpdatedOn = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
                                 continue;
 
                         }
                     case 2:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 25673UL) { goto FAIL; }
 
-                        __Id__ = formatterResolver.GetFormatterWithVerify<global::System.Guid>().Deserialize(ref reader, options);
+                        ____result.Id = formatterResolver.GetFormatterWithVerify<global::System.Guid>().Deserialize(ref reader, options);
                         continue;
                     case 4:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 1701667150UL) { goto FAIL; }
 
-                        __Name__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Name = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         continue;
                     case 12:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_SimpleModels().Slice(1))) { goto FAIL; }
 
-                        __SimpleModels__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IList<global::SimpleModel>>().Deserialize(ref reader, options);
+                        formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IList<global::SimpleModel>>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::ComplexModel()
-            {
-                CreatedOn = __CreatedOn__,
-                Id = __Id__,
-                Name = __Name__,
-                UpdatedOn = __UpdatedOn__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -1479,7 +1464,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(6);
             writer.WriteRaw(GetSpan_Id());
             writer.Write(value.Id);
@@ -1503,18 +1488,13 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __Id__ = default(int);
-            var __Name__ = default(string);
-            var __CreatedOn__ = default(global::System.DateTime);
-            var __Precision__ = default(int);
-            var __Money__ = default(decimal);
-            var __Amount__ = default(long);
+            var ____result = new global::SimpleModel();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -1524,12 +1504,12 @@ namespace MessagePack.Formatters
                     case 2:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 25673UL) { goto FAIL; }
 
-                        __Id__ = reader.ReadInt32();
+                        ____result.Id = reader.ReadInt32();
                         continue;
                     case 4:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 1701667150UL) { goto FAIL; }
 
-                        __Name__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Name = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         continue;
                     case 9:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
@@ -1538,38 +1518,29 @@ namespace MessagePack.Formatters
                             case 5720808977192022595UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __CreatedOn__ = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
+                                ____result.CreatedOn = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
                                 continue;
 
                             case 8028074707240972880UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __Precision__ = reader.ReadInt32();
+                                ____result.Precision = reader.ReadInt32();
                                 continue;
 
                         }
                     case 5:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 521392779085UL) { goto FAIL; }
 
-                        __Money__ = formatterResolver.GetFormatterWithVerify<decimal>().Deserialize(ref reader, options);
+                        ____result.Money = formatterResolver.GetFormatterWithVerify<decimal>().Deserialize(ref reader, options);
                         continue;
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 128017765461313UL) { goto FAIL; }
 
-                        __Amount__ = reader.ReadInt64();
+                        reader.ReadInt64();
                         continue;
 
                 }
             }
-
-            var ____result = new global::SimpleModel()
-            {
-                Id = __Id__,
-                Name = __Name__,
-                CreatedOn = __CreatedOn__,
-                Precision = __Precision__,
-                Money = __Money__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -1595,10 +1566,8 @@ namespace MessagePack.Formatters
 
 namespace MessagePack.Formatters.PerfBenchmarkDotNet
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class StringKeySerializerTargetFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::PerfBenchmarkDotNet.StringKeySerializerTarget>
     {
@@ -1659,19 +1628,11 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
-            var __MyProperty4__ = default(int);
-            var __MyProperty5__ = default(int);
-            var __MyProperty6__ = default(int);
-            var __MyProperty7__ = default(int);
-            var __MyProperty8__ = default(int);
-            var __MyProperty9__ = default(int);
+            var ____result = new global::PerfBenchmarkDotNet.StringKeySerializerTarget();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -1687,31 +1648,31 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
                                 {
                                     default: goto FAIL;
                                     case 3242356UL:
-                                        __MyProperty1__ = reader.ReadInt32();
+                                        ____result.MyProperty1 = reader.ReadInt32();
                                         continue;
                                     case 3307892UL:
-                                        __MyProperty2__ = reader.ReadInt32();
+                                        ____result.MyProperty2 = reader.ReadInt32();
                                         continue;
                                     case 3373428UL:
-                                        __MyProperty3__ = reader.ReadInt32();
+                                        ____result.MyProperty3 = reader.ReadInt32();
                                         continue;
                                     case 3438964UL:
-                                        __MyProperty4__ = reader.ReadInt32();
+                                        ____result.MyProperty4 = reader.ReadInt32();
                                         continue;
                                     case 3504500UL:
-                                        __MyProperty5__ = reader.ReadInt32();
+                                        ____result.MyProperty5 = reader.ReadInt32();
                                         continue;
                                     case 3570036UL:
-                                        __MyProperty6__ = reader.ReadInt32();
+                                        ____result.MyProperty6 = reader.ReadInt32();
                                         continue;
                                     case 3635572UL:
-                                        __MyProperty7__ = reader.ReadInt32();
+                                        ____result.MyProperty7 = reader.ReadInt32();
                                         continue;
                                     case 3701108UL:
-                                        __MyProperty8__ = reader.ReadInt32();
+                                        ____result.MyProperty8 = reader.ReadInt32();
                                         continue;
                                     case 3766644UL:
-                                        __MyProperty9__ = reader.ReadInt32();
+                                        ____result.MyProperty9 = reader.ReadInt32();
                                         continue;
                                 }
 
@@ -1719,19 +1680,6 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
 
                 }
             }
-
-            var ____result = new global::PerfBenchmarkDotNet.StringKeySerializerTarget()
-            {
-                MyProperty1 = __MyProperty1__,
-                MyProperty2 = __MyProperty2__,
-                MyProperty3 = __MyProperty3__,
-                MyProperty4 = __MyProperty4__,
-                MyProperty5 = __MyProperty5__,
-                MyProperty6 = __MyProperty6__,
-                MyProperty7 = __MyProperty7__,
-                MyProperty8 = __MyProperty8__,
-                MyProperty9 = __MyProperty9__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -3616,10 +3564,8 @@ namespace MessagePack.Formatters.SharedData
 
 namespace MessagePack.Formatters.SharedData
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class Callback2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Callback2>
     {
@@ -3644,10 +3590,11 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
             var __X__ = default(int);
+            var __X__IsInitialized = false;
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3657,16 +3604,18 @@ namespace MessagePack.Formatters.SharedData
                     case 1:
                         if (stringKey[0] != 88) { goto FAIL; }
 
+                        __X__IsInitialized = true;
                         __X__ = reader.ReadInt32();
                         continue;
 
                 }
             }
 
-            var ____result = new global::SharedData.Callback2(__X__)
+            var ____result = new global::SharedData.Callback2(__X__);
+            if (__X__IsInitialized)
             {
-                X = __X__,
-            };
+                ____result.X = __X__;
+            }
 
             ____result.OnAfterDeserialize();
             reader.Depth--;
@@ -3697,10 +3646,11 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
             var __X__ = default(int);
+            var __X__IsInitialized = false;
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3710,16 +3660,18 @@ namespace MessagePack.Formatters.SharedData
                     case 1:
                         if (stringKey[0] != 88) { goto FAIL; }
 
+                        __X__IsInitialized = true;
                         __X__ = reader.ReadInt32();
                         continue;
 
                 }
             }
 
-            var ____result = new global::SharedData.Callback2_2(__X__)
+            var ____result = new global::SharedData.Callback2_2(__X__);
+            if (__X__IsInitialized)
             {
-                X = __X__,
-            };
+                ____result.X = __X__;
+            }
 
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
             reader.Depth--;
@@ -3729,7 +3681,6 @@ namespace MessagePack.Formatters.SharedData
 
     public sealed class Empty2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Empty2>
     {
-
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Empty2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -3781,11 +3732,11 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.NonEmpty2();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3795,16 +3746,11 @@ namespace MessagePack.Formatters.SharedData
                     case 10:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_MyProperty().Slice(1))) { goto FAIL; }
 
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         continue;
 
                 }
             }
-
-            var ____result = new global::SharedData.NonEmpty2()
-            {
-                MyProperty = __MyProperty__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -3828,7 +3774,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
             writer.WriteRaw(GetSpan_Prop1());
             writer.Write(value.Prop1);
@@ -3846,15 +3792,13 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __Prop1__ = default(int);
-            var __Prop2__ = default(global::SharedData.ByteEnum);
-            var __Prop3__ = default(int);
+            var ____result = new global::SharedData.SimpleStringKeyData();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3866,25 +3810,18 @@ namespace MessagePack.Formatters.SharedData
                         {
                             default: goto FAIL;
                             case 212339749456UL:
-                                __Prop1__ = reader.ReadInt32();
+                                ____result.Prop1 = reader.ReadInt32();
                                 continue;
                             case 216634716752UL:
-                                __Prop2__ = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
+                                ____result.Prop2 = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
                                 continue;
                             case 220929684048UL:
-                                __Prop3__ = reader.ReadInt32();
+                                ____result.Prop3 = reader.ReadInt32();
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::SharedData.SimpleStringKeyData()
-            {
-                Prop1 = __Prop1__,
-                Prop2 = __Prop2__,
-                Prop3 = __Prop3__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -3900,7 +3837,7 @@ namespace MessagePack.Formatters.SharedData
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SimpleStructStringKeyData value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_X());
             writer.Write(value.X);
@@ -3916,14 +3853,13 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __X__ = default(int);
-            var __Y__ = default(int[]);
+            var ____result = new global::SharedData.SimpleStructStringKeyData();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3935,21 +3871,15 @@ namespace MessagePack.Formatters.SharedData
                         {
                             default: goto FAIL;
                             case 378720052587UL:
-                                __X__ = reader.ReadInt32();
+                                ____result.X = reader.ReadInt32();
                                 continue;
                             case 383015019883UL:
-                                __Y__ = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
+                                ____result.Y = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::SharedData.SimpleStructStringKeyData()
-            {
-                X = __X__,
-                Y = __Y__,
-            };
 
             reader.Depth--;
             return ____result;

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -935,14 +935,14 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -950,8 +950,6 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
                 }
             }
 
-            var ____result = new global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -1023,38 +1021,32 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(int[]);
-            var __MyProperty1__ = default(int[,]);
-            var __MyProperty2__ = default(global::GlobalMyEnum[,]);
-            var __MyProperty3__ = default(int[,,]);
-            var __MyProperty4__ = default(int[,,,]);
-            var __MyProperty5__ = default(global::GlobalMyEnum[]);
-            var __MyProperty6__ = default(global::QuestMessageBody[]);
+            var ____result = new global::ArrayTestTest();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<int[,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<int[,]>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __MyProperty2__ = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty2 = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[,]>().Deserialize(ref reader, options);
                         break;
                     case 3:
-                        __MyProperty3__ = formatterResolver.GetFormatterWithVerify<int[,,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty3 = formatterResolver.GetFormatterWithVerify<int[,,]>().Deserialize(ref reader, options);
                         break;
                     case 4:
-                        __MyProperty4__ = formatterResolver.GetFormatterWithVerify<int[,,,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty4 = formatterResolver.GetFormatterWithVerify<int[,,,]>().Deserialize(ref reader, options);
                         break;
                     case 5:
-                        __MyProperty5__ = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[]>().Deserialize(ref reader, options);
+                        ____result.MyProperty5 = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[]>().Deserialize(ref reader, options);
                         break;
                     case 6:
-                        __MyProperty6__ = formatterResolver.GetFormatterWithVerify<global::QuestMessageBody[]>().Deserialize(ref reader, options);
+                        ____result.MyProperty6 = formatterResolver.GetFormatterWithVerify<global::QuestMessageBody[]>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1062,14 +1054,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::ArrayTestTest();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
-            ____result.MyProperty4 = __MyProperty4__;
-            ____result.MyProperty5 = __MyProperty5__;
-            ____result.MyProperty6 = __MyProperty6__;
             reader.Depth--;
             return ____result;
         }
@@ -1099,14 +1083,14 @@ namespace MessagePack.Formatters
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::GlobalMan();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -1114,8 +1098,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::GlobalMan();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -1150,26 +1132,23 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __UserId__ = default(int);
-            var __RoomId__ = default(int);
-            var __PostTime__ = default(global::System.DateTime);
-            var __Body__ = default(global::IMessageBody);
+            var ____result = new global::Message();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __UserId__ = reader.ReadInt32();
+                        ____result.UserId = reader.ReadInt32();
                         break;
                     case 1:
-                        __RoomId__ = reader.ReadInt32();
+                        ____result.RoomId = reader.ReadInt32();
                         break;
                     case 2:
-                        __PostTime__ = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
+                        ____result.PostTime = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
                         break;
                     case 3:
-                        __Body__ = formatterResolver.GetFormatterWithVerify<global::IMessageBody>().Deserialize(ref reader, options);
+                        ____result.Body = formatterResolver.GetFormatterWithVerify<global::IMessageBody>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1177,11 +1156,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::Message();
-            ____result.UserId = __UserId__;
-            ____result.RoomId = __RoomId__;
-            ____result.PostTime = __PostTime__;
-            ____result.Body = __Body__;
             reader.Depth--;
             return ____result;
         }
@@ -1214,18 +1188,17 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __QuestId__ = default(int);
-            var __Text__ = default(string);
+            var ____result = new global::QuestMessageBody();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __QuestId__ = reader.ReadInt32();
+                        ____result.QuestId = reader.ReadInt32();
                         break;
                     case 1:
-                        __Text__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Text = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1233,9 +1206,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::QuestMessageBody();
-            ____result.QuestId = __QuestId__;
-            ____result.Text = __Text__;
             reader.Depth--;
             return ____result;
         }
@@ -1265,14 +1235,14 @@ namespace MessagePack.Formatters
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __StampId__ = default(int);
+            var ____result = new global::StampMessageBody();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __StampId__ = reader.ReadInt32();
+                        ____result.StampId = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -1280,8 +1250,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::StampMessageBody();
-            ____result.StampId = __StampId__;
             reader.Depth--;
             return ____result;
         }
@@ -1313,14 +1281,14 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Text__ = default(string);
+            var ____result = new global::TextMessageBody();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Text__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Text = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1328,8 +1296,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::TextMessageBody();
-            ____result.Text = __Text__;
             reader.Depth--;
             return ____result;
         }
@@ -1833,74 +1799,59 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(int);
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
-            var __MyProperty4__ = default(int);
-            var __MyProperty5__ = default(int);
-            var __MyProperty6__ = default(int);
-            var __MyProperty7__ = default(int);
-            var __MyProperty8__ = default(int);
-            var __MyProvperty9__ = default(int);
-            var __MyProperty10__ = default(int);
-            var __MyProperty11__ = default(int);
-            var __MyPropverty12__ = default(int);
-            var __MyPropevrty13__ = default(int);
-            var __MyProperty14__ = default(int);
-            var __MyProperty15__ = default(int);
+            var ____result = new global::SharedData.ArrayOptimizeClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = reader.ReadInt32();
+                        ____result.MyProperty0 = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 2:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 3:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     case 4:
-                        __MyProperty4__ = reader.ReadInt32();
+                        ____result.MyProperty4 = reader.ReadInt32();
                         break;
                     case 5:
-                        __MyProperty5__ = reader.ReadInt32();
+                        ____result.MyProperty5 = reader.ReadInt32();
                         break;
                     case 6:
-                        __MyProperty6__ = reader.ReadInt32();
+                        ____result.MyProperty6 = reader.ReadInt32();
                         break;
                     case 7:
-                        __MyProperty7__ = reader.ReadInt32();
+                        ____result.MyProperty7 = reader.ReadInt32();
                         break;
                     case 8:
-                        __MyProperty8__ = reader.ReadInt32();
+                        ____result.MyProperty8 = reader.ReadInt32();
                         break;
                     case 9:
-                        __MyProvperty9__ = reader.ReadInt32();
+                        ____result.MyProvperty9 = reader.ReadInt32();
                         break;
                     case 10:
-                        __MyProperty10__ = reader.ReadInt32();
+                        ____result.MyProperty10 = reader.ReadInt32();
                         break;
                     case 11:
-                        __MyProperty11__ = reader.ReadInt32();
+                        ____result.MyProperty11 = reader.ReadInt32();
                         break;
                     case 12:
-                        __MyPropverty12__ = reader.ReadInt32();
+                        ____result.MyPropverty12 = reader.ReadInt32();
                         break;
                     case 13:
-                        __MyPropevrty13__ = reader.ReadInt32();
+                        ____result.MyPropevrty13 = reader.ReadInt32();
                         break;
                     case 14:
-                        __MyProperty14__ = reader.ReadInt32();
+                        ____result.MyProperty14 = reader.ReadInt32();
                         break;
                     case 15:
-                        __MyProperty15__ = reader.ReadInt32();
+                        ____result.MyProperty15 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -1908,23 +1859,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.ArrayOptimizeClass();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
-            ____result.MyProperty4 = __MyProperty4__;
-            ____result.MyProperty5 = __MyProperty5__;
-            ____result.MyProperty6 = __MyProperty6__;
-            ____result.MyProperty7 = __MyProperty7__;
-            ____result.MyProperty8 = __MyProperty8__;
-            ____result.MyProvperty9 = __MyProvperty9__;
-            ____result.MyProperty10 = __MyProperty10__;
-            ____result.MyProperty11 = __MyProperty11__;
-            ____result.MyPropverty12 = __MyPropverty12__;
-            ____result.MyPropevrty13 = __MyPropevrty13__;
-            ____result.MyProperty14 = __MyProperty14__;
-            ____result.MyProperty15 = __MyProperty15__;
             reader.Depth--;
             return ____result;
         }
@@ -1956,14 +1890,14 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __OPQ__ = default(string);
+            var ____result = new global::SharedData.BarClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __OPQ__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.OPQ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1971,8 +1905,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.BarClass();
-            ____result.OPQ = __OPQ__;
             reader.Depth--;
             return ____result;
         }
@@ -2019,7 +1951,14 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback1(__X__);
+            if (length <= 0)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.X = __X__;
+
+        MEMBER_ASSIGNMENT_END:
             ____result.OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -2067,7 +2006,14 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback1_2(__X__);
+            if (length <= 0)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.X = __X__;
+
+        MEMBER_ASSIGNMENT_END:
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -2176,22 +2122,8 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            options.Security.DepthStep(ref reader);
-            var length = reader.ReadArrayHeader();
-
-            for (int i = 0; i < length; i++)
-            {
-                switch (i)
-                {
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            var ____result = new global::SharedData.Empty1();
-            reader.Depth--;
-            return ____result;
+            reader.Skip();
+            return new global::SharedData.Empty1();
         }
     }
 
@@ -2216,22 +2148,8 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            options.Security.DepthStep(ref reader);
-            var length = reader.ReadArrayHeader();
-
-            for (int i = 0; i < length; i++)
-            {
-                switch (i)
-                {
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            var ____result = new global::SharedData.EmptyClass();
-            reader.Depth--;
-            return ____result;
+            reader.Skip();
+            return new global::SharedData.EmptyClass();
         }
     }
 
@@ -2250,22 +2168,8 @@ namespace MessagePack.Formatters.SharedData
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
-            options.Security.DepthStep(ref reader);
-            var length = reader.ReadArrayHeader();
-
-            for (int i = 0; i < length; i++)
-            {
-                switch (i)
-                {
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            var ____result = new global::SharedData.EmptyStruct();
-            reader.Depth--;
-            return ____result;
+            reader.Skip();
+            return new global::SharedData.EmptyStruct();
         }
     }
 
@@ -2297,22 +2201,20 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Prop1__ = default(int);
-            var __Prop2__ = default(string);
-            var __Prop3__ = default(int);
+            var ____result = new global::SharedData.FirstSimpleData();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Prop1__ = reader.ReadInt32();
+                        ____result.Prop1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __Prop2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Prop2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __Prop3__ = reader.ReadInt32();
+                        ____result.Prop3 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2320,10 +2222,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.FirstSimpleData();
-            ____result.Prop1 = __Prop1__;
-            ____result.Prop2 = __Prop2__;
-            ____result.Prop3 = __Prop3__;
             reader.Depth--;
             return ____result;
         }
@@ -2353,14 +2251,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __XYZ__ = default(int);
+            var ____result = new global::SharedData.FooClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __XYZ__ = reader.ReadInt32();
+                        ____result.XYZ = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2368,8 +2266,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.FooClass();
-            ____result.XYZ = __XYZ__;
             reader.Depth--;
             return ____result;
         }
@@ -2402,18 +2298,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(T1);
-            var __MyProperty1__ = default(T2);
+            var ____result = new global::SharedData.GenericClass<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2421,9 +2316,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.GenericClass<T1, T2>();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -2450,18 +2342,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(T1);
-            var __MyProperty1__ = default(T2);
+            var ____result = new global::SharedData.GenericStruct<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2469,9 +2360,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.GenericStruct<T1, T2>();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -2504,18 +2392,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(global::SharedData.Version0);
-            var __After__ = default(int);
+            var ____result = new global::SharedData.HolderV0();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __After__ = reader.ReadInt32();
+                        ____result.After = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2523,9 +2410,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.HolderV0();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.After = __After__;
             reader.Depth--;
             return ____result;
         }
@@ -2558,18 +2442,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(global::SharedData.Version1);
-            var __After__ = default(int);
+            var ____result = new global::SharedData.HolderV1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __After__ = reader.ReadInt32();
+                        ____result.After = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2577,9 +2460,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.HolderV1();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.After = __After__;
             reader.Depth--;
             return ____result;
         }
@@ -2612,18 +2492,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(global::SharedData.Version2);
-            var __After__ = default(int);
+            var ____result = new global::SharedData.HolderV2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __After__ = reader.ReadInt32();
+                        ____result.After = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2631,9 +2510,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.HolderV2();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.After = __After__;
             reader.Depth--;
             return ____result;
         }
@@ -2665,22 +2541,20 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
+            var ____result = new global::SharedData.MyClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 2:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2688,10 +2562,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MyClass();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
             reader.Depth--;
             return ____result;
         }
@@ -2724,14 +2594,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __One__ = default(int);
+            var ____result = new global::SharedData.MySubUnion1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __One__ = reader.ReadInt32();
+                        ____result.One = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2739,8 +2609,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion1();
-            ____result.One = __One__;
             reader.Depth--;
             return ____result;
         }
@@ -2769,14 +2637,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __Two__ = default(int);
+            var ____result = new global::SharedData.MySubUnion2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 5:
-                        __Two__ = reader.ReadInt32();
+                        ____result.Two = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2784,8 +2652,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion2();
-            ____result.Two = __Two__;
             reader.Depth--;
             return ____result;
         }
@@ -2817,14 +2683,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __Three__ = default(int);
+            var ____result = new global::SharedData.MySubUnion3();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 2:
-                        __Three__ = reader.ReadInt32();
+                        ____result.Three = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2832,8 +2698,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion3();
-            ____result.Three = __Three__;
             reader.Depth--;
             return ____result;
         }
@@ -2864,14 +2728,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __Four__ = default(int);
+            var ____result = new global::SharedData.MySubUnion4();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 7:
-                        __Four__ = reader.ReadInt32();
+                        ____result.Four = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2879,8 +2743,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion4();
-            ____result.Four = __Four__;
             reader.Depth--;
             return ____result;
         }
@@ -2910,14 +2772,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.NestParent.NestContract();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2925,8 +2787,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.NestParent.NestContract();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -2956,14 +2816,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.NonEmpty1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2971,8 +2831,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.NonEmpty1();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -3010,38 +2868,32 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Prop1__ = default(int);
-            var __Prop2__ = default(global::SharedData.ByteEnum);
-            var __Prop3__ = default(string);
-            var __Prop4__ = default(global::SharedData.SimpleStringKeyData);
-            var __Prop5__ = default(global::SharedData.SimpleStructIntKeyData);
-            var __Prop6__ = default(global::SharedData.SimpleStructStringKeyData);
-            var __BytesSpecial__ = default(byte[]);
+            var ____result = new global::SharedData.SimpleIntKeyData();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Prop1__ = reader.ReadInt32();
+                        ____result.Prop1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __Prop2__ = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
+                        ____result.Prop2 = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __Prop3__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Prop3 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     case 3:
-                        __Prop4__ = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStringKeyData>().Deserialize(ref reader, options);
+                        ____result.Prop4 = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStringKeyData>().Deserialize(ref reader, options);
                         break;
                     case 4:
-                        __Prop5__ = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructIntKeyData>().Deserialize(ref reader, options);
+                        ____result.Prop5 = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructIntKeyData>().Deserialize(ref reader, options);
                         break;
                     case 5:
-                        __Prop6__ = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructStringKeyData>().Deserialize(ref reader, options);
+                        ____result.Prop6 = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructStringKeyData>().Deserialize(ref reader, options);
                         break;
                     case 6:
-                        __BytesSpecial__ = reader.ReadBytes()?.ToArray();
+                        ____result.BytesSpecial = reader.ReadBytes()?.ToArray();
                         break;
                     default:
                         reader.Skip();
@@ -3049,14 +2901,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SimpleIntKeyData();
-            ____result.Prop1 = __Prop1__;
-            ____result.Prop2 = __Prop2__;
-            ____result.Prop3 = __Prop3__;
-            ____result.Prop4 = __Prop4__;
-            ____result.Prop5 = __Prop5__;
-            ____result.Prop6 = __Prop6__;
-            ____result.BytesSpecial = __BytesSpecial__;
             reader.Depth--;
             return ____result;
         }
@@ -3082,22 +2926,20 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __X__ = default(int);
-            var __Y__ = default(int);
-            var __BytesSpecial__ = default(byte[]);
+            var ____result = new global::SharedData.SimpleStructIntKeyData();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __X__ = reader.ReadInt32();
+                        ____result.X = reader.ReadInt32();
                         break;
                     case 1:
-                        __Y__ = reader.ReadInt32();
+                        ____result.Y = reader.ReadInt32();
                         break;
                     case 2:
-                        __BytesSpecial__ = reader.ReadBytes()?.ToArray();
+                        ____result.BytesSpecial = reader.ReadBytes()?.ToArray();
                         break;
                     default:
                         reader.Skip();
@@ -3105,10 +2947,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SimpleStructIntKeyData();
-            ____result.X = __X__;
-            ____result.Y = __Y__;
-            ____result.BytesSpecial = __BytesSpecial__;
             reader.Depth--;
             return ____result;
         }
@@ -3139,18 +2977,17 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.SubUnionType1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3158,9 +2995,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SubUnionType1();
-            ____result.MyProperty = __MyProperty__;
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -3191,18 +3025,17 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty2__ = default(int);
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.SubUnionType2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3210,9 +3043,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SubUnionType2();
-            ____result.MyProperty = __MyProperty__;
-            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3244,18 +3074,17 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
-            var __MyProperty2__ = default(int);
+            var ____result = new global::SharedData.UnVersionBlockTest();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 2:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3263,9 +3092,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.UnVersionBlockTest();
-            ____result.MyProperty = __MyProperty__;
-            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3359,9 +3185,26 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Vector3Like(__x__, __y__, __z__);
+            if (length <= 0)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.x = __x__;
+            if (length <= 1)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.y = __y__;
+            if (length <= 2)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.z = __z__;
+
+        MEMBER_ASSIGNMENT_END:
             reader.Depth--;
             return ____result;
         }
@@ -3406,8 +3249,20 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.VectorLike2(__x__, __y__);
+            if (length <= 0)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.x = __x__;
+            if (length <= 1)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.y = __y__;
+
+        MEMBER_ASSIGNMENT_END:
             reader.Depth--;
             return ____result;
         }
@@ -3440,14 +3295,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
+            var ____result = new global::SharedData.Version0();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3455,8 +3310,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Version0();
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -3491,22 +3344,20 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
+            var ____result = new global::SharedData.Version1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 4:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 5:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3514,10 +3365,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Version1();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
             reader.Depth--;
             return ____result;
         }
@@ -3554,26 +3401,23 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
-            var __MyProperty5__ = default(int);
+            var ____result = new global::SharedData.Version2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 4:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 5:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     case 7:
-                        __MyProperty5__ = reader.ReadInt32();
+                        ____result.MyProperty5 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3581,11 +3425,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Version2();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
-            ____result.MyProperty5 = __MyProperty5__;
             reader.Depth--;
             return ____result;
         }
@@ -3619,22 +3458,20 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
-            var __UnknownBlock__ = default(global::SharedData.MyClass);
-            var __MyProperty2__ = default(int);
+            var ____result = new global::SharedData.VersionBlockTest();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 1:
-                        __UnknownBlock__ = formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Deserialize(ref reader, options);
+                        ____result.UnknownBlock = formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3642,10 +3479,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.VersionBlockTest();
-            ____result.MyProperty = __MyProperty__;
-            ____result.UnknownBlock = __UnknownBlock__;
-            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3682,14 +3515,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __FV__ = default(int);
+            var ____result = new global::SharedData.VersioningUnion();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 7:
-                        __FV__ = reader.ReadInt32();
+                        ____result.FV = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3697,8 +3530,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.VersioningUnion();
-            ____result.FV = __FV__;
             reader.Depth--;
             return ____result;
         }
@@ -3731,18 +3562,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Data1__ = default(int);
-            var __Data2__ = default(string);
+            var ____result = new global::SharedData.WithIndexer();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Data1__ = reader.ReadInt32();
+                        ____result.Data1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __Data2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Data2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -3750,9 +3580,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.WithIndexer();
-            ____result.Data1 = __Data1__;
-            ____result.Data2 = __Data2__;
             reader.Depth--;
             return ____result;
         }

--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -181,10 +181,8 @@ namespace MessagePack.Formatters.TestData2
 
 namespace MessagePack.Formatters.TestData2
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class AFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.A>
     {
@@ -203,7 +201,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
             writer.WriteRaw(GetSpan_a());
             writer.Write(value.a);
@@ -221,15 +219,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __a__ = default(int);
-            var __bs__ = default(global::System.Collections.Generic.List<global::TestData2.B>);
-            var __c__ = default(global::TestData2.C);
+            var ____result = new global::TestData2.A();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -241,27 +237,20 @@ namespace MessagePack.Formatters.TestData2
                         {
                             default: goto FAIL;
                             case 97UL:
-                                __a__ = reader.ReadInt32();
+                                ____result.a = reader.ReadInt32();
                                 continue;
                             case 99UL:
-                                __c__ = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
+                                ____result.c = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
                                 continue;
                         }
                     case 2:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 29538UL) { goto FAIL; }
 
-                        __bs__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.B>>().Deserialize(ref reader, options);
+                        ____result.bs = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.B>>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::TestData2.A()
-            {
-                a = __a__,
-                bs = __bs__,
-                c = __c__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -285,7 +274,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
             writer.WriteRaw(GetSpan_ass());
             formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>().Serialize(ref writer, value.ass, options);
@@ -303,15 +292,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __ass__ = default(global::System.Collections.Generic.List<global::TestData2.A>);
-            var __c__ = default(global::TestData2.C);
-            var __a__ = default(int);
+            var ____result = new global::TestData2.B();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -321,29 +308,22 @@ namespace MessagePack.Formatters.TestData2
                     case 3:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 7566177UL) { goto FAIL; }
 
-                        __ass__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>().Deserialize(ref reader, options);
+                        ____result.ass = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>().Deserialize(ref reader, options);
                         continue;
                     case 1:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
                         {
                             default: goto FAIL;
                             case 99UL:
-                                __c__ = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
+                                ____result.c = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
                                 continue;
                             case 97UL:
-                                __a__ = reader.ReadInt32();
+                                ____result.a = reader.ReadInt32();
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::TestData2.B()
-            {
-                ass = __ass__,
-                c = __c__,
-                a = __a__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -365,7 +345,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_b());
             formatterResolver.GetFormatterWithVerify<global::TestData2.B>().Serialize(ref writer, value.b, options);
@@ -381,14 +361,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __b__ = default(global::TestData2.B);
-            var __a__ = default(int);
+            var ____result = new global::TestData2.C();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -400,21 +379,15 @@ namespace MessagePack.Formatters.TestData2
                         {
                             default: goto FAIL;
                             case 98UL:
-                                __b__ = formatterResolver.GetFormatterWithVerify<global::TestData2.B>().Deserialize(ref reader, options);
+                                ____result.b = formatterResolver.GetFormatterWithVerify<global::TestData2.B>().Deserialize(ref reader, options);
                                 continue;
                             case 97UL:
-                                __a__ = reader.ReadInt32();
+                                ____result.a = reader.ReadInt32();
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::TestData2.C()
-            {
-                b = __b__,
-                a = __a__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -436,7 +409,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_EnumId());
             formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.Id>().Serialize(ref writer, value.EnumId, options);
@@ -452,14 +425,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __EnumId__ = default(global::TestData2.Nest1.Id);
-            var __ClassId__ = default(global::TestData2.Nest1.IdType);
+            var ____result = new global::TestData2.Nest1();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -469,22 +441,16 @@ namespace MessagePack.Formatters.TestData2
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 110266531802693UL) { goto FAIL; }
 
-                        __EnumId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.Id>().Deserialize(ref reader, options);
+                        ____result.EnumId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.Id>().Deserialize(ref reader, options);
                         continue;
                     case 7:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 28228257876896835UL) { goto FAIL; }
 
-                        __ClassId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.IdType>().Deserialize(ref reader, options);
+                        ____result.ClassId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.IdType>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::TestData2.Nest1()
-            {
-                EnumId = __EnumId__,
-                ClassId = __ClassId__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -493,7 +459,6 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class Nest1_IdTypeFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.Nest1.IdType>
     {
-
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.Nest1.IdType value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -533,7 +498,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_EnumId());
             formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.Id>().Serialize(ref writer, value.EnumId, options);
@@ -549,14 +514,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __EnumId__ = default(global::TestData2.Nest2.Id);
-            var __ClassId__ = default(global::TestData2.Nest2.IdType);
+            var ____result = new global::TestData2.Nest2();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -566,22 +530,16 @@ namespace MessagePack.Formatters.TestData2
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 110266531802693UL) { goto FAIL; }
 
-                        __EnumId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.Id>().Deserialize(ref reader, options);
+                        ____result.EnumId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.Id>().Deserialize(ref reader, options);
                         continue;
                     case 7:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 28228257876896835UL) { goto FAIL; }
 
-                        __ClassId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.IdType>().Deserialize(ref reader, options);
+                        ____result.ClassId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.IdType>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::TestData2.Nest2()
-            {
-                EnumId = __EnumId__,
-                ClassId = __ClassId__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -590,7 +548,6 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class Nest2_IdTypeFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.Nest2.IdType>
     {
-
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.Nest2.IdType value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -630,7 +587,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_MyProperty1());
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.MyProperty1, options);
@@ -646,14 +603,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __MyProperty1__ = default(string);
-            var __MyProperty2__ = default(string);
+            var ____result = new global::TestData2.PropNameCheck1();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -669,10 +625,10 @@ namespace MessagePack.Formatters.TestData2
                                 {
                                     default: goto FAIL;
                                     case 3242356UL:
-                                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                     case 3307892UL:
-                                        __MyProperty2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                 }
 
@@ -680,12 +636,6 @@ namespace MessagePack.Formatters.TestData2
 
                 }
             }
-
-            var ____result = new global::TestData2.PropNameCheck1()
-            {
-                MyProperty1 = __MyProperty1__,
-                MyProperty2 = __MyProperty2__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -707,7 +657,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_MyProperty1());
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.MyProperty1, options);
@@ -723,14 +673,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __MyProperty1__ = default(string);
-            var __MyProperty2__ = default(string);
+            var ____result = new global::TestData2.PropNameCheck2();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -746,10 +695,10 @@ namespace MessagePack.Formatters.TestData2
                                 {
                                     default: goto FAIL;
                                     case 3242356UL:
-                                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                     case 3307892UL:
-                                        __MyProperty2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                 }
 
@@ -757,12 +706,6 @@ namespace MessagePack.Formatters.TestData2
 
                 }
             }
-
-            var ____result = new global::TestData2.PropNameCheck2()
-            {
-                MyProperty1 = __MyProperty1__,
-                MyProperty2 = __MyProperty2__,
-            };
 
             reader.Depth--;
             return ____result;

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -85,6 +85,7 @@ namespace ");
             this.Write("            global::MessagePack.IFormatterResolver formatterResolver = options.Re" +
                     "solver;\r\n");
  }
+
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
   if (objInfo.NeedsCastOnBefore) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value" +
@@ -119,7 +120,8 @@ namespace ");
  } 
             this.Write("            }\r\n\r\n            options.Security.DepthStep(ref reader);\r\n");
  if (isFormatterResolverNecessary) { 
-            this.Write("            var formatterResolver = options.Resolver;\r\n");
+            this.Write("            global::MessagePack.IFormatterResolver formatterResolver = options.Re" +
+                    "solver;\r\n");
  } 
             this.Write("            var length = reader.ReadArrayHeader();\r\n");
  foreach (var member in objInfo.Members) { 

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -118,18 +118,30 @@ namespace ");
             this.Write("                throw new global::System.InvalidOperationException(\"typecode is n" +
                     "ull, struct not supported\");\r\n");
  } 
-            this.Write("            }\r\n\r\n            options.Security.DepthStep(ref reader);\r\n");
+            this.Write("            }\r\n\r\n");
+ if (objInfo.MaxKey == -1 && !objInfo.HasIMessagePackSerializationCallbackReceiver) { 
+            this.Write("            reader.Skip();\r\n            return new ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
+            this.Write(";\r\n");
+ } else { 
+            this.Write("            options.Security.DepthStep(ref reader);\r\n");
  if (isFormatterResolverNecessary) { 
             this.Write("            global::MessagePack.IFormatterResolver formatterResolver = options.Re" +
                     "solver;\r\n");
  } 
             this.Write("            var length = reader.ReadArrayHeader();\r\n");
- foreach (var member in objInfo.Members) { 
+ var canOverwrite = objInfo.ConstructorParameters.Length == 0;
+ if (canOverwrite) { 
+            this.Write("            var ____result = new ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
+            this.Write(";\r\n");
+ } else { foreach (var member in objInfo.Members) { 
             this.Write("            var __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = default(");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Type));
             this.Write(");\r\n");
+ } 
  } 
             this.Write("\r\n            for (int i = 0; i < length; i++)\r\n            {\r\n                sw" +
                     "itch (i)\r\n                {\r\n");
@@ -138,25 +150,49 @@ namespace ");
   if (member == null) { continue; } 
             this.Write("                    case ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IntKey));
-            this.Write(":\r\n                        __");
+            this.Write(":\r\n");
+ if (canOverwrite) {
+  if (member.IsWritable) { 
+            this.Write("                        ____result.");
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
+            this.Write(" = ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.GetDeserializeMethodString()));
+            this.Write(";\r\n");
+ } else { 
+            this.Write("                        ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.GetDeserializeMethodString()));
+            this.Write(";\r\n");
+ } 
+ } else {
+            this.Write("                        __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetDeserializeMethodString()));
-            this.Write(";\r\n                        break;\r\n");
+            this.Write(";\r\n");
+ } 
+            this.Write("                        break;\r\n");
  } 
             this.Write("                    default:\r\n                        reader.Skip();\r\n           " +
-                    "             break;\r\n                }\r\n            }\r\n\r\n            var ____res" +
-                    "ult = new ");
+                    "             break;\r\n                }\r\n            }\r\n\r\n");
+ if (!canOverwrite) { 
+            this.Write("            var ____result = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             this.Write(";\r\n");
  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
   if (member == null || !member.IsWritable) { continue; } 
-            this.Write("            ____result.");
+            this.Write("            if (length <= ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(memberIndex));
+            this.Write(")\r\n            {\r\n                goto MEMBER_ASSIGNMENT_END;\r\n            }\r\n\r\n " +
+                    "           ____result.");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write(" = __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__;\r\n");
+ if (memberIndex == objInfo.MaxKey) { 
+            this.Write("\r\n        MEMBER_ASSIGNMENT_END:\r\n");
+ }
+  }
  }
 
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
@@ -167,7 +203,9 @@ namespace ");
             this.Write("            ____result.OnAfterDeserialize();\r\n");
  } 
  } 
-            this.Write("            reader.Depth--;\r\n            return ____result;\r\n        }\r\n    }\r\n");
+            this.Write("            reader.Depth--;\r\n            return ____result;\r\n");
+ } 
+            this.Write("        }\r\n    }\r\n");
  } 
             this.Write(@"}
 

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -44,10 +44,8 @@ namespace MessagePackCompiler.Generator
 namespace ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
             this.Write("\r\n{\r\n    using global::System.Buffers;\r\n    using global::MessagePack;\r\n");
-
 foreach (var objInfo in ObjectSerializationInfos) {
  bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
-
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.Name));
             this.Write("Formatter");

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -45,9 +45,8 @@ namespace ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
             this.Write("\r\n{\r\n    using global::System.Buffers;\r\n    using global::MessagePack;\r\n");
 
-foreach (var objInfo in ObjectSerializationInfos)
-{
-    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
+foreach (var objInfo in ObjectSerializationInfos) {
+ bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
 
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.Name));
@@ -56,24 +55,16 @@ foreach (var objInfo in ObjectSerializationInfos)
             this.Write(" : global::MessagePack.Formatters.IMessagePackFormatter<");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(">\r\n");
-
-    foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints))
-    {
-
+ foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) {
             this.Write("        where ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Name));
             this.Write(" : ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Constraints));
             this.Write("\r\n");
-
-    }
-
+ }
             this.Write("    {\r\n");
-
-    foreach (var item in objInfo.Members)
-    {
-        if (item.CustomFormatterTypeName != null)
-        {
+ foreach (var item in objInfo.Members) {
+  if (item.CustomFormatterTypeName != null) {
 
             this.Write("        private readonly ");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.CustomFormatterTypeName));
@@ -82,119 +73,70 @@ foreach (var objInfo in ObjectSerializationInfos)
             this.Write("CustomFormatter__ = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.CustomFormatterTypeName));
             this.Write("();\r\n");
-
-        }
-    }
-
+  }
+ }
             this.Write("\r\n        public void Serialize(ref global::MessagePack.MessagePackWriter writer," +
                     " ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" value, global::MessagePack.MessagePackSerializerOptions options)\r\n        {\r\n");
-
-    if (objInfo.IsClass)
-    {
-
+ if (objInfo.IsClass) {
             this.Write("            if (value == null)\r\n            {\r\n                writer.WriteNil();" +
                     "\r\n                return;\r\n            }\r\n\r\n");
-
-    }
-
-    if (isFormatterResolverNecessary)
-    {
+ }
+ if (isFormatterResolverNecessary) {
 
             this.Write("            var formatterResolver = options.Resolver;\r\n");
-
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnBefore)
-        {
-
+ }
+ if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+  if (objInfo.NeedsCastOnBefore) {
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value" +
                     ").OnBeforeSerialize();\r\n");
-
-        }
-        else
-        {
-
+  } else {
             this.Write("            value.OnBeforeSerialize();\r\n");
-
-        }
-    }
-
+  }
+ }
             this.Write("            writer.WriteArrayHeader(");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.MaxKey + 1));
             this.Write(");\r\n");
-
-    for (var i = 0; i <= objInfo.MaxKey; i++)
-    {
-        var member = objInfo.GetMember(i);
-        if (member == null)
-        {
-
+ for (var i = 0; i <= objInfo.MaxKey; i++) {
+  var member = objInfo.GetMember(i);
+  if (member == null) {
             this.Write("            writer.WriteNil();\r\n");
-
-        }
-        else
-        {
-
+  } else {
             this.Write("            ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetSerializeMethodString()));
             this.Write(";\r\n");
-
-        }
-    }
-
+  }
+ }
             this.Write("        }\r\n\r\n        public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePac" +
                     "k.MessagePackSerializerOptions options)\r\n        {\r\n            if (reader.TryRe" +
                     "adNil())\r\n            {\r\n");
-
-    if (objInfo.IsClass)
-    {
-
+ if (objInfo.IsClass) {
             this.Write("                return null;\r\n");
-
-    }
-    else
-    {
-
+ } else {
             this.Write("                throw new global::System.InvalidOperationException(\"typecode is n" +
                     "ull, struct not supported\");\r\n");
-
-    }
-
+ }
             this.Write("            }\r\n\r\n");
-
-    if (isFormatterResolverNecessary)
-    {
-
+ if (isFormatterResolverNecessary) {
             this.Write("            var formatterResolver = options.Resolver;\r\n");
-
-    }
-
+ }
             this.Write("            options.Security.DepthStep(ref reader);\r\n            var length = rea" +
                     "der.ReadArrayHeader();\r\n");
-
-    foreach (var member in objInfo.Members)
-    {
-
+ foreach (var member in objInfo.Members) {
             this.Write("            var __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = default(");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Type));
             this.Write(");\r\n");
-
-    }
-
-            this.Write("\r\n            for (int i = 0; i < length; i++)\r\n            {\r\n                sw" +
+ }
+            this.Write("\r\n            for (var i = 0; i < length; i++)\r\n            {\r\n                sw" +
                     "itch (i)\r\n                {\r\n");
-
-    foreach (var member in objInfo.Members)
-    {
-
+ for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+  var member = objInfo.GetMember(memberIndex);
+  if (member == null) { continue; }
             this.Write("                    case ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IntKey));
             this.Write(":\r\n                        __");
@@ -202,53 +144,31 @@ foreach (var objInfo in ObjectSerializationInfos)
             this.Write("__ = ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetDeserializeMethodString()));
             this.Write(";\r\n                        break;\r\n");
-
-    }
-
+ }
             this.Write("                    default:\r\n                        reader.Skip();\r\n           " +
                     "             break;\r\n                }\r\n            }\r\n\r\n            var ____res" +
                     "ult = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             this.Write(";\r\n");
-
-    for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++)
-    {
-        var member = objInfo.GetMember(memberIndex);
-        if (member == null || !member.IsWritable)
-        {
-            continue;
-        }
-
-
+ for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+  var member = objInfo.GetMember(memberIndex);
+  if (member == null || !member.IsWritable) { continue; }
             this.Write("            ____result.");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write(" = __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__;\r\n");
-
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnAfter)
-        {
-
+ }
+ if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+  if (objInfo.NeedsCastOnAfter) {
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____r" +
                     "esult).OnAfterDeserialize();\r\n");
-
-        }
-        else
-        {
-
+  } else {
             this.Write("            ____result.OnAfterDeserialize();\r\n");
-
-        }
-    }
-
+  }
+ }
             this.Write("            reader.Depth--;\r\n            return ____result;\r\n        }\r\n    }\r\n");
-
 }
-
             this.Write(@"}
 
 #pragma warning restore 168

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -44,26 +44,25 @@ namespace MessagePackCompiler.Generator
 namespace ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
             this.Write("\r\n{\r\n    using global::System.Buffers;\r\n    using global::MessagePack;\r\n");
-foreach (var objInfo in ObjectSerializationInfos) {
- bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
+ foreach (var objInfo in ObjectSerializationInfos) {
+    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.Name));
             this.Write("Formatter");
-            this.Write(this.ToStringHelper.ToStringWithCulture((objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "")));
+            this.Write(this.ToStringHelper.ToStringWithCulture((objInfo.IsOpenGenericType ? $"<{string.Join(", ", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "")));
             this.Write(" : global::MessagePack.Formatters.IMessagePackFormatter<");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(">\r\n");
- foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) {
+ foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) { 
             this.Write("        where ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Name));
             this.Write(" : ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Constraints));
             this.Write("\r\n");
- }
+ } 
             this.Write("    {\r\n");
- foreach (var item in objInfo.Members) {
-  if (item.CustomFormatterTypeName != null) {
-
+ foreach (var item in objInfo.Members) { 
+ if (item.CustomFormatterTypeName != null) { 
             this.Write("        private readonly ");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.CustomFormatterTypeName));
             this.Write(" __");
@@ -71,8 +70,8 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write("CustomFormatter__ = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.CustomFormatterTypeName));
             this.Write("();\r\n");
-  }
- }
+ } 
+ } 
             this.Write("\r\n        public void Serialize(ref global::MessagePack.MessagePackWriter writer," +
                     " ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
@@ -81,18 +80,20 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write("            if (value == null)\r\n            {\r\n                writer.WriteNil();" +
                     "\r\n                return;\r\n            }\r\n\r\n");
  }
- if (isFormatterResolverNecessary) {
 
-            this.Write("            var formatterResolver = options.Resolver;\r\n");
+  if (isFormatterResolverNecessary) {
+
+            this.Write("            global::MessagePack.IFormatterResolver formatterResolver = options.Re" +
+                    "solver;\r\n");
  }
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
-  if (objInfo.NeedsCastOnBefore) {
+  if (objInfo.NeedsCastOnBefore) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value" +
                     ").OnBeforeSerialize();\r\n");
-  } else {
+  } else { 
             this.Write("            value.OnBeforeSerialize();\r\n");
-  }
- }
+ } 
+ } 
             this.Write("            writer.WriteArrayHeader(");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.MaxKey + 1));
             this.Write(");\r\n");
@@ -100,12 +101,12 @@ foreach (var objInfo in ObjectSerializationInfos) {
   var member = objInfo.GetMember(i);
   if (member == null) {
             this.Write("            writer.WriteNil();\r\n");
-  } else {
+  } else { 
             this.Write("            ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetSerializeMethodString()));
             this.Write(";\r\n");
-  }
- }
+ } 
+ } 
             this.Write("        }\r\n\r\n        public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePac" +
@@ -117,20 +118,19 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write("                throw new global::System.InvalidOperationException(\"typecode is n" +
                     "ull, struct not supported\");\r\n");
  }
-            this.Write("            }\r\n\r\n");
- if (isFormatterResolverNecessary) {
+            this.Write("            }\r\n\r\n            options.Security.DepthStep(ref reader);\r\n");
+ if (isFormatterResolverNecessary) { 
             this.Write("            var formatterResolver = options.Resolver;\r\n");
- }
-            this.Write("            options.Security.DepthStep(ref reader);\r\n            var length = rea" +
-                    "der.ReadArrayHeader();\r\n");
- foreach (var member in objInfo.Members) {
+ } 
+            this.Write("            var length = reader.ReadArrayHeader();\r\n");
+ foreach (var member in objInfo.Members) { 
             this.Write("            var __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = default(");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Type));
             this.Write(");\r\n");
- }
-            this.Write("\r\n            for (var i = 0; i < length; i++)\r\n            {\r\n                sw" +
+ } 
+            this.Write("\r\n            for (int i = 0; i < length; i++)\r\n            {\r\n                sw" +
                     "itch (i)\r\n                {\r\n");
  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
@@ -142,7 +142,7 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write("__ = ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetDeserializeMethodString()));
             this.Write(";\r\n                        break;\r\n");
- }
+ } 
             this.Write("                    default:\r\n                        reader.Skip();\r\n           " +
                     "             break;\r\n                }\r\n            }\r\n\r\n            var ____res" +
                     "ult = new ");
@@ -150,23 +150,24 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write(";\r\n");
  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null || !member.IsWritable) { continue; }
+  if (member == null || !member.IsWritable) { continue; } 
             this.Write("            ____result.");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write(" = __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__;\r\n");
  }
+
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
-  if (objInfo.NeedsCastOnAfter) {
+  if (objInfo.NeedsCastOnAfter) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____r" +
                     "esult).OnAfterDeserialize();\r\n");
-  } else {
+  } else { 
             this.Write("            ____result.OnAfterDeserialize();\r\n");
-  }
- }
+ } 
+ } 
             this.Write("            reader.Depth--;\r\n            return ____result;\r\n        }\r\n    }\r\n");
-}
+ } 
             this.Write(@"}
 
 #pragma warning restore 168

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -76,7 +76,7 @@ namespace ");
                     " ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" value, global::MessagePack.MessagePackSerializerOptions options)\r\n        {\r\n");
- if (objInfo.IsClass) {
+ if (objInfo.IsClass) { 
             this.Write("            if (value == null)\r\n            {\r\n                writer.WriteNil();" +
                     "\r\n                return;\r\n            }\r\n\r\n");
  }
@@ -90,7 +90,7 @@ namespace ");
   if (objInfo.NeedsCastOnBefore) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value" +
                     ").OnBeforeSerialize();\r\n");
-  } else { 
+ } else { 
             this.Write("            value.OnBeforeSerialize();\r\n");
  } 
  } 
@@ -99,9 +99,9 @@ namespace ");
             this.Write(");\r\n");
  for (var i = 0; i <= objInfo.MaxKey; i++) {
   var member = objInfo.GetMember(i);
-  if (member == null) {
+  if (member == null) { 
             this.Write("            writer.WriteNil();\r\n");
-  } else { 
+ } else { 
             this.Write("            ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetSerializeMethodString()));
             this.Write(";\r\n");
@@ -112,12 +112,12 @@ namespace ");
             this.Write(" Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePac" +
                     "k.MessagePackSerializerOptions options)\r\n        {\r\n            if (reader.TryRe" +
                     "adNil())\r\n            {\r\n");
- if (objInfo.IsClass) {
+ if (objInfo.IsClass) { 
             this.Write("                return null;\r\n");
- } else {
+ } else { 
             this.Write("                throw new global::System.InvalidOperationException(\"typecode is n" +
                     "ull, struct not supported\");\r\n");
- }
+ } 
             this.Write("            }\r\n\r\n            options.Security.DepthStep(ref reader);\r\n");
  if (isFormatterResolverNecessary) { 
             this.Write("            var formatterResolver = options.Resolver;\r\n");
@@ -134,7 +134,7 @@ namespace ");
                     "itch (i)\r\n                {\r\n");
  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null) { continue; }
+  if (member == null) { continue; } 
             this.Write("                    case ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.IntKey));
             this.Write(":\r\n                        __");
@@ -162,7 +162,7 @@ namespace ");
   if (objInfo.NeedsCastOnAfter) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____r" +
                     "esult).OnAfterDeserialize();\r\n");
-  } else { 
+ } else { 
             this.Write("            ____result.OnAfterDeserialize();\r\n");
  } 
  } 

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -43,9 +43,12 @@ namespace MessagePackCompiler.Generator
 
 namespace ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
-            this.Write("\r\n{\r\n    using System;\r\n    using System.Buffers;\r\n    using MessagePack;\r\n");
- foreach(var objInfo in ObjectSerializationInfos) {
+            this.Write("\r\n{\r\n    using global::System.Buffers;\r\n    using global::MessagePack;\r\n");
+
+foreach (var objInfo in ObjectSerializationInfos)
+{
     bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
+
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.Name));
             this.Write("Formatter");
@@ -53,108 +56,199 @@ namespace ");
             this.Write(" : global::MessagePack.Formatters.IMessagePackFormatter<");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(">\r\n");
- foreach(var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) { 
+
+    foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints))
+    {
+
             this.Write("        where ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Name));
             this.Write(" : ");
             this.Write(this.ToStringHelper.ToStringWithCulture(typeArg.Constraints));
             this.Write("\r\n");
- } 
+
+    }
+
             this.Write("    {\r\n");
- foreach(var item in objInfo.Members) { 
- if(item.CustomFormatterTypeName != null) { 
-            this.Write("        ");
+
+    foreach (var item in objInfo.Members)
+    {
+        if (item.CustomFormatterTypeName != null)
+        {
+
+            this.Write("        private readonly ");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.CustomFormatterTypeName));
             this.Write(" __");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.Name));
             this.Write("CustomFormatter__ = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(item.CustomFormatterTypeName));
             this.Write("();\r\n");
- } 
- } 
-            this.Write("\r\n        public void Serialize(ref MessagePackWriter writer, ");
+
+        }
+    }
+
+            this.Write("\r\n        public void Serialize(ref global::MessagePack.MessagePackWriter writer," +
+                    " ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" value, global::MessagePack.MessagePackSerializerOptions options)\r\n        {\r\n");
- if( objInfo.IsClass) { 
+
+    if (objInfo.IsClass)
+    {
+
             this.Write("            if (value == null)\r\n            {\r\n                writer.WriteNil();" +
                     "\r\n                return;\r\n            }\r\n\r\n");
- }
 
-  if (isFormatterResolverNecessary) { 
-            this.Write("            IFormatterResolver formatterResolver = options.Resolver;\r\n");
-}
+    }
 
-  if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBefore) { 
-            this.Write("            ((IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize(" +
-                    ");\r\n");
- } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { 
+    if (isFormatterResolverNecessary)
+    {
+
+            this.Write("            var formatterResolver = options.Resolver;\r\n");
+
+    }
+
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
+    {
+        if (objInfo.NeedsCastOnBefore)
+        {
+
+            this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value" +
+                    ").OnBeforeSerialize();\r\n");
+
+        }
+        else
+        {
+
             this.Write("            value.OnBeforeSerialize();\r\n");
- } 
+
+        }
+    }
+
             this.Write("            writer.WriteArrayHeader(");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.MaxKey + 1));
             this.Write(");\r\n");
- for(var i =0; i<= objInfo.MaxKey; i++) { var member = objInfo.GetMember(i); 
- if( member == null) { 
+
+    for (var i = 0; i <= objInfo.MaxKey; i++)
+    {
+        var member = objInfo.GetMember(i);
+        if (member == null)
+        {
+
             this.Write("            writer.WriteNil();\r\n");
- } else { 
+
+        }
+        else
+        {
+
             this.Write("            ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetSerializeMethodString()));
             this.Write(";\r\n");
- } } 
+
+        }
+    }
+
             this.Write("        }\r\n\r\n        public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
-            this.Write(" Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSeriali" +
-                    "zerOptions options)\r\n        {\r\n            if (reader.TryReadNil())\r\n          " +
-                    "  {\r\n");
- if( objInfo.IsClass) { 
+            this.Write(" Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePac" +
+                    "k.MessagePackSerializerOptions options)\r\n        {\r\n            if (reader.TryRe" +
+                    "adNil())\r\n            {\r\n");
+
+    if (objInfo.IsClass)
+    {
+
             this.Write("                return null;\r\n");
- } else { 
-            this.Write("                throw new InvalidOperationException(\"typecode is null, struct not" +
-                    " supported\");\r\n");
- } 
-            this.Write("            }\r\n\r\n            options.Security.DepthStep(ref reader);\r\n");
- if (isFormatterResolverNecessary) { 
-            this.Write("            IFormatterResolver formatterResolver = options.Resolver;\r\n");
- } 
-            this.Write("            var length = reader.ReadArrayHeader();\r\n");
- foreach(var x in objInfo.Members) { 
+
+    }
+    else
+    {
+
+            this.Write("                throw new global::System.InvalidOperationException(\"typecode is n" +
+                    "ull, struct not supported\");\r\n");
+
+    }
+
+            this.Write("            }\r\n\r\n");
+
+    if (isFormatterResolverNecessary)
+    {
+
+            this.Write("            var formatterResolver = options.Resolver;\r\n");
+
+    }
+
+            this.Write("            options.Security.DepthStep(ref reader);\r\n            var length = rea" +
+                    "der.ReadArrayHeader();\r\n");
+
+    foreach (var member in objInfo.Members)
+    {
+
             this.Write("            var __");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = default(");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.Type));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Type));
             this.Write(");\r\n");
- } 
+
+    }
+
             this.Write("\r\n            for (int i = 0; i < length; i++)\r\n            {\r\n                sw" +
                     "itch (i)\r\n                {\r\n");
- foreach(var x in objInfo.Members) { 
+
+    foreach (var member in objInfo.Members)
+    {
+
             this.Write("                    case ");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.IntKey));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.IntKey));
             this.Write(":\r\n                        __");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = ");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.GetDeserializeMethodString()));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.GetDeserializeMethodString()));
             this.Write(";\r\n                        break;\r\n");
- } 
+
+    }
+
             this.Write("                    default:\r\n                        reader.Skip();\r\n           " +
                     "             break;\r\n                }\r\n            }\r\n\r\n            var ____res" +
                     "ult = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             this.Write(";\r\n");
- foreach(var x in objInfo.Members.Where(x => x.IsWritable)) { 
+
+    for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++)
+    {
+        var member = objInfo.GetMember(memberIndex);
+        if (member == null || !member.IsWritable)
+        {
+            continue;
+        }
+
+
             this.Write("            ____result.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write(" = __");
-            this.Write(this.ToStringHelper.ToStringWithCulture(x.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__;\r\n");
- } 
-if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnAfter) { 
-            this.Write("            ((IMessagePackSerializationCallbackReceiver)____result).OnAfterDeseri" +
-                    "alize();\r\n");
- } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { 
+
+    }
+
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
+    {
+        if (objInfo.NeedsCastOnAfter)
+        {
+
+            this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____r" +
+                    "esult).OnAfterDeserialize();\r\n");
+
+        }
+        else
+        {
+
             this.Write("            ____result.OnAfterDeserialize();\r\n");
- } 
+
+        }
+    }
+
             this.Write("            reader.Depth--;\r\n            return ____result;\r\n        }\r\n    }\r\n");
- } 
+
+}
+
             this.Write(@"}
 
 #pragma warning restore 168

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -81,8 +81,7 @@ namespace ");
                     "\r\n                return;\r\n            }\r\n\r\n");
  }
 
-  if (isFormatterResolverNecessary) {
-
+  if (isFormatterResolverNecessary) { 
             this.Write("            global::MessagePack.IFormatterResolver formatterResolver = options.Re" +
                     "solver;\r\n");
  }

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.cs
@@ -178,9 +178,11 @@ namespace ");
             this.Write("            var ____result = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             this.Write(";\r\n");
- for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+ bool memberAssignExists = false;
+  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null || !member.IsWritable) { continue; } 
+  if (member == null || !member.IsWritable || objInfo.ConstructorParameters.Any(p => p.Equals(member))) { continue; }
+  memberAssignExists = true;
             this.Write("            if (length <= ");
             this.Write(this.ToStringHelper.ToStringWithCulture(memberIndex));
             this.Write(")\r\n            {\r\n                goto MEMBER_ASSIGNMENT_END;\r\n            }\r\n\r\n " +
@@ -189,10 +191,10 @@ namespace ");
             this.Write(" = __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__;\r\n");
- if (memberIndex == objInfo.MaxKey) { 
+ } 
+ if (memberAssignExists) { 
             this.Write("\r\n        MEMBER_ASSIGNMENT_END:\r\n");
  }
-  }
  }
 
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -24,145 +24,85 @@ namespace <#= Namespace #>
     using global::System.Buffers;
     using global::MessagePack;
 <#
-foreach (var objInfo in ObjectSerializationInfos)
-{
-    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
+foreach (var objInfo in ObjectSerializationInfos) {
+ bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
 #>
 
     public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
-<#
-    foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints))
-    {
-#>
+<# foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) {#>
         where <#= typeArg.Name #> : <#= typeArg.Constraints #>
-<#
-    }
-#>
+<# }#>
     {
-<#
-    foreach (var item in objInfo.Members)
-    {
-        if (item.CustomFormatterTypeName != null)
-        {
+<# foreach (var item in objInfo.Members) {
+  if (item.CustomFormatterTypeName != null) {
 #>
         private readonly <#= item.CustomFormatterTypeName #> __<#= item.Name #>CustomFormatter__ = new <#= item.CustomFormatterTypeName #>();
-<#
-        }
-    }
-#>
+<#  }
+ }#>
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-<#
-    if (objInfo.IsClass)
-    {
-#>
+<# if (objInfo.IsClass) {#>
             if (value == null)
             {
                 writer.WriteNil();
                 return;
             }
 
-<#
-    }
-
-    if (isFormatterResolverNecessary)
-    {
+<# }
+ if (isFormatterResolverNecessary) {
 #>
             var formatterResolver = options.Resolver;
-<#
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnBefore)
-        {
-#>
+<# }
+ if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+  if (objInfo.NeedsCastOnBefore) {#>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-<#
-        }
-        else
-        {
-#>
+<#  } else {#>
             value.OnBeforeSerialize();
-<#
-        }
-    }
-#>
+<#  }
+ }#>
             writer.WriteArrayHeader(<#= objInfo.MaxKey + 1 #>);
-<#
-    for (var i = 0; i <= objInfo.MaxKey; i++)
-    {
-        var member = objInfo.GetMember(i);
-        if (member == null)
-        {
-#>
+<# for (var i = 0; i <= objInfo.MaxKey; i++) {
+  var member = objInfo.GetMember(i);
+  if (member == null) {#>
             writer.WriteNil();
-<#
-        }
-        else
-        {
-#>
+<#  } else {#>
             <#= member.GetSerializeMethodString() #>;
-<#
-        }
-    }
-#>
+<#  }
+ }#>
         }
 
         public <#= objInfo.FullName #> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-<#
-    if (objInfo.IsClass)
-    {
-#>
+<# if (objInfo.IsClass) {#>
                 return null;
-<#
-    }
-    else
-    {
-#>
+<# } else {#>
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
-<#
-    }
-#>
+<# }#>
             }
 
-<#
-    if (isFormatterResolverNecessary)
-    {
-#>
+<# if (isFormatterResolverNecessary) {#>
             var formatterResolver = options.Resolver;
-<#
-    }
-#>
+<# }#>
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-<#
-    foreach (var member in objInfo.Members)
-    {
-#>
+<# foreach (var member in objInfo.Members) {#>
             var __<#= member.Name #>__ = default(<#= member.Type #>);
-<#
-    }
-#>
+<# }#>
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 switch (i)
                 {
-<#
-    foreach (var member in objInfo.Members)
-    {
-#>
+<# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+  var member = objInfo.GetMember(memberIndex);
+  if (member == null) { continue; }#>
                     case <#= member.IntKey #>:
                         __<#= member.Name #>__ = <#= member.GetDeserializeMethodString() #>;
                         break;
-<#
-    }
-#>
+<# }#>
                     default:
                         reader.Skip();
                         break;
@@ -170,43 +110,23 @@ foreach (var objInfo in ObjectSerializationInfos)
             }
 
             var ____result = new <#= objInfo.GetConstructorString()  #>;
-<#
-    for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++)
-    {
-        var member = objInfo.GetMember(memberIndex);
-        if (member == null || !member.IsWritable)
-        {
-            continue;
-        }
-
-#>
+<# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+  var member = objInfo.GetMember(memberIndex);
+  if (member == null || !member.IsWritable) { continue; }#>
             ____result.<#= member.Name #> = __<#= member.Name #>__;
-<#
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnAfter)
-        {
-#>
+<# }
+ if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+  if (objInfo.NeedsCastOnAfter) {#>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
-<#
-        }
-        else
-        {
-#>
+<#  } else {#>
             ____result.OnAfterDeserialize();
-<#
-        }
-    }
-#>
+<#  }
+ }#>
             reader.Depth--;
             return ____result;
         }
     }
-<#
-}
-#>
+<#}#>
 }
 
 #pragma warning restore 168

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -51,6 +51,7 @@ namespace <#= Namespace #>
   if (isFormatterResolverNecessary) { #>
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
 <# }
+
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
   if (objInfo.NeedsCastOnBefore) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
@@ -82,7 +83,7 @@ namespace <#= Namespace #>
 
             options.Security.DepthStep(ref reader);
 <# if (isFormatterResolverNecessary) { #>
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
 <# } #>
             var length = reader.ReadArrayHeader();
 <# foreach (var member in objInfo.Members) { #>

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -23,20 +23,19 @@ namespace <#= Namespace #>
 {
     using global::System.Buffers;
     using global::MessagePack;
-<#foreach (var objInfo in ObjectSerializationInfos) {
- bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);#>
+<# foreach (var objInfo in ObjectSerializationInfos) {
+    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);#>
 
-    public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
-<# foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) {#>
+    public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(", ", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
+<# foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) { #>
         where <#= typeArg.Name #> : <#= typeArg.Constraints #>
-<# }#>
+<# } #>
     {
-<# foreach (var item in objInfo.Members) {
-  if (item.CustomFormatterTypeName != null) {
-#>
+<# foreach (var item in objInfo.Members) { #>
+<# if (item.CustomFormatterTypeName != null) { #>
         private readonly <#= item.CustomFormatterTypeName #> __<#= item.Name #>CustomFormatter__ = new <#= item.CustomFormatterTypeName #>();
-<#  }
- }#>
+<# } #>
+<# } #>
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
         {
@@ -48,26 +47,27 @@ namespace <#= Namespace #>
             }
 
 <# }
- if (isFormatterResolverNecessary) {
+
+  if (isFormatterResolverNecessary) {
 #>
-            var formatterResolver = options.Resolver;
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
 <# }
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
-  if (objInfo.NeedsCastOnBefore) {#>
+  if (objInfo.NeedsCastOnBefore) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-<#  } else {#>
+<#  } else { #>
             value.OnBeforeSerialize();
-<#  }
- }#>
+<# } #>
+<# } #>
             writer.WriteArrayHeader(<#= objInfo.MaxKey + 1 #>);
 <# for (var i = 0; i <= objInfo.MaxKey; i++) {
   var member = objInfo.GetMember(i);
   if (member == null) {#>
             writer.WriteNil();
-<#  } else {#>
+<#  } else { #>
             <#= member.GetSerializeMethodString() #>;
-<#  }
- }#>
+<# } #>
+<# } #>
         }
 
         public <#= objInfo.FullName #> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -81,16 +81,16 @@ namespace <#= Namespace #>
 <# }#>
             }
 
-<# if (isFormatterResolverNecessary) {#>
-            var formatterResolver = options.Resolver;
-<# }#>
             options.Security.DepthStep(ref reader);
+<# if (isFormatterResolverNecessary) { #>
+            var formatterResolver = options.Resolver;
+<# } #>
             var length = reader.ReadArrayHeader();
-<# foreach (var member in objInfo.Members) {#>
+<# foreach (var member in objInfo.Members) { #>
             var __<#= member.Name #>__ = default(<#= member.Type #>);
-<# }#>
+<# } #>
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
@@ -100,7 +100,7 @@ namespace <#= Namespace #>
                     case <#= member.IntKey #>:
                         __<#= member.Name #>__ = <#= member.GetDeserializeMethodString() #>;
                         break;
-<# }#>
+<# } #>
                     default:
                         reader.Skip();
                         break;
@@ -110,21 +110,22 @@ namespace <#= Namespace #>
             var ____result = new <#= objInfo.GetConstructorString()  #>;
 <# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null || !member.IsWritable) { continue; }#>
+  if (member == null || !member.IsWritable) { continue; } #>
             ____result.<#= member.Name #> = __<#= member.Name #>__;
 <# }
+
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
-  if (objInfo.NeedsCastOnAfter) {#>
+  if (objInfo.NeedsCastOnAfter) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
-<#  } else {#>
+<#  } else { #>
             ____result.OnAfterDeserialize();
-<#  }
- }#>
+<# } #>
+<# } #>
             reader.Depth--;
             return ____result;
         }
     }
-<#}#>
+<# } #>
 }
 
 #pragma warning restore 168

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -39,7 +39,7 @@ namespace <#= Namespace #>
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-<# if (objInfo.IsClass) {#>
+<# if (objInfo.IsClass) { #>
             if (value == null)
             {
                 writer.WriteNil();
@@ -55,16 +55,16 @@ namespace <#= Namespace #>
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
   if (objInfo.NeedsCastOnBefore) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-<#  } else { #>
+<# } else { #>
             value.OnBeforeSerialize();
 <# } #>
 <# } #>
             writer.WriteArrayHeader(<#= objInfo.MaxKey + 1 #>);
 <# for (var i = 0; i <= objInfo.MaxKey; i++) {
   var member = objInfo.GetMember(i);
-  if (member == null) {#>
+  if (member == null) { #>
             writer.WriteNil();
-<#  } else { #>
+<# } else { #>
             <#= member.GetSerializeMethodString() #>;
 <# } #>
 <# } #>
@@ -74,11 +74,11 @@ namespace <#= Namespace #>
         {
             if (reader.TryReadNil())
             {
-<# if (objInfo.IsClass) {#>
+<# if (objInfo.IsClass) { #>
                 return null;
-<# } else {#>
+<# } else { #>
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
-<# }#>
+<# } #>
             }
 
             options.Security.DepthStep(ref reader);
@@ -96,7 +96,7 @@ namespace <#= Namespace #>
                 {
 <# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null) { continue; }#>
+  if (member == null) { continue; } #>
                     case <#= member.IntKey #>:
                         __<#= member.Name #>__ = <#= member.GetDeserializeMethodString() #>;
                         break;
@@ -117,7 +117,7 @@ namespace <#= Namespace #>
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
   if (objInfo.NeedsCastOnAfter) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
-<#  } else { #>
+<# } else { #>
             ____result.OnAfterDeserialize();
 <# } #>
 <# } #>

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -21,81 +21,148 @@
 
 namespace <#= Namespace #>
 {
-    using System;
-    using System.Buffers;
-    using MessagePack;
-<# foreach(var objInfo in ObjectSerializationInfos) {
-    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);#>
+    using global::System.Buffers;
+    using global::MessagePack;
+<#
+foreach (var objInfo in ObjectSerializationInfos)
+{
+    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
+#>
 
     public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
-<# foreach(var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) { #>
-        where <#= typeArg.Name #> : <#= typeArg.Constraints #>
-<# } #>
+<#
+    foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints))
     {
-<# foreach(var item in objInfo.Members) { #>
-<# if(item.CustomFormatterTypeName != null) { #>
-        <#= item.CustomFormatterTypeName #> __<#= item.Name #>CustomFormatter__ = new <#= item.CustomFormatterTypeName #>();
-<# } #>
-<# } #>
-
-        public void Serialize(ref MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
+#>
+        where <#= typeArg.Name #> : <#= typeArg.Constraints #>
+<#
+    }
+#>
+    {
+<#
+    foreach (var item in objInfo.Members)
+    {
+        if (item.CustomFormatterTypeName != null)
         {
-<# if( objInfo.IsClass) { #>
+#>
+        private readonly <#= item.CustomFormatterTypeName #> __<#= item.Name #>CustomFormatter__ = new <#= item.CustomFormatterTypeName #>();
+<#
+        }
+    }
+#>
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+<#
+    if (objInfo.IsClass)
+    {
+#>
             if (value == null)
             {
                 writer.WriteNil();
                 return;
             }
 
-<# }
+<#
+    }
 
-  if (isFormatterResolverNecessary) { #>
-            IFormatterResolver formatterResolver = options.Resolver;
-<#}
+    if (isFormatterResolverNecessary)
+    {
+#>
+            var formatterResolver = options.Resolver;
+<#
+    }
 
-  if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnBefore) { #>
-            ((IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-<# } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { #>
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
+    {
+        if (objInfo.NeedsCastOnBefore)
+        {
+#>
+            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
+<#
+        }
+        else
+        {
+#>
             value.OnBeforeSerialize();
-<# } #>
+<#
+        }
+    }
+#>
             writer.WriteArrayHeader(<#= objInfo.MaxKey + 1 #>);
-<# for(var i =0; i<= objInfo.MaxKey; i++) { var member = objInfo.GetMember(i); #>
-<# if( member == null) { #>
+<#
+    for (var i = 0; i <= objInfo.MaxKey; i++)
+    {
+        var member = objInfo.GetMember(i);
+        if (member == null)
+        {
+#>
             writer.WriteNil();
-<# } else { #>
+<#
+        }
+        else
+        {
+#>
             <#= member.GetSerializeMethodString() #>;
-<# } } #>
+<#
+        }
+    }
+#>
         }
 
-        public <#= objInfo.FullName #> Deserialize(ref MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        public <#= objInfo.FullName #> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-<# if( objInfo.IsClass) { #>
+<#
+    if (objInfo.IsClass)
+    {
+#>
                 return null;
-<# } else { #>
-                throw new InvalidOperationException("typecode is null, struct not supported");
-<# } #>
+<#
+    }
+    else
+    {
+#>
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
+<#
+    }
+#>
             }
 
+<#
+    if (isFormatterResolverNecessary)
+    {
+#>
+            var formatterResolver = options.Resolver;
+<#
+    }
+#>
             options.Security.DepthStep(ref reader);
-<# if (isFormatterResolverNecessary) { #>
-            IFormatterResolver formatterResolver = options.Resolver;
-<# } #>
             var length = reader.ReadArrayHeader();
-<# foreach(var x in objInfo.Members) { #>
-            var __<#= x.Name #>__ = default(<#= x.Type #>);
-<# } #>
+<#
+    foreach (var member in objInfo.Members)
+    {
+#>
+            var __<#= member.Name #>__ = default(<#= member.Type #>);
+<#
+    }
+#>
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
-<# foreach(var x in objInfo.Members) { #>
-                    case <#= x.IntKey #>:
-                        __<#= x.Name #>__ = <#= x.GetDeserializeMethodString() #>;
+<#
+    foreach (var member in objInfo.Members)
+    {
+#>
+                    case <#= member.IntKey #>:
+                        __<#= member.Name #>__ = <#= member.GetDeserializeMethodString() #>;
                         break;
-<# } #>
+<#
+    }
+#>
                     default:
                         reader.Skip();
                         break;
@@ -103,19 +170,43 @@ namespace <#= Namespace #>
             }
 
             var ____result = new <#= objInfo.GetConstructorString()  #>;
-<# foreach(var x in objInfo.Members.Where(x => x.IsWritable)) { #>
-            ____result.<#= x.Name #> = __<#= x.Name #>__;
-<# } #>
-<#if(objInfo.HasIMessagePackSerializationCallbackReceiver && objInfo.NeedsCastOnAfter) { #>
-            ((IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
-<# } else if(objInfo.HasIMessagePackSerializationCallbackReceiver) { #>
+<#
+    for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++)
+    {
+        var member = objInfo.GetMember(memberIndex);
+        if (member == null || !member.IsWritable)
+        {
+            continue;
+        }
+
+#>
+            ____result.<#= member.Name #> = __<#= member.Name #>__;
+<#
+    }
+
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
+    {
+        if (objInfo.NeedsCastOnAfter)
+        {
+#>
+            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
+<#
+        }
+        else
+        {
+#>
             ____result.OnAfterDeserialize();
-<# } #>
+<#
+        }
+    }
+#>
             reader.Depth--;
             return ____result;
         }
     }
-<# } #>
+<#
+}
+#>
 }
 
 #pragma warning restore 168

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -48,8 +48,7 @@ namespace <#= Namespace #>
 
 <# }
 
-  if (isFormatterResolverNecessary) {
-#>
+  if (isFormatterResolverNecessary) { #>
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
 <# }
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -125,20 +125,22 @@ namespace <#= Namespace #>
 
 <# if (!canOverwrite) { #>
             var ____result = new <#= objInfo.GetConstructorString()  #>;
-<# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+<# bool memberAssignExists = false;
+  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null || !member.IsWritable) { continue; } #>
+  if (member == null || !member.IsWritable || objInfo.ConstructorParameters.Any(p => p.Equals(member))) { continue; }
+  memberAssignExists = true;#>
             if (length <= <#= memberIndex #>)
             {
                 goto MEMBER_ASSIGNMENT_END;
             }
 
             ____result.<#= member.Name #> = __<#= member.Name #>__;
-<# if (memberIndex == objInfo.MaxKey) { #>
+<# } #>
+<# if (memberAssignExists) { #>
 
         MEMBER_ASSIGNMENT_END:
 <# }
-  }
  }
 
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -81,13 +81,21 @@ namespace <#= Namespace #>
 <# } #>
             }
 
+<# if (objInfo.MaxKey == -1 && !objInfo.HasIMessagePackSerializationCallbackReceiver) { #>
+            reader.Skip();
+            return new <#= objInfo.GetConstructorString()  #>;
+<# } else { #>
             options.Security.DepthStep(ref reader);
 <# if (isFormatterResolverNecessary) { #>
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
 <# } #>
             var length = reader.ReadArrayHeader();
-<# foreach (var member in objInfo.Members) { #>
+<# var canOverwrite = objInfo.ConstructorParameters.Length == 0;
+ if (canOverwrite) { #>
+            var ____result = new <#= objInfo.GetConstructorString()  #>;
+<# } else { foreach (var member in objInfo.Members) { #>
             var __<#= member.Name #>__ = default(<#= member.Type #>);
+<# } #>
 <# } #>
 
             for (int i = 0; i < length; i++)
@@ -98,7 +106,15 @@ namespace <#= Namespace #>
   var member = objInfo.GetMember(memberIndex);
   if (member == null) { continue; } #>
                     case <#= member.IntKey #>:
+<# if (canOverwrite) {
+  if (member.IsWritable) { #>
+                        ____result.<#= member.Name #> = <#= member.GetDeserializeMethodString() #>;
+<# } else { #>
+                        <#= member.GetDeserializeMethodString() #>;
+<# } #>
+<# } else {#>
                         __<#= member.Name #>__ = <#= member.GetDeserializeMethodString() #>;
+<# } #>
                         break;
 <# } #>
                     default:
@@ -107,12 +123,23 @@ namespace <#= Namespace #>
                 }
             }
 
+<# if (!canOverwrite) { #>
             var ____result = new <#= objInfo.GetConstructorString()  #>;
 <# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
   if (member == null || !member.IsWritable) { continue; } #>
+            if (length <= <#= memberIndex #>)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.<#= member.Name #> = __<#= member.Name #>__;
+<# if (memberIndex == objInfo.MaxKey) { #>
+
+        MEMBER_ASSIGNMENT_END:
 <# }
+  }
+ }
 
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
   if (objInfo.NeedsCastOnAfter) { #>
@@ -123,6 +150,7 @@ namespace <#= Namespace #>
 <# } #>
             reader.Depth--;
             return ____result;
+<# } #>
         }
     }
 <# } #>

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -23,10 +23,8 @@ namespace <#= Namespace #>
 {
     using global::System.Buffers;
     using global::MessagePack;
-<#
-foreach (var objInfo in ObjectSerializationInfos) {
- bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
-#>
+<#foreach (var objInfo in ObjectSerializationInfos) {
+ bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);#>
 
     public sealed class <#= objInfo.Name #>Formatter<#= (objInfo.IsOpenGenericType ? $"<{string.Join(",", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "") #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
 <# foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) {#>

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterDeserializeHelper.cs
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterDeserializeHelper.cs
@@ -12,7 +12,7 @@ namespace MessagePackCompiler.Generator
 {
     internal static class StringKeyFormatterDeserializeHelper
     {
-        public static string Classify(MemberSerializationInfo[] memberArray, string indent)
+        public static string Classify(MemberSerializationInfo[] memberArray, string indent, bool canOverwrite)
         {
             var buffer = new StringBuilder();
             foreach (var memberInfoTuples in memberArray.Select(member => new MemberInfoTuple(member)).GroupBy(member => member.Binary.Length))
@@ -22,18 +22,36 @@ namespace MessagePackCompiler.Generator
                 keyLength += keyLength << 3 == binaryLength ? 0 : 1;
 
                 buffer.Append(indent).Append("case ").Append(binaryLength).Append(":\r\n");
-                ClassifyRecursion(buffer, indent, 1, keyLength, memberInfoTuples);
+                ClassifyRecursion(buffer, indent, 1, keyLength, memberInfoTuples, canOverwrite);
             }
 
             return buffer.ToString();
         }
 
-        private static void Assign(StringBuilder buffer, in MemberInfoTuple member)
+        private static void Assign(StringBuilder buffer, in MemberInfoTuple member, bool canOverwrite, string indent, string tab, int tabCount)
         {
-            buffer.Append("__").Append(member.Info.Name).Append("__ = ").Append(member.Info.GetDeserializeMethodString()).Append(";\r\n");
+            if (canOverwrite)
+            {
+                if (member.Info.IsWritable)
+                {
+                    buffer.Append("____result.").Append(member.Info.Name).Append(" = ");
+                }
+            }
+            else
+            {
+                buffer.Append("__").Append(member.Info.Name).Append("__IsInitialized = true;\r\n").Append(indent);
+                for (var i = 0; i < tabCount; i++)
+                {
+                    buffer.Append(tab);
+                }
+
+                buffer.Append("__").Append(member.Info.Name).Append("__ = ");
+            }
+
+            buffer.Append(member.Info.GetDeserializeMethodString()).Append(";\r\n");
         }
 
-        private static void ClassifyRecursion(StringBuilder buffer, string indent, int tabCount, int keyLength, IEnumerable<MemberInfoTuple> memberCollection)
+        private static void ClassifyRecursion(StringBuilder buffer, string indent, int tabCount, int keyLength, IEnumerable<MemberInfoTuple> memberCollection, bool canOverwrite)
         {
             const string Tab = "    ";
             buffer.Append(indent);
@@ -46,7 +64,7 @@ namespace MessagePackCompiler.Generator
             if (memberArray.Length == 1)
             {
                 var member = memberArray[0];
-                EmbedOne(buffer, indent, tabCount, member);
+                EmbedOne(buffer, indent, tabCount, member, canOverwrite);
                 return;
             }
 
@@ -83,7 +101,7 @@ namespace MessagePackCompiler.Generator
                     }
 
                     var member = grouping.Single();
-                    Assign(buffer, member);
+                    Assign(buffer, member, canOverwrite, indent, Tab, tabCount + 2);
                     buffer.Append(Tab + Tab).Append(indent);
                     for (var i = 0; i < tabCount; i++)
                     {
@@ -94,7 +112,7 @@ namespace MessagePackCompiler.Generator
                     continue;
                 }
 
-                ClassifyRecursion(buffer, indent + Tab, tabCount + 1, keyLength, grouping);
+                ClassifyRecursion(buffer, indent + Tab, tabCount + 1, keyLength, grouping, canOverwrite);
             }
 
             buffer.Append("\r\n").Append(indent);
@@ -106,7 +124,7 @@ namespace MessagePackCompiler.Generator
             buffer.Append("}\r\n");
         }
 
-        private static void EmbedOne(StringBuilder buffer, string indent, int tabCount, in MemberInfoTuple member)
+        private static void EmbedOne(StringBuilder buffer, string indent, int tabCount, in MemberInfoTuple member, bool canOverwrite)
         {
             const string Tab = "    ";
             var binary = member.Binary.AsSpan((tabCount - 1) << 3);
@@ -136,7 +154,7 @@ namespace MessagePackCompiler.Generator
                 buffer.Append(Tab);
             }
 
-            Assign(buffer, member);
+            Assign(buffer, member, canOverwrite, indent, Tab, tabCount);
             buffer.Append(indent);
             for (var i = 0; i < tabCount; i++)
             {

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterDeserializeHelper.cs
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterDeserializeHelper.cs
@@ -44,28 +44,32 @@ namespace MessagePackCompiler.Generator
 
         private static void Assign(StringBuilder buffer, in MemberInfoTuple member, bool canOverwrite, string indent, string tab, int tabCount)
         {
-            if (canOverwrite)
+            if (member.Info.IsWritable)
             {
-                if (member.Info.IsWritable)
+                if (canOverwrite)
                 {
                     buffer.Append("____result.").Append(member.Info.Name).Append(" = ");
                 }
+                else
+                {
+                    if (!member.IsConstructorParameter)
+                    {
+                        buffer.Append("__").Append(member.Info.Name).Append("__IsInitialized = true;\r\n").Append(indent);
+                        for (var i = 0; i < tabCount; i++)
+                        {
+                            buffer.Append(tab);
+                        }
+                    }
+
+                    buffer.Append("__").Append(member.Info.Name).Append("__ = ");
+                }
+
+                buffer.Append(member.Info.GetDeserializeMethodString()).Append(";\r\n");
             }
             else
             {
-                if (!member.IsConstructorParameter)
-                {
-                    buffer.Append("__").Append(member.Info.Name).Append("__IsInitialized = true;\r\n").Append(indent);
-                    for (var i = 0; i < tabCount; i++)
-                    {
-                        buffer.Append(tab);
-                    }
-                }
-
-                buffer.Append("__").Append(member.Info.Name).Append("__ = ");
+                buffer.Append("reader.Skip();\r\n");
             }
-
-            buffer.Append(member.Info.GetDeserializeMethodString()).Append(";\r\n");
         }
 
         private static void ClassifyRecursion(StringBuilder buffer, string indent, int tabCount, int keyLength, IEnumerable<MemberInfoTuple> memberCollection, bool canOverwrite)

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.cs
@@ -43,33 +43,25 @@ namespace MessagePackCompiler.Generator
 
 namespace ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Namespace));
-            this.Write("\r\n{\r\n    using System;\r\n    using System.Buffers;\r\n    using System.Runtime.Inter" +
-                    "opServices;\r\n    using MessagePack;\r\n");
-
-var list = new List<ValueTuple<MemberSerializationInfo, byte[]>>();
-foreach (var objInfo in ObjectSerializationInfos)
-{
+            this.Write("\r\n{\r\n    using global::System.Buffers;\r\n    using global::MessagePack;\r\n");
+ var list = new List<ValueTuple<MemberSerializationInfo, byte[]>>();
+foreach (var objInfo in ObjectSerializationInfos) {
     list.Clear();
-    foreach (var member in objInfo.Members)
-    {
+    foreach (var member in objInfo.Members) {
         var binary = EmbedStringHelper.Utf8.GetBytes(member.StringKey);
         list.Add(new ValueTuple<MemberSerializationInfo, byte[]>(member, binary));
     }
 
     string formatterName = objInfo.Name + (objInfo.IsOpenGenericType ? $"Formatter<{string.Join(",", (object[])objInfo.GenericTypeParameters)}>" : "Formatter");
-    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
-
+    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members); 
             this.Write("\r\n    public sealed class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(formatterName));
             this.Write(" : global::MessagePack.Formatters.IMessagePackFormatter<");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(">\r\n    {\r\n");
-
-    foreach (var memberAndBinary in list)
-    {
-        var member = memberAndBinary.Item1;
-        var binary = memberAndBinary.Item2;
-
+ for (var i = 0; i < list.Count; i++) {
+        var member = list[i].Item1;
+        var binary = list[i].Item2; 
             this.Write("        // ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.StringKey));
             this.Write("\r\n        private static global::System.ReadOnlySpan<byte> GetSpan_");
@@ -77,121 +69,83 @@ foreach (var objInfo in ObjectSerializationInfos)
             this.Write("() => ");
             this.Write(this.ToStringHelper.ToStringWithCulture(EmbedStringHelper.ToByteArrayString(binary)));
             this.Write(";\r\n");
-
-    }
-
-            this.Write("\r\n        public void Serialize(ref global::MessagePack.MessagePackWriter writer," +
-                    " ");
+ } 
+ if (list.Count != 0) { 
+            this.Write("\r\n");
+ } 
+            this.Write("        public void Serialize(ref global::MessagePack.MessagePackWriter writer, ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" value, global::MessagePack.MessagePackSerializerOptions options)\r\n        {\r\n");
-
-    if (objInfo.IsClass)
-    {
-
+ if (objInfo.IsClass) { 
             this.Write("            if (value is null)\r\n            {\r\n                writer.WriteNil();" +
                     "\r\n                return;\r\n            }\r\n\r\n");
+ }
 
-    }
+    if (isFormatterResolverNecessary) { 
+            this.Write("            var formatterResolver = options.Resolver;\r\n");
+ }
 
-    if (isFormatterResolverNecessary)
-    {
-
-            this.Write("            IFormatterResolver formatterResolver = options.Resolver;\r\n");
-
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnBefore)
-        {
-
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+        if (objInfo.NeedsCastOnBefore) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value" +
                     ").OnBeforeSerialize();\r\n");
-
-        }
-        else
-        {
-
+ } else { 
             this.Write("            value.OnBeforeSerialize();\r\n");
-
-        }
-    }
-
+ } 
+ } 
             this.Write("            writer.WriteMapHeader(");
             this.Write(this.ToStringHelper.ToStringWithCulture(list.Count));
             this.Write(");\r\n");
-
-    foreach (var memberAndBinary in list)
-    {
-        var member = memberAndBinary.Item1;
-
+ foreach (var memberAndBinary in list) {
+        var member = memberAndBinary.Item1; 
             this.Write("            writer.WriteRaw(GetSpan_");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("());\r\n            ");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.GetSerializeMethodString()));
             this.Write(";\r\n");
-
-    }
-
+ } 
             this.Write("        }\r\n\r\n        public ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.FullName));
             this.Write(" Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePac" +
                     "k.MessagePackSerializerOptions options)\r\n        {\r\n            if (reader.TryRe" +
                     "adNil())\r\n            {\r\n");
-
-    if (objInfo.IsClass)
-    {
-
+ if (objInfo.IsClass) { 
             this.Write("                return null;\r\n");
-
-    }
-    else
-    {
-
+ } else { 
             this.Write("                throw new global::System.InvalidOperationException(\"typecode is n" +
                     "ull, struct not supported\");\r\n");
-
-    }
-
+ } 
             this.Write("            }\r\n\r\n");
-
-    if (objInfo.Members.Length == 0)
-    {
-
+ if (objInfo.Members.Length == 0) { 
             this.Write("            reader.Skip();\r\n            var ____result = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             this.Write(";\r\n");
-
-    }
-    else
-    {
-
+ } else { 
             this.Write("            options.Security.DepthStep(ref reader);\r\n");
-
-        if (isFormatterResolverNecessary)
-        {
-
-            this.Write("            IFormatterResolver formatterResolver = options.Resolver;\r\n");
-
-        }
-
+ if (isFormatterResolverNecessary) { 
+            this.Write("            var formatterResolver = options.Resolver;\r\n");
+ } 
             this.Write("            var length = reader.ReadMapHeader();\r\n");
-
-        foreach (var memberInfo in objInfo.Members)
-        {
-
+ var canOverwrite = objInfo.ConstructorParameters.Length == 0;
+        if (canOverwrite) { 
+            this.Write("            var ____result = new ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
+            this.Write(";\r\n");
+ } else {
+            foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { 
             this.Write("            var __");
-            this.Write(this.ToStringHelper.ToStringWithCulture(memberInfo.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = default(");
-            this.Write(this.ToStringHelper.ToStringWithCulture(memberInfo.Type));
-            this.Write(");\r\n");
-
-        }
-
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Type));
+            this.Write(");\r\n            var __");
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
+            this.Write("__IsInitialized = false;\r\n");
+ } 
+ } 
             this.Write(@"
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -199,55 +153,36 @@ foreach (var objInfo in ObjectSerializationInfos)
                       reader.Skip();
                       continue;
 ");
-            this.Write(this.ToStringHelper.ToStringWithCulture(StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ")));
-            this.Write("\r\n                }\r\n            }\r\n\r\n            var ____result = new ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ", canOverwrite)));
+            this.Write("\r\n                }\r\n            }\r\n\r\n");
+ if (!canOverwrite) { 
+            this.Write("            var ____result = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
-            this.Write("\r\n            {\r\n");
-
-        // Preparation for C#9 Record class
-        foreach (var member in objInfo.Members.Where(x => x.IsWritable))
-        {
-
-            this.Write("                ");
+            this.Write(";\r\n");
+ foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { 
+            this.Write("            if (__");
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
+            this.Write("__IsInitialized)\r\n            {\r\n                ____result.");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write(" = __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
-            this.Write("__,\r\n");
-
-        }
-
-            this.Write("            };\r\n\r\n");
-
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnAfter)
-        {
-
+            this.Write("__;\r\n            }\r\n\r\n");
+ } 
+ } 
+ } 
+ if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+        if (objInfo.NeedsCastOnAfter) { 
             this.Write("            ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____r" +
                     "esult).OnAfterDeserialize();\r\n");
-
-        }
-        else
-        {
-
+ } else { 
             this.Write("            ____result.OnAfterDeserialize();\r\n");
-
-        }
-    }
-
-    if (objInfo.Members.Length != 0)
-    {
-
+ } 
+ } 
+ if (objInfo.Members.Length != 0) { 
             this.Write("            reader.Depth--;\r\n");
-
-    }
-
+ } 
             this.Write("            return ____result;\r\n        }\r\n    }\r\n");
-
-}
-
+ } 
             this.Write("}\r\n");
             return this.GenerationEnvironment.ToString();
         }

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.cs
@@ -159,7 +159,7 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write("            var ____result = new ");
             this.Write(this.ToStringHelper.ToStringWithCulture(objInfo.GetConstructorString()));
             this.Write(";\r\n");
- foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { 
+ foreach (var member in objInfo.Members.Where(x => x.IsWritable && !objInfo.ConstructorParameters.Any(p => p.Equals(x)))) { 
             this.Write("            if (__");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__IsInitialized)\r\n            {\r\n                ____result.");

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.cs
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.cs
@@ -133,13 +133,16 @@ foreach (var objInfo in ObjectSerializationInfos) {
             this.Write(";\r\n");
  } else {
             foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { 
+ if (objInfo.ConstructorParameters.All(p => !p.Equals(member))) { 
+            this.Write("            var __");
+            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
+            this.Write("__IsInitialized = false;\r\n");
+ } 
             this.Write("            var __");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
             this.Write("__ = default(");
             this.Write(this.ToStringHelper.ToStringWithCulture(member.Type));
-            this.Write(");\r\n            var __");
-            this.Write(this.ToStringHelper.ToStringWithCulture(member.Name));
-            this.Write("__IsInitialized = false;\r\n");
+            this.Write(");\r\n");
  } 
  } 
             this.Write(@"
@@ -153,7 +156,7 @@ foreach (var objInfo in ObjectSerializationInfos) {
                       reader.Skip();
                       continue;
 ");
-            this.Write(this.ToStringHelper.ToStringWithCulture(StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ", canOverwrite)));
+            this.Write(this.ToStringHelper.ToStringWithCulture(StringKeyFormatterDeserializeHelper.Classify(objInfo, "                    ", canOverwrite)));
             this.Write("\r\n                }\r\n            }\r\n\r\n");
  if (!canOverwrite) { 
             this.Write("            var ____result = new ");

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
@@ -22,196 +22,126 @@
 
 namespace <#= Namespace #>
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
-<#
-var list = new List<ValueTuple<MemberSerializationInfo, byte[]>>();
-foreach (var objInfo in ObjectSerializationInfos)
-{
+    using global::System.Buffers;
+    using global::MessagePack;
+<# var list = new List<ValueTuple<MemberSerializationInfo, byte[]>>();
+foreach (var objInfo in ObjectSerializationInfos) {
     list.Clear();
-    foreach (var member in objInfo.Members)
-    {
+    foreach (var member in objInfo.Members) {
         var binary = EmbedStringHelper.Utf8.GetBytes(member.StringKey);
         list.Add(new ValueTuple<MemberSerializationInfo, byte[]>(member, binary));
     }
 
     string formatterName = objInfo.Name + (objInfo.IsOpenGenericType ? $"Formatter<{string.Join(",", (object[])objInfo.GenericTypeParameters)}>" : "Formatter");
-    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
-#>
+    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members); #>
 
     public sealed class <#= formatterName #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
     {
-<#
-    foreach (var memberAndBinary in list)
-    {
-        var member = memberAndBinary.Item1;
-        var binary = memberAndBinary.Item2;
-#>
+<# for (var i = 0; i < list.Count; i++) {
+        var member = list[i].Item1;
+        var binary = list[i].Item2; #>
         // <#= member.StringKey #>
         private static global::System.ReadOnlySpan<byte> GetSpan_<#= member.Name #>() => <#= EmbedStringHelper.ToByteArrayString(binary) #>;
-<#
-    }
-#>
+<# } #>
+<# if (list.Count != 0) { #>
 
+<# } #>
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-<#
-    if (objInfo.IsClass)
-    {
-#>
+<# if (objInfo.IsClass) { #>
             if (value is null)
             {
                 writer.WriteNil();
                 return;
             }
 
-<#
-    }
+<# }
 
-    if (isFormatterResolverNecessary)
-    {
-#>
-            IFormatterResolver formatterResolver = options.Resolver;
-<#
-    }
+    if (isFormatterResolverNecessary) { #>
+            var formatterResolver = options.Resolver;
+<# }
 
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnBefore)
-        {
-#>
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+        if (objInfo.NeedsCastOnBefore) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-<#
-        }
-        else
-        {
-#>
+<# } else { #>
             value.OnBeforeSerialize();
-<#
-        }
-    }
-#>
+<# } #>
+<# } #>
             writer.WriteMapHeader(<#= list.Count #>);
-<#
-    foreach (var memberAndBinary in list)
-    {
-        var member = memberAndBinary.Item1;
-#>
+<# foreach (var memberAndBinary in list) {
+        var member = memberAndBinary.Item1; #>
             writer.WriteRaw(GetSpan_<#= member.Name #>());
             <#= member.GetSerializeMethodString() #>;
-<#
-    }
-#>
+<# } #>
         }
 
         public <#= objInfo.FullName #> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-<#
-    if (objInfo.IsClass)
-    {
-#>
+<# if (objInfo.IsClass) { #>
                 return null;
-<#
-    }
-    else
-    {
-#>
+<# } else { #>
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
-<#
-    }
-#>
+<# } #>
             }
 
-<#
-    if (objInfo.Members.Length == 0)
-    {
-#>
+<# if (objInfo.Members.Length == 0) { #>
             reader.Skip();
             var ____result = new <#= objInfo.GetConstructorString() #>;
-<#
-    }
-    else
-    {
-#>
+<# } else { #>
             options.Security.DepthStep(ref reader);
-<#
-        if (isFormatterResolverNecessary)
-        {
-#>
-            IFormatterResolver formatterResolver = options.Resolver;
-<#
-        }
-#>
+<# if (isFormatterResolverNecessary) { #>
+            var formatterResolver = options.Resolver;
+<# } #>
             var length = reader.ReadMapHeader();
-<#
-        foreach (var memberInfo in objInfo.Members)
-        {
-#>
-            var __<#= memberInfo.Name #>__ = default(<#= memberInfo.Type #>);
-<#
-        }
-#>
+<# var canOverwrite = objInfo.ConstructorParameters.Length == 0;
+        if (canOverwrite) { #>
+            var ____result = new <#= objInfo.GetConstructorString() #>;
+<# } else {
+            foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { #>
+            var __<#= member.Name #>__ = default(<#= member.Type #>);
+            var __<#= member.Name #>__IsInitialized = false;
+<# } #>
+<# } #>
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
                     FAIL:
                       reader.Skip();
                       continue;
-<#= StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ") #>
+<#= StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ", canOverwrite) #>
                 }
             }
 
-            var ____result = new <#= objInfo.GetConstructorString() #>
+<# if (!canOverwrite) { #>
+            var ____result = new <#= objInfo.GetConstructorString() #>;
+<# foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { #>
+            if (__<#= member.Name #>__IsInitialized)
             {
-<#
-        // Preparation for C#9 Record class
-        foreach (var member in objInfo.Members.Where(x => x.IsWritable))
-        {
-#>
-                <#= member.Name #> = __<#= member.Name #>__,
-<#
-        }
-#>
-            };
+                ____result.<#= member.Name #> = __<#= member.Name #>__;
+            }
 
-<#
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnAfter)
-        {
-#>
+<# } #>
+<# } #>
+<# } #>
+<# if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+        if (objInfo.NeedsCastOnAfter) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
-<#
-        }
-        else
-        {
-#>
+<# } else { #>
             ____result.OnAfterDeserialize();
-<#
-        }
-    }
-
-    if (objInfo.Members.Length != 0)
-    {
-#>
+<# } #>
+<# } #>
+<# if (objInfo.Members.Length != 0) { #>
             reader.Depth--;
-<#
-    }
-#>
+<# } #>
             return ____result;
         }
     }
-<#
-}
-#>
+<# } #>
 }

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
@@ -101,8 +101,10 @@ foreach (var objInfo in ObjectSerializationInfos) {
             var ____result = new <#= objInfo.GetConstructorString() #>;
 <# } else {
             foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { #>
-            var __<#= member.Name #>__ = default(<#= member.Type #>);
+<# if (objInfo.ConstructorParameters.All(p => !p.Equals(member))) { #>
             var __<#= member.Name #>__IsInitialized = false;
+<# } #>
+            var __<#= member.Name #>__ = default(<#= member.Type #>);
 <# } #>
 <# } #>
 
@@ -115,7 +117,7 @@ foreach (var objInfo in ObjectSerializationInfos) {
                     FAIL:
                       reader.Skip();
                       continue;
-<#= StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ", canOverwrite) #>
+<#= StringKeyFormatterDeserializeHelper.Classify(objInfo, "                    ", canOverwrite) #>
                 }
             }
 

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
@@ -121,7 +121,7 @@ foreach (var objInfo in ObjectSerializationInfos) {
 
 <# if (!canOverwrite) { #>
             var ____result = new <#= objInfo.GetConstructorString() #>;
-<# foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { #>
+<# foreach (var member in objInfo.Members.Where(x => x.IsWritable && !objInfo.ConstructorParameters.Any(p => p.Equals(x)))) { #>
             if (__<#= member.Name #>__IsInitialized)
             {
                 ____result.<#= member.Name #> = __<#= member.Name #>__;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
@@ -118,14 +118,19 @@ namespace SharedData
     [MessagePackObject(true)]
     public class DefaultValueStringKeyClassWithoutExplicitConstructor
     {
-        public int Prop1 { get; set; } = 114;
+        public const int Prop1Constant = 11;
+        public const int Prop2Constant = 45;
 
-        public int Prop2 { get; set; } = 514;
+        public int Prop1 { get; set; } = Prop1Constant;
+
+        public int Prop2 { get; set; } = Prop2Constant;
     }
 
     [MessagePackObject(true)]
     public class DefaultValueStringKeyClassWithExplicitConstructor
     {
+        public const int Prop2Constant = 1419;
+
         public int Prop1 { get; set; }
 
         public int Prop2 { get; set; }
@@ -133,13 +138,15 @@ namespace SharedData
         public DefaultValueStringKeyClassWithExplicitConstructor(int prop1)
         {
             Prop1 = prop1;
-            Prop2 = 191;
+            Prop2 = Prop2Constant;
         }
     }
 
     [MessagePackObject(true)]
     public struct DefaultValueStringKeyStructWithExplicitConstructor
     {
+        public const int Prop2Constant = 198;
+
         public int Prop1 { get; set; }
 
         public int Prop2 { get; set; }
@@ -147,23 +154,28 @@ namespace SharedData
         public DefaultValueStringKeyStructWithExplicitConstructor(int prop1)
         {
             Prop1 = prop1;
-            Prop2 = 9810;
+            Prop2 = Prop2Constant;
         }
     }
 
     [MessagePackObject]
     public class DefaultValueIntKeyClassWithoutExplicitConstructor
     {
+        public const int Prop1Constant = 33;
+        public const int Prop2Constant = -4;
+
         [Key(0)]
-        public int Prop1 { get; set; } = 33;
+        public int Prop1 { get; set; } = Prop1Constant;
 
         [Key(1)]
-        public int Prop2 { get; set; } = -4;
+        public int Prop2 { get; set; } = Prop2Constant;
     }
 
     [MessagePackObject]
     public class DefaultValueIntKeyClassWithExplicitConstructor
     {
+        public const int Prop2Constant = -109;
+
         [Key(0)]
         public int Prop1 { get; set; }
 
@@ -173,13 +185,15 @@ namespace SharedData
         public DefaultValueIntKeyClassWithExplicitConstructor(int prop1)
         {
             Prop1 = prop1;
-            Prop2 = -931;
+            Prop2 = Prop2Constant;
         }
     }
 
     [MessagePackObject]
     public struct DefaultValueIntKeyStructWithExplicitConstructor
     {
+        public const int Prop2Constant = 31;
+
         [Key(0)]
         public int Prop1 { get; set; }
 
@@ -189,7 +203,7 @@ namespace SharedData
         public DefaultValueIntKeyStructWithExplicitConstructor(int prop1)
         {
             Prop1 = prop1;
-            Prop2 = 810;
+            Prop2 = Prop2Constant;
         }
     }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
@@ -116,6 +116,84 @@ namespace SharedData
     }
 
     [MessagePackObject(true)]
+    public class DefaultValueStringKeyClassWithoutExplicitConstructor
+    {
+        public int Prop1 { get; set; } = 114;
+
+        public int Prop2 { get; set; } = 514;
+    }
+
+    [MessagePackObject(true)]
+    public class DefaultValueStringKeyClassWithExplicitConstructor
+    {
+        public int Prop1 { get; set; }
+
+        public int Prop2 { get; set; }
+
+        public DefaultValueStringKeyClassWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = 191;
+        }
+    }
+
+    [MessagePackObject(true)]
+    public struct DefaultValueStringKeyStructWithExplicitConstructor
+    {
+        public int Prop1 { get; set; }
+
+        public int Prop2 { get; set; }
+
+        public DefaultValueStringKeyStructWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = 9810;
+        }
+    }
+
+    [MessagePackObject]
+    public class DefaultValueIntKeyClassWithoutExplicitConstructor
+    {
+        [Key(0)]
+        public int Prop1 { get; set; } = 33;
+
+        [Key(1)]
+        public int Prop2 { get; set; } = -4;
+    }
+
+    [MessagePackObject]
+    public class DefaultValueIntKeyClassWithExplicitConstructor
+    {
+        [Key(0)]
+        public int Prop1 { get; set; }
+
+        [Key(1)]
+        public int Prop2 { get; set; }
+
+        public DefaultValueIntKeyClassWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = -931;
+        }
+    }
+
+    [MessagePackObject]
+    public struct DefaultValueIntKeyStructWithExplicitConstructor
+    {
+        [Key(0)]
+        public int Prop1 { get; set; }
+
+        [Key(1)]
+        public int Prop2 { get; set; }
+
+        public DefaultValueIntKeyStructWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = 810;
+        }
+    }
+
+    [MessagePackObject(true)]
     public class SimpleStringKeyData
     {
         public int Prop1 { get; set; }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
@@ -175,6 +175,8 @@ namespace SharedData
     public class DefaultValueIntKeyClassWithExplicitConstructor
     {
         public const int Prop2Constant = -109;
+        public const string Prop3Constant = "生命、宇宙、そして万物についての究極の疑問の答え";
+        public const string Prop4Constant = "Hello, world! To you, From me.";
 
         [Key(0)]
         public int Prop1 { get; set; }
@@ -182,10 +184,18 @@ namespace SharedData
         [Key(1)]
         public int Prop2 { get; set; }
 
+        [Key(2)]
+        public string Prop3 { get; set; }
+
+        [Key(3)]
+        public string Prop4 { get; set; }
+
         public DefaultValueIntKeyClassWithExplicitConstructor(int prop1)
         {
             Prop1 = prop1;
             Prop2 = Prop2Constant;
+            Prop3 = Prop3Constant;
+            Prop4 = Prop4Constant;
         }
     }
 

--- a/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
+++ b/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sandbox\Sandbox\Sandbox.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MessagePack.GeneratedCode.Tests/MissingPropertiesTest.cs
+++ b/tests/MessagePack.GeneratedCode.Tests/MissingPropertiesTest.cs
@@ -1,0 +1,105 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MessagePack.Resolvers;
+using Nerdbank.Streams;
+using SharedData;
+using Xunit;
+
+namespace MessagePack.GeneratedCode.Tests
+{
+    public class MissingPropertiesTest
+    {
+        private readonly MessagePackSerializerOptions options;
+
+        public MissingPropertiesTest()
+        {
+            var resolver = CompositeResolver.Create(GeneratedResolver.Instance, StandardResolver.Instance);
+            options = MessagePackSerializerOptions.Standard.WithResolver(resolver);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithoutExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(0);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithoutExplicitConstructor>(seq, options);
+            Assert.Equal(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop1Constant, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(1);
+            writer.Write(nameof(DefaultValueStringKeyClassWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyClassWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyStructWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(1);
+            writer.Write(nameof(DefaultValueStringKeyStructWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyStructWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyStructWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithoutExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(0);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithoutExplicitConstructor>(seq, options);
+            Assert.Equal(DefaultValueIntKeyClassWithoutExplicitConstructor.Prop1Constant, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyClassWithoutExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyClassWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyStructWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyStructWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyStructWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+    }
+}


### PR DESCRIPTION
I find a behaviour mismatch between mpc.exe and DynamicObjectResolver.
If a member belongs to constructor parameters, the assignment is skipped in Dynamic.
I changed the mpc.exe to be the same as the DynamicObjectResolver.