### PR TITLE
Stop initializing members to their default values when deserializing where no data was provided for that member

### DIFF
--- a/MessagePack.sln
+++ b/MessagePack.sln
@@ -88,6 +88,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.Experimental", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagePack.Experimental.Tests", "tests\MessagePack.Experimental.Tests\MessagePack.Experimental.Tests.csproj", "{8AB40D1C-1134-4D77-B39A-19AEDC729450}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePack.GeneratedCode.Tests", "tests\MessagePack.GeneratedCode.Tests\MessagePack.GeneratedCode.Tests.csproj", "{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -310,6 +312,14 @@ Global
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450}.Release|NoVSIX.ActiveCfg = Release|Any CPU
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450}.Release|NoVSIX.Build.0 = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|NoVSIX.ActiveCfg = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Debug|NoVSIX.Build.0 = Debug|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|NoVSIX.ActiveCfg = Release|Any CPU
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E}.Release|NoVSIX.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -342,6 +352,7 @@ Global
 		{4C9BB260-62D8-49CD-9F9C-9AA6A8BFC637} = {51A614B0-E583-4DD2-AC7D-6A65634582E0}
 		{AC2503A7-736D-4AE6-9355-CF35D9DF6139} = {86309CF6-0054-4CE3-BFD3-CA0AA7DB17BC}
 		{8AB40D1C-1134-4D77-B39A-19AEDC729450} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
+		{D4CE7347-CEBE-46E5-BD12-1319573B6C5E} = {19FE674A-AC94-4E7E-B24C-2285D1D04CDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3911209-2DBF-47F8-98F6-BBC0EDFE63DE}

--- a/sandbox/Sandbox/Generated.cs
+++ b/sandbox/Sandbox/Generated.cs
@@ -49,7 +49,7 @@ namespace MessagePack.Resolvers
 
         static GeneratedResolverGetFormatterHelper()
         {
-            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(65)
+            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(71)
             {
                 { typeof(global::GlobalMyEnum[,]), 0 },
                 { typeof(global::GlobalMyEnum[]), 1 },
@@ -80,42 +80,48 @@ namespace MessagePack.Resolvers
                 { typeof(global::SharedData.Callback1_2), 26 },
                 { typeof(global::SharedData.Callback2), 27 },
                 { typeof(global::SharedData.Callback2_2), 28 },
-                { typeof(global::SharedData.Empty1), 29 },
-                { typeof(global::SharedData.Empty2), 30 },
-                { typeof(global::SharedData.EmptyClass), 31 },
-                { typeof(global::SharedData.EmptyStruct), 32 },
-                { typeof(global::SharedData.FirstSimpleData), 33 },
-                { typeof(global::SharedData.FooClass), 34 },
-                { typeof(global::SharedData.HolderV0), 35 },
-                { typeof(global::SharedData.HolderV1), 36 },
-                { typeof(global::SharedData.HolderV2), 37 },
-                { typeof(global::SharedData.MyClass), 38 },
-                { typeof(global::SharedData.MySubUnion1), 39 },
-                { typeof(global::SharedData.MySubUnion2), 40 },
-                { typeof(global::SharedData.MySubUnion3), 41 },
-                { typeof(global::SharedData.MySubUnion4), 42 },
-                { typeof(global::SharedData.NestParent.NestContract), 43 },
-                { typeof(global::SharedData.NonEmpty1), 44 },
-                { typeof(global::SharedData.NonEmpty2), 45 },
-                { typeof(global::SharedData.SimpleIntKeyData), 46 },
-                { typeof(global::SharedData.SimpleStringKeyData), 47 },
-                { typeof(global::SharedData.SimpleStructIntKeyData), 48 },
-                { typeof(global::SharedData.SimpleStructStringKeyData), 49 },
-                { typeof(global::SharedData.SubUnionType1), 50 },
-                { typeof(global::SharedData.SubUnionType2), 51 },
-                { typeof(global::SharedData.UnVersionBlockTest), 52 },
-                { typeof(global::SharedData.Vector2), 53 },
-                { typeof(global::SharedData.Vector3Like), 54 },
-                { typeof(global::SharedData.VectorLike2), 55 },
-                { typeof(global::SharedData.Version0), 56 },
-                { typeof(global::SharedData.Version1), 57 },
-                { typeof(global::SharedData.Version2), 58 },
-                { typeof(global::SharedData.VersionBlockTest), 59 },
-                { typeof(global::SharedData.VersioningUnion), 60 },
-                { typeof(global::SharedData.WithIndexer), 61 },
-                { typeof(global::SimpleModel), 62 },
-                { typeof(global::StampMessageBody), 63 },
-                { typeof(global::TextMessageBody), 64 },
+                { typeof(global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor), 29 },
+                { typeof(global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor), 30 },
+                { typeof(global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor), 31 },
+                { typeof(global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor), 32 },
+                { typeof(global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor), 33 },
+                { typeof(global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor), 34 },
+                { typeof(global::SharedData.Empty1), 35 },
+                { typeof(global::SharedData.Empty2), 36 },
+                { typeof(global::SharedData.EmptyClass), 37 },
+                { typeof(global::SharedData.EmptyStruct), 38 },
+                { typeof(global::SharedData.FirstSimpleData), 39 },
+                { typeof(global::SharedData.FooClass), 40 },
+                { typeof(global::SharedData.HolderV0), 41 },
+                { typeof(global::SharedData.HolderV1), 42 },
+                { typeof(global::SharedData.HolderV2), 43 },
+                { typeof(global::SharedData.MyClass), 44 },
+                { typeof(global::SharedData.MySubUnion1), 45 },
+                { typeof(global::SharedData.MySubUnion2), 46 },
+                { typeof(global::SharedData.MySubUnion3), 47 },
+                { typeof(global::SharedData.MySubUnion4), 48 },
+                { typeof(global::SharedData.NestParent.NestContract), 49 },
+                { typeof(global::SharedData.NonEmpty1), 50 },
+                { typeof(global::SharedData.NonEmpty2), 51 },
+                { typeof(global::SharedData.SimpleIntKeyData), 52 },
+                { typeof(global::SharedData.SimpleStringKeyData), 53 },
+                { typeof(global::SharedData.SimpleStructIntKeyData), 54 },
+                { typeof(global::SharedData.SimpleStructStringKeyData), 55 },
+                { typeof(global::SharedData.SubUnionType1), 56 },
+                { typeof(global::SharedData.SubUnionType2), 57 },
+                { typeof(global::SharedData.UnVersionBlockTest), 58 },
+                { typeof(global::SharedData.Vector2), 59 },
+                { typeof(global::SharedData.Vector3Like), 60 },
+                { typeof(global::SharedData.VectorLike2), 61 },
+                { typeof(global::SharedData.Version0), 62 },
+                { typeof(global::SharedData.Version1), 63 },
+                { typeof(global::SharedData.Version2), 64 },
+                { typeof(global::SharedData.VersionBlockTest), 65 },
+                { typeof(global::SharedData.VersioningUnion), 66 },
+                { typeof(global::SharedData.WithIndexer), 67 },
+                { typeof(global::SimpleModel), 68 },
+                { typeof(global::StampMessageBody), 69 },
+                { typeof(global::TextMessageBody), 70 },
             };
         }
 
@@ -158,42 +164,48 @@ namespace MessagePack.Resolvers
                 case 26: return new MessagePack.Formatters.SharedData.Callback1_2Formatter();
                 case 27: return new MessagePack.Formatters.SharedData.Callback2Formatter();
                 case 28: return new MessagePack.Formatters.SharedData.Callback2_2Formatter();
-                case 29: return new MessagePack.Formatters.SharedData.Empty1Formatter();
-                case 30: return new MessagePack.Formatters.SharedData.Empty2Formatter();
-                case 31: return new MessagePack.Formatters.SharedData.EmptyClassFormatter();
-                case 32: return new MessagePack.Formatters.SharedData.EmptyStructFormatter();
-                case 33: return new MessagePack.Formatters.SharedData.FirstSimpleDataFormatter();
-                case 34: return new MessagePack.Formatters.SharedData.FooClassFormatter();
-                case 35: return new MessagePack.Formatters.SharedData.HolderV0Formatter();
-                case 36: return new MessagePack.Formatters.SharedData.HolderV1Formatter();
-                case 37: return new MessagePack.Formatters.SharedData.HolderV2Formatter();
-                case 38: return new MessagePack.Formatters.SharedData.MyClassFormatter();
-                case 39: return new MessagePack.Formatters.SharedData.MySubUnion1Formatter();
-                case 40: return new MessagePack.Formatters.SharedData.MySubUnion2Formatter();
-                case 41: return new MessagePack.Formatters.SharedData.MySubUnion3Formatter();
-                case 42: return new MessagePack.Formatters.SharedData.MySubUnion4Formatter();
-                case 43: return new MessagePack.Formatters.SharedData.NestParent_NestContractFormatter();
-                case 44: return new MessagePack.Formatters.SharedData.NonEmpty1Formatter();
-                case 45: return new MessagePack.Formatters.SharedData.NonEmpty2Formatter();
-                case 46: return new MessagePack.Formatters.SharedData.SimpleIntKeyDataFormatter();
-                case 47: return new MessagePack.Formatters.SharedData.SimpleStringKeyDataFormatter();
-                case 48: return new MessagePack.Formatters.SharedData.SimpleStructIntKeyDataFormatter();
-                case 49: return new MessagePack.Formatters.SharedData.SimpleStructStringKeyDataFormatter();
-                case 50: return new MessagePack.Formatters.SharedData.SubUnionType1Formatter();
-                case 51: return new MessagePack.Formatters.SharedData.SubUnionType2Formatter();
-                case 52: return new MessagePack.Formatters.SharedData.UnVersionBlockTestFormatter();
-                case 53: return new MessagePack.Formatters.SharedData.Vector2Formatter();
-                case 54: return new MessagePack.Formatters.SharedData.Vector3LikeFormatter();
-                case 55: return new MessagePack.Formatters.SharedData.VectorLike2Formatter();
-                case 56: return new MessagePack.Formatters.SharedData.Version0Formatter();
-                case 57: return new MessagePack.Formatters.SharedData.Version1Formatter();
-                case 58: return new MessagePack.Formatters.SharedData.Version2Formatter();
-                case 59: return new MessagePack.Formatters.SharedData.VersionBlockTestFormatter();
-                case 60: return new MessagePack.Formatters.SharedData.VersioningUnionFormatter();
-                case 61: return new MessagePack.Formatters.SharedData.WithIndexerFormatter();
-                case 62: return new MessagePack.Formatters.SimpleModelFormatter();
-                case 63: return new MessagePack.Formatters.StampMessageBodyFormatter();
-                case 64: return new MessagePack.Formatters.TextMessageBodyFormatter();
+                case 29: return new MessagePack.Formatters.SharedData.DefaultValueIntKeyClassWithExplicitConstructorFormatter();
+                case 30: return new MessagePack.Formatters.SharedData.DefaultValueIntKeyClassWithoutExplicitConstructorFormatter();
+                case 31: return new MessagePack.Formatters.SharedData.DefaultValueIntKeyStructWithExplicitConstructorFormatter();
+                case 32: return new MessagePack.Formatters.SharedData.DefaultValueStringKeyClassWithExplicitConstructorFormatter();
+                case 33: return new MessagePack.Formatters.SharedData.DefaultValueStringKeyClassWithoutExplicitConstructorFormatter();
+                case 34: return new MessagePack.Formatters.SharedData.DefaultValueStringKeyStructWithExplicitConstructorFormatter();
+                case 35: return new MessagePack.Formatters.SharedData.Empty1Formatter();
+                case 36: return new MessagePack.Formatters.SharedData.Empty2Formatter();
+                case 37: return new MessagePack.Formatters.SharedData.EmptyClassFormatter();
+                case 38: return new MessagePack.Formatters.SharedData.EmptyStructFormatter();
+                case 39: return new MessagePack.Formatters.SharedData.FirstSimpleDataFormatter();
+                case 40: return new MessagePack.Formatters.SharedData.FooClassFormatter();
+                case 41: return new MessagePack.Formatters.SharedData.HolderV0Formatter();
+                case 42: return new MessagePack.Formatters.SharedData.HolderV1Formatter();
+                case 43: return new MessagePack.Formatters.SharedData.HolderV2Formatter();
+                case 44: return new MessagePack.Formatters.SharedData.MyClassFormatter();
+                case 45: return new MessagePack.Formatters.SharedData.MySubUnion1Formatter();
+                case 46: return new MessagePack.Formatters.SharedData.MySubUnion2Formatter();
+                case 47: return new MessagePack.Formatters.SharedData.MySubUnion3Formatter();
+                case 48: return new MessagePack.Formatters.SharedData.MySubUnion4Formatter();
+                case 49: return new MessagePack.Formatters.SharedData.NestParent_NestContractFormatter();
+                case 50: return new MessagePack.Formatters.SharedData.NonEmpty1Formatter();
+                case 51: return new MessagePack.Formatters.SharedData.NonEmpty2Formatter();
+                case 52: return new MessagePack.Formatters.SharedData.SimpleIntKeyDataFormatter();
+                case 53: return new MessagePack.Formatters.SharedData.SimpleStringKeyDataFormatter();
+                case 54: return new MessagePack.Formatters.SharedData.SimpleStructIntKeyDataFormatter();
+                case 55: return new MessagePack.Formatters.SharedData.SimpleStructStringKeyDataFormatter();
+                case 56: return new MessagePack.Formatters.SharedData.SubUnionType1Formatter();
+                case 57: return new MessagePack.Formatters.SharedData.SubUnionType2Formatter();
+                case 58: return new MessagePack.Formatters.SharedData.UnVersionBlockTestFormatter();
+                case 59: return new MessagePack.Formatters.SharedData.Vector2Formatter();
+                case 60: return new MessagePack.Formatters.SharedData.Vector3LikeFormatter();
+                case 61: return new MessagePack.Formatters.SharedData.VectorLike2Formatter();
+                case 62: return new MessagePack.Formatters.SharedData.Version0Formatter();
+                case 63: return new MessagePack.Formatters.SharedData.Version1Formatter();
+                case 64: return new MessagePack.Formatters.SharedData.Version2Formatter();
+                case 65: return new MessagePack.Formatters.SharedData.VersionBlockTestFormatter();
+                case 66: return new MessagePack.Formatters.SharedData.VersioningUnionFormatter();
+                case 67: return new MessagePack.Formatters.SharedData.WithIndexerFormatter();
+                case 68: return new MessagePack.Formatters.SimpleModelFormatter();
+                case 69: return new MessagePack.Formatters.StampMessageBodyFormatter();
+                case 70: return new MessagePack.Formatters.TextMessageBodyFormatter();
                 default: return null;
             }
         }
@@ -935,14 +947,14 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -950,8 +962,6 @@ namespace MessagePack.Formatters.Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad
                 }
             }
 
-            var ____result = new global::Abcdefg.Efcdigjl.Ateatatea.Hgfagfafgad.TnonodsfarnoiuAtatqaga();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -1023,38 +1033,32 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(int[]);
-            var __MyProperty1__ = default(int[,]);
-            var __MyProperty2__ = default(global::GlobalMyEnum[,]);
-            var __MyProperty3__ = default(int[,,]);
-            var __MyProperty4__ = default(int[,,,]);
-            var __MyProperty5__ = default(global::GlobalMyEnum[]);
-            var __MyProperty6__ = default(global::QuestMessageBody[]);
+            var ____result = new global::ArrayTestTest();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<int[,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<int[,]>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __MyProperty2__ = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty2 = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[,]>().Deserialize(ref reader, options);
                         break;
                     case 3:
-                        __MyProperty3__ = formatterResolver.GetFormatterWithVerify<int[,,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty3 = formatterResolver.GetFormatterWithVerify<int[,,]>().Deserialize(ref reader, options);
                         break;
                     case 4:
-                        __MyProperty4__ = formatterResolver.GetFormatterWithVerify<int[,,,]>().Deserialize(ref reader, options);
+                        ____result.MyProperty4 = formatterResolver.GetFormatterWithVerify<int[,,,]>().Deserialize(ref reader, options);
                         break;
                     case 5:
-                        __MyProperty5__ = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[]>().Deserialize(ref reader, options);
+                        ____result.MyProperty5 = formatterResolver.GetFormatterWithVerify<global::GlobalMyEnum[]>().Deserialize(ref reader, options);
                         break;
                     case 6:
-                        __MyProperty6__ = formatterResolver.GetFormatterWithVerify<global::QuestMessageBody[]>().Deserialize(ref reader, options);
+                        ____result.MyProperty6 = formatterResolver.GetFormatterWithVerify<global::QuestMessageBody[]>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1062,14 +1066,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::ArrayTestTest();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
-            ____result.MyProperty4 = __MyProperty4__;
-            ____result.MyProperty5 = __MyProperty5__;
-            ____result.MyProperty6 = __MyProperty6__;
             reader.Depth--;
             return ____result;
         }
@@ -1099,14 +1095,14 @@ namespace MessagePack.Formatters
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::GlobalMan();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -1114,8 +1110,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::GlobalMan();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -1150,26 +1144,23 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __UserId__ = default(int);
-            var __RoomId__ = default(int);
-            var __PostTime__ = default(global::System.DateTime);
-            var __Body__ = default(global::IMessageBody);
+            var ____result = new global::Message();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __UserId__ = reader.ReadInt32();
+                        ____result.UserId = reader.ReadInt32();
                         break;
                     case 1:
-                        __RoomId__ = reader.ReadInt32();
+                        ____result.RoomId = reader.ReadInt32();
                         break;
                     case 2:
-                        __PostTime__ = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
+                        ____result.PostTime = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
                         break;
                     case 3:
-                        __Body__ = formatterResolver.GetFormatterWithVerify<global::IMessageBody>().Deserialize(ref reader, options);
+                        ____result.Body = formatterResolver.GetFormatterWithVerify<global::IMessageBody>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1177,11 +1168,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::Message();
-            ____result.UserId = __UserId__;
-            ____result.RoomId = __RoomId__;
-            ____result.PostTime = __PostTime__;
-            ____result.Body = __Body__;
             reader.Depth--;
             return ____result;
         }
@@ -1214,18 +1200,17 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __QuestId__ = default(int);
-            var __Text__ = default(string);
+            var ____result = new global::QuestMessageBody();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __QuestId__ = reader.ReadInt32();
+                        ____result.QuestId = reader.ReadInt32();
                         break;
                     case 1:
-                        __Text__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Text = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1233,9 +1218,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::QuestMessageBody();
-            ____result.QuestId = __QuestId__;
-            ____result.Text = __Text__;
             reader.Depth--;
             return ____result;
         }
@@ -1265,14 +1247,14 @@ namespace MessagePack.Formatters
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __StampId__ = default(int);
+            var ____result = new global::StampMessageBody();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __StampId__ = reader.ReadInt32();
+                        ____result.StampId = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -1280,8 +1262,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::StampMessageBody();
-            ____result.StampId = __StampId__;
             reader.Depth--;
             return ____result;
         }
@@ -1313,14 +1293,14 @@ namespace MessagePack.Formatters
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Text__ = default(string);
+            var ____result = new global::TextMessageBody();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Text__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Text = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1328,8 +1308,6 @@ namespace MessagePack.Formatters
                 }
             }
 
-            var ____result = new global::TextMessageBody();
-            ____result.Text = __Text__;
             reader.Depth--;
             return ____result;
         }
@@ -1366,10 +1344,8 @@ namespace MessagePack.Formatters
 
 namespace MessagePack.Formatters
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class ComplexModelFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::ComplexModel>
     {
@@ -1394,7 +1370,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(6);
             writer.WriteRaw(GetSpan_AdditionalProperty());
             formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IDictionary<string, string>>().Serialize(ref writer, value.AdditionalProperty, options);
@@ -1418,18 +1394,13 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __AdditionalProperty__ = default(global::System.Collections.Generic.IDictionary<string, string>);
-            var __CreatedOn__ = default(global::System.DateTimeOffset);
-            var __Id__ = default(global::System.Guid);
-            var __Name__ = default(string);
-            var __UpdatedOn__ = default(global::System.DateTimeOffset);
-            var __SimpleModels__ = default(global::System.Collections.Generic.IList<global::SimpleModel>);
+            var ____result = new global::ComplexModel();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -1439,7 +1410,7 @@ namespace MessagePack.Formatters
                     case 18:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_AdditionalProperty().Slice(1))) { goto FAIL; }
 
-                        __AdditionalProperty__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IDictionary<string, string>>().Deserialize(ref reader, options);
+                        reader.Skip();
                         continue;
                     case 9:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
@@ -1448,42 +1419,34 @@ namespace MessagePack.Formatters
                             case 5720808977192022595UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __CreatedOn__ = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
+                                ____result.CreatedOn = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
                                 continue;
 
                             case 5720808977191956565UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __UpdatedOn__ = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
+                                ____result.UpdatedOn = formatterResolver.GetFormatterWithVerify<global::System.DateTimeOffset>().Deserialize(ref reader, options);
                                 continue;
 
                         }
                     case 2:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 25673UL) { goto FAIL; }
 
-                        __Id__ = formatterResolver.GetFormatterWithVerify<global::System.Guid>().Deserialize(ref reader, options);
+                        ____result.Id = formatterResolver.GetFormatterWithVerify<global::System.Guid>().Deserialize(ref reader, options);
                         continue;
                     case 4:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 1701667150UL) { goto FAIL; }
 
-                        __Name__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Name = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         continue;
                     case 12:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_SimpleModels().Slice(1))) { goto FAIL; }
 
-                        __SimpleModels__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.IList<global::SimpleModel>>().Deserialize(ref reader, options);
+                        reader.Skip();
                         continue;
 
                 }
             }
-
-            var ____result = new global::ComplexModel()
-            {
-                CreatedOn = __CreatedOn__,
-                Id = __Id__,
-                Name = __Name__,
-                UpdatedOn = __UpdatedOn__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -1513,7 +1476,7 @@ namespace MessagePack.Formatters
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(6);
             writer.WriteRaw(GetSpan_Id());
             writer.Write(value.Id);
@@ -1537,18 +1500,13 @@ namespace MessagePack.Formatters
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __Id__ = default(int);
-            var __Name__ = default(string);
-            var __CreatedOn__ = default(global::System.DateTime);
-            var __Precision__ = default(int);
-            var __Money__ = default(decimal);
-            var __Amount__ = default(long);
+            var ____result = new global::SimpleModel();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -1558,12 +1516,12 @@ namespace MessagePack.Formatters
                     case 2:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 25673UL) { goto FAIL; }
 
-                        __Id__ = reader.ReadInt32();
+                        ____result.Id = reader.ReadInt32();
                         continue;
                     case 4:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 1701667150UL) { goto FAIL; }
 
-                        __Name__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Name = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         continue;
                     case 9:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
@@ -1572,38 +1530,29 @@ namespace MessagePack.Formatters
                             case 5720808977192022595UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __CreatedOn__ = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
+                                ____result.CreatedOn = formatterResolver.GetFormatterWithVerify<global::System.DateTime>().Deserialize(ref reader, options);
                                 continue;
 
                             case 8028074707240972880UL:
                                 if (stringKey[0] != 110) { goto FAIL; }
 
-                                __Precision__ = reader.ReadInt32();
+                                ____result.Precision = reader.ReadInt32();
                                 continue;
 
                         }
                     case 5:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 521392779085UL) { goto FAIL; }
 
-                        __Money__ = formatterResolver.GetFormatterWithVerify<decimal>().Deserialize(ref reader, options);
+                        ____result.Money = formatterResolver.GetFormatterWithVerify<decimal>().Deserialize(ref reader, options);
                         continue;
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 128017765461313UL) { goto FAIL; }
 
-                        __Amount__ = reader.ReadInt64();
+                        reader.Skip();
                         continue;
 
                 }
             }
-
-            var ____result = new global::SimpleModel()
-            {
-                Id = __Id__,
-                Name = __Name__,
-                CreatedOn = __CreatedOn__,
-                Precision = __Precision__,
-                Money = __Money__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -1629,10 +1578,8 @@ namespace MessagePack.Formatters
 
 namespace MessagePack.Formatters.PerfBenchmarkDotNet
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class StringKeySerializerTargetFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::PerfBenchmarkDotNet.StringKeySerializerTarget>
     {
@@ -1693,19 +1640,11 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
-            var __MyProperty4__ = default(int);
-            var __MyProperty5__ = default(int);
-            var __MyProperty6__ = default(int);
-            var __MyProperty7__ = default(int);
-            var __MyProperty8__ = default(int);
-            var __MyProperty9__ = default(int);
+            var ____result = new global::PerfBenchmarkDotNet.StringKeySerializerTarget();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -1721,31 +1660,31 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
                                 {
                                     default: goto FAIL;
                                     case 3242356UL:
-                                        __MyProperty1__ = reader.ReadInt32();
+                                        ____result.MyProperty1 = reader.ReadInt32();
                                         continue;
                                     case 3307892UL:
-                                        __MyProperty2__ = reader.ReadInt32();
+                                        ____result.MyProperty2 = reader.ReadInt32();
                                         continue;
                                     case 3373428UL:
-                                        __MyProperty3__ = reader.ReadInt32();
+                                        ____result.MyProperty3 = reader.ReadInt32();
                                         continue;
                                     case 3438964UL:
-                                        __MyProperty4__ = reader.ReadInt32();
+                                        ____result.MyProperty4 = reader.ReadInt32();
                                         continue;
                                     case 3504500UL:
-                                        __MyProperty5__ = reader.ReadInt32();
+                                        ____result.MyProperty5 = reader.ReadInt32();
                                         continue;
                                     case 3570036UL:
-                                        __MyProperty6__ = reader.ReadInt32();
+                                        ____result.MyProperty6 = reader.ReadInt32();
                                         continue;
                                     case 3635572UL:
-                                        __MyProperty7__ = reader.ReadInt32();
+                                        ____result.MyProperty7 = reader.ReadInt32();
                                         continue;
                                     case 3701108UL:
-                                        __MyProperty8__ = reader.ReadInt32();
+                                        ____result.MyProperty8 = reader.ReadInt32();
                                         continue;
                                     case 3766644UL:
-                                        __MyProperty9__ = reader.ReadInt32();
+                                        ____result.MyProperty9 = reader.ReadInt32();
                                         continue;
                                 }
 
@@ -1753,19 +1692,6 @@ namespace MessagePack.Formatters.PerfBenchmarkDotNet
 
                 }
             }
-
-            var ____result = new global::PerfBenchmarkDotNet.StringKeySerializerTarget()
-            {
-                MyProperty1 = __MyProperty1__,
-                MyProperty2 = __MyProperty2__,
-                MyProperty3 = __MyProperty3__,
-                MyProperty4 = __MyProperty4__,
-                MyProperty5 = __MyProperty5__,
-                MyProperty6 = __MyProperty6__,
-                MyProperty7 = __MyProperty7__,
-                MyProperty8 = __MyProperty8__,
-                MyProperty9 = __MyProperty9__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -1833,74 +1759,59 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(int);
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
-            var __MyProperty4__ = default(int);
-            var __MyProperty5__ = default(int);
-            var __MyProperty6__ = default(int);
-            var __MyProperty7__ = default(int);
-            var __MyProperty8__ = default(int);
-            var __MyProvperty9__ = default(int);
-            var __MyProperty10__ = default(int);
-            var __MyProperty11__ = default(int);
-            var __MyPropverty12__ = default(int);
-            var __MyPropevrty13__ = default(int);
-            var __MyProperty14__ = default(int);
-            var __MyProperty15__ = default(int);
+            var ____result = new global::SharedData.ArrayOptimizeClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = reader.ReadInt32();
+                        ____result.MyProperty0 = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 2:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 3:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     case 4:
-                        __MyProperty4__ = reader.ReadInt32();
+                        ____result.MyProperty4 = reader.ReadInt32();
                         break;
                     case 5:
-                        __MyProperty5__ = reader.ReadInt32();
+                        ____result.MyProperty5 = reader.ReadInt32();
                         break;
                     case 6:
-                        __MyProperty6__ = reader.ReadInt32();
+                        ____result.MyProperty6 = reader.ReadInt32();
                         break;
                     case 7:
-                        __MyProperty7__ = reader.ReadInt32();
+                        ____result.MyProperty7 = reader.ReadInt32();
                         break;
                     case 8:
-                        __MyProperty8__ = reader.ReadInt32();
+                        ____result.MyProperty8 = reader.ReadInt32();
                         break;
                     case 9:
-                        __MyProvperty9__ = reader.ReadInt32();
+                        ____result.MyProvperty9 = reader.ReadInt32();
                         break;
                     case 10:
-                        __MyProperty10__ = reader.ReadInt32();
+                        ____result.MyProperty10 = reader.ReadInt32();
                         break;
                     case 11:
-                        __MyProperty11__ = reader.ReadInt32();
+                        ____result.MyProperty11 = reader.ReadInt32();
                         break;
                     case 12:
-                        __MyPropverty12__ = reader.ReadInt32();
+                        ____result.MyPropverty12 = reader.ReadInt32();
                         break;
                     case 13:
-                        __MyPropevrty13__ = reader.ReadInt32();
+                        ____result.MyPropevrty13 = reader.ReadInt32();
                         break;
                     case 14:
-                        __MyProperty14__ = reader.ReadInt32();
+                        ____result.MyProperty14 = reader.ReadInt32();
                         break;
                     case 15:
-                        __MyProperty15__ = reader.ReadInt32();
+                        ____result.MyProperty15 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -1908,23 +1819,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.ArrayOptimizeClass();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
-            ____result.MyProperty4 = __MyProperty4__;
-            ____result.MyProperty5 = __MyProperty5__;
-            ____result.MyProperty6 = __MyProperty6__;
-            ____result.MyProperty7 = __MyProperty7__;
-            ____result.MyProperty8 = __MyProperty8__;
-            ____result.MyProvperty9 = __MyProvperty9__;
-            ____result.MyProperty10 = __MyProperty10__;
-            ____result.MyProperty11 = __MyProperty11__;
-            ____result.MyPropverty12 = __MyPropverty12__;
-            ____result.MyPropevrty13 = __MyPropevrty13__;
-            ____result.MyProperty14 = __MyProperty14__;
-            ____result.MyProperty15 = __MyProperty15__;
             reader.Depth--;
             return ____result;
         }
@@ -1956,14 +1850,14 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __OPQ__ = default(string);
+            var ____result = new global::SharedData.BarClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __OPQ__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.OPQ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -1971,8 +1865,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.BarClass();
-            ____result.OPQ = __OPQ__;
             reader.Depth--;
             return ____result;
         }
@@ -2019,7 +1911,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback1(__X__);
-            ____result.X = __X__;
             ____result.OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -2067,8 +1958,189 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Callback1_2(__X__);
-            ____result.X = __X__;
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueIntKeyClassWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
+            writer.WriteArrayHeader(4);
+            writer.Write(value.Prop1);
+            writer.Write(value.Prop2);
+            formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop3, options);
+            formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.Prop4, options);
+        }
+
+        public global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
+            var length = reader.ReadArrayHeader();
+            var __Prop1__ = default(int);
+            var __Prop2__ = default(int);
+            var __Prop3__ = default(string);
+            var __Prop4__ = default(string);
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        __Prop1__ = reader.ReadInt32();
+                        break;
+                    case 1:
+                        __Prop2__ = reader.ReadInt32();
+                        break;
+                    case 2:
+                        __Prop3__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        break;
+                    case 3:
+                        __Prop4__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueIntKeyClassWithExplicitConstructor(__Prop1__);
+            if (length <= 1)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop2 = __Prop2__;
+            if (length <= 2)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop3 = __Prop3__;
+            if (length <= 3)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop4 = __Prop4__;
+
+        MEMBER_ASSIGNMENT_END:
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueIntKeyClassWithoutExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteArrayHeader(2);
+            writer.Write(value.Prop1);
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadArrayHeader();
+            var ____result = new global::SharedData.DefaultValueIntKeyClassWithoutExplicitConstructor();
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        ____result.Prop1 = reader.ReadInt32();
+                        break;
+                    case 1:
+                        ____result.Prop2 = reader.ReadInt32();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueIntKeyStructWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor>
+    {
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            writer.WriteArrayHeader(2);
+            writer.Write(value.Prop1);
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadArrayHeader();
+            var __Prop1__ = default(int);
+            var __Prop2__ = default(int);
+
+            for (int i = 0; i < length; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        __Prop1__ = reader.ReadInt32();
+                        break;
+                    case 1:
+                        __Prop2__ = reader.ReadInt32();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueIntKeyStructWithExplicitConstructor(__Prop1__);
+            if (length <= 1)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
+            ____result.Prop2 = __Prop2__;
+
+        MEMBER_ASSIGNMENT_END:
             reader.Depth--;
             return ____result;
         }
@@ -2176,22 +2248,8 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            options.Security.DepthStep(ref reader);
-            var length = reader.ReadArrayHeader();
-
-            for (int i = 0; i < length; i++)
-            {
-                switch (i)
-                {
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            var ____result = new global::SharedData.Empty1();
-            reader.Depth--;
-            return ____result;
+            reader.Skip();
+            return new global::SharedData.Empty1();
         }
     }
 
@@ -2216,22 +2274,8 @@ namespace MessagePack.Formatters.SharedData
                 return null;
             }
 
-            options.Security.DepthStep(ref reader);
-            var length = reader.ReadArrayHeader();
-
-            for (int i = 0; i < length; i++)
-            {
-                switch (i)
-                {
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            var ____result = new global::SharedData.EmptyClass();
-            reader.Depth--;
-            return ____result;
+            reader.Skip();
+            return new global::SharedData.EmptyClass();
         }
     }
 
@@ -2250,22 +2294,8 @@ namespace MessagePack.Formatters.SharedData
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
             }
 
-            options.Security.DepthStep(ref reader);
-            var length = reader.ReadArrayHeader();
-
-            for (int i = 0; i < length; i++)
-            {
-                switch (i)
-                {
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            var ____result = new global::SharedData.EmptyStruct();
-            reader.Depth--;
-            return ____result;
+            reader.Skip();
+            return new global::SharedData.EmptyStruct();
         }
     }
 
@@ -2297,22 +2327,20 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Prop1__ = default(int);
-            var __Prop2__ = default(string);
-            var __Prop3__ = default(int);
+            var ____result = new global::SharedData.FirstSimpleData();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Prop1__ = reader.ReadInt32();
+                        ____result.Prop1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __Prop2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Prop2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __Prop3__ = reader.ReadInt32();
+                        ____result.Prop3 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2320,10 +2348,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.FirstSimpleData();
-            ____result.Prop1 = __Prop1__;
-            ____result.Prop2 = __Prop2__;
-            ____result.Prop3 = __Prop3__;
             reader.Depth--;
             return ____result;
         }
@@ -2353,14 +2377,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __XYZ__ = default(int);
+            var ____result = new global::SharedData.FooClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __XYZ__ = reader.ReadInt32();
+                        ____result.XYZ = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2368,8 +2392,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.FooClass();
-            ____result.XYZ = __XYZ__;
             reader.Depth--;
             return ____result;
         }
@@ -2402,18 +2424,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(T1);
-            var __MyProperty1__ = default(T2);
+            var ____result = new global::SharedData.GenericClass<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2421,9 +2442,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.GenericClass<T1, T2>();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -2458,18 +2476,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(T1);
-            var __Comparer__ = default(T2);
+            var ____result = new global::SharedData.GenericConstrainedClassIntKey<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __Comparer__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.Comparer = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2477,9 +2494,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.GenericConstrainedClassIntKey<T1, T2>();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.Comparer = __Comparer__;
             reader.Depth--;
             return ____result;
         }
@@ -2508,18 +2522,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(T1);
-            var __Comparer__ = default(T2);
+            var ____result = new global::SharedData.GenericConstrainedStructIntKey<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __Comparer__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.Comparer = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2527,9 +2540,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.GenericConstrainedStructIntKey<T1, T2>();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.Comparer = __Comparer__;
             reader.Depth--;
             return ____result;
         }
@@ -2556,18 +2566,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty0__ = default(T1);
-            var __MyProperty1__ = default(T2);
+            var ____result = new global::SharedData.GenericStruct<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -2575,9 +2584,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.GenericStruct<T1, T2>();
-            ____result.MyProperty0 = __MyProperty0__;
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -2610,18 +2616,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(global::SharedData.Version0);
-            var __After__ = default(int);
+            var ____result = new global::SharedData.HolderV0();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<global::SharedData.Version0>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __After__ = reader.ReadInt32();
+                        ____result.After = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2629,9 +2634,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.HolderV0();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.After = __After__;
             reader.Depth--;
             return ____result;
         }
@@ -2664,18 +2666,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(global::SharedData.Version1);
-            var __After__ = default(int);
+            var ____result = new global::SharedData.HolderV1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<global::SharedData.Version1>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __After__ = reader.ReadInt32();
+                        ____result.After = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2683,9 +2684,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.HolderV1();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.After = __After__;
             reader.Depth--;
             return ____result;
         }
@@ -2718,18 +2716,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(global::SharedData.Version2);
-            var __After__ = default(int);
+            var ____result = new global::SharedData.HolderV2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Deserialize(ref reader, options);
+                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<global::SharedData.Version2>().Deserialize(ref reader, options);
                         break;
                     case 1:
-                        __After__ = reader.ReadInt32();
+                        ____result.After = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2737,9 +2734,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.HolderV2();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.After = __After__;
             reader.Depth--;
             return ____result;
         }
@@ -2771,22 +2765,20 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
+            var ____result = new global::SharedData.MyClass();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 2:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2794,10 +2786,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MyClass();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
             reader.Depth--;
             return ____result;
         }
@@ -2830,14 +2818,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __One__ = default(int);
+            var ____result = new global::SharedData.MySubUnion1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __One__ = reader.ReadInt32();
+                        ____result.One = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2845,8 +2833,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion1();
-            ____result.One = __One__;
             reader.Depth--;
             return ____result;
         }
@@ -2875,14 +2861,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __Two__ = default(int);
+            var ____result = new global::SharedData.MySubUnion2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 5:
-                        __Two__ = reader.ReadInt32();
+                        ____result.Two = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2890,8 +2876,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion2();
-            ____result.Two = __Two__;
             reader.Depth--;
             return ____result;
         }
@@ -2923,14 +2907,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __Three__ = default(int);
+            var ____result = new global::SharedData.MySubUnion3();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 2:
-                        __Three__ = reader.ReadInt32();
+                        ____result.Three = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2938,8 +2922,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion3();
-            ____result.Three = __Three__;
             reader.Depth--;
             return ____result;
         }
@@ -2970,14 +2952,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __Four__ = default(int);
+            var ____result = new global::SharedData.MySubUnion4();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 7:
-                        __Four__ = reader.ReadInt32();
+                        ____result.Four = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -2985,8 +2967,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.MySubUnion4();
-            ____result.Four = __Four__;
             reader.Depth--;
             return ____result;
         }
@@ -3016,14 +2996,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.NestParent.NestContract();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3031,8 +3011,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.NestParent.NestContract();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -3062,14 +3040,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.NonEmpty1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3077,8 +3055,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.NonEmpty1();
-            ____result.MyProperty = __MyProperty__;
             reader.Depth--;
             return ____result;
         }
@@ -3116,38 +3092,32 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Prop1__ = default(int);
-            var __Prop2__ = default(global::SharedData.ByteEnum);
-            var __Prop3__ = default(string);
-            var __Prop4__ = default(global::SharedData.SimpleStringKeyData);
-            var __Prop5__ = default(global::SharedData.SimpleStructIntKeyData);
-            var __Prop6__ = default(global::SharedData.SimpleStructStringKeyData);
-            var __BytesSpecial__ = default(byte[]);
+            var ____result = new global::SharedData.SimpleIntKeyData();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Prop1__ = reader.ReadInt32();
+                        ____result.Prop1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __Prop2__ = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
+                        ____result.Prop2 = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __Prop3__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Prop3 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     case 3:
-                        __Prop4__ = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStringKeyData>().Deserialize(ref reader, options);
+                        ____result.Prop4 = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStringKeyData>().Deserialize(ref reader, options);
                         break;
                     case 4:
-                        __Prop5__ = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructIntKeyData>().Deserialize(ref reader, options);
+                        ____result.Prop5 = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructIntKeyData>().Deserialize(ref reader, options);
                         break;
                     case 5:
-                        __Prop6__ = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructStringKeyData>().Deserialize(ref reader, options);
+                        ____result.Prop6 = formatterResolver.GetFormatterWithVerify<global::SharedData.SimpleStructStringKeyData>().Deserialize(ref reader, options);
                         break;
                     case 6:
-                        __BytesSpecial__ = reader.ReadBytes()?.ToArray();
+                        ____result.BytesSpecial = reader.ReadBytes()?.ToArray();
                         break;
                     default:
                         reader.Skip();
@@ -3155,14 +3125,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SimpleIntKeyData();
-            ____result.Prop1 = __Prop1__;
-            ____result.Prop2 = __Prop2__;
-            ____result.Prop3 = __Prop3__;
-            ____result.Prop4 = __Prop4__;
-            ____result.Prop5 = __Prop5__;
-            ____result.Prop6 = __Prop6__;
-            ____result.BytesSpecial = __BytesSpecial__;
             reader.Depth--;
             return ____result;
         }
@@ -3188,22 +3150,20 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __X__ = default(int);
-            var __Y__ = default(int);
-            var __BytesSpecial__ = default(byte[]);
+            var ____result = new global::SharedData.SimpleStructIntKeyData();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __X__ = reader.ReadInt32();
+                        ____result.X = reader.ReadInt32();
                         break;
                     case 1:
-                        __Y__ = reader.ReadInt32();
+                        ____result.Y = reader.ReadInt32();
                         break;
                     case 2:
-                        __BytesSpecial__ = reader.ReadBytes()?.ToArray();
+                        ____result.BytesSpecial = reader.ReadBytes()?.ToArray();
                         break;
                     default:
                         reader.Skip();
@@ -3211,10 +3171,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SimpleStructIntKeyData();
-            ____result.X = __X__;
-            ____result.Y = __Y__;
-            ____result.BytesSpecial = __BytesSpecial__;
             reader.Depth--;
             return ____result;
         }
@@ -3245,18 +3201,17 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.SubUnionType1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3264,9 +3219,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SubUnionType1();
-            ____result.MyProperty = __MyProperty__;
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -3297,18 +3249,17 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty2__ = default(int);
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.SubUnionType2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 1:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3316,9 +3267,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.SubUnionType2();
-            ____result.MyProperty = __MyProperty__;
-            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3350,18 +3298,17 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
-            var __MyProperty2__ = default(int);
+            var ____result = new global::SharedData.UnVersionBlockTest();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 2:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3369,9 +3316,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.UnVersionBlockTest();
-            ____result.MyProperty = __MyProperty__;
-            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3465,9 +3409,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.Vector3Like(__x__, __y__, __z__);
-            ____result.x = __x__;
-            ____result.y = __y__;
-            ____result.z = __z__;
             reader.Depth--;
             return ____result;
         }
@@ -3512,8 +3453,6 @@ namespace MessagePack.Formatters.SharedData
             }
 
             var ____result = new global::SharedData.VectorLike2(__x__, __y__);
-            ____result.x = __x__;
-            ____result.y = __y__;
             reader.Depth--;
             return ____result;
         }
@@ -3546,14 +3485,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
+            var ____result = new global::SharedData.Version0();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3561,8 +3500,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Version0();
-            ____result.MyProperty1 = __MyProperty1__;
             reader.Depth--;
             return ____result;
         }
@@ -3597,22 +3534,20 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
+            var ____result = new global::SharedData.Version1();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 4:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 5:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3620,10 +3555,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Version1();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
             reader.Depth--;
             return ____result;
         }
@@ -3660,26 +3591,23 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __MyProperty1__ = default(int);
-            var __MyProperty2__ = default(int);
-            var __MyProperty3__ = default(int);
-            var __MyProperty5__ = default(int);
+            var ____result = new global::SharedData.Version2();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 3:
-                        __MyProperty1__ = reader.ReadInt32();
+                        ____result.MyProperty1 = reader.ReadInt32();
                         break;
                     case 4:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     case 5:
-                        __MyProperty3__ = reader.ReadInt32();
+                        ____result.MyProperty3 = reader.ReadInt32();
                         break;
                     case 7:
-                        __MyProperty5__ = reader.ReadInt32();
+                        ____result.MyProperty5 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3687,11 +3615,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Version2();
-            ____result.MyProperty1 = __MyProperty1__;
-            ____result.MyProperty2 = __MyProperty2__;
-            ____result.MyProperty3 = __MyProperty3__;
-            ____result.MyProperty5 = __MyProperty5__;
             reader.Depth--;
             return ____result;
         }
@@ -3725,22 +3648,20 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __MyProperty__ = default(int);
-            var __UnknownBlock__ = default(global::SharedData.MyClass);
-            var __MyProperty2__ = default(int);
+            var ____result = new global::SharedData.VersionBlockTest();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         break;
                     case 1:
-                        __UnknownBlock__ = formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Deserialize(ref reader, options);
+                        ____result.UnknownBlock = formatterResolver.GetFormatterWithVerify<global::SharedData.MyClass>().Deserialize(ref reader, options);
                         break;
                     case 2:
-                        __MyProperty2__ = reader.ReadInt32();
+                        ____result.MyProperty2 = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3748,10 +3669,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.VersionBlockTest();
-            ____result.MyProperty = __MyProperty__;
-            ____result.UnknownBlock = __UnknownBlock__;
-            ____result.MyProperty2 = __MyProperty2__;
             reader.Depth--;
             return ____result;
         }
@@ -3788,14 +3705,14 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadArrayHeader();
-            var __FV__ = default(int);
+            var ____result = new global::SharedData.VersioningUnion();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 7:
-                        __FV__ = reader.ReadInt32();
+                        ____result.FV = reader.ReadInt32();
                         break;
                     default:
                         reader.Skip();
@@ -3803,8 +3720,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.VersioningUnion();
-            ____result.FV = __FV__;
             reader.Depth--;
             return ____result;
         }
@@ -3837,18 +3752,17 @@ namespace MessagePack.Formatters.SharedData
             options.Security.DepthStep(ref reader);
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
             var length = reader.ReadArrayHeader();
-            var __Data1__ = default(int);
-            var __Data2__ = default(string);
+            var ____result = new global::SharedData.WithIndexer();
 
             for (int i = 0; i < length; i++)
             {
                 switch (i)
                 {
                     case 0:
-                        __Data1__ = reader.ReadInt32();
+                        ____result.Data1 = reader.ReadInt32();
                         break;
                     case 1:
-                        __Data2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        ____result.Data2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                         break;
                     default:
                         reader.Skip();
@@ -3856,9 +3770,6 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.WithIndexer();
-            ____result.Data1 = __Data1__;
-            ____result.Data2 = __Data2__;
             reader.Depth--;
             return ____result;
         }
@@ -3895,10 +3806,8 @@ namespace MessagePack.Formatters.SharedData
 
 namespace MessagePack.Formatters.SharedData
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class Callback2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Callback2>
     {
@@ -3926,7 +3835,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3942,11 +3851,7 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Callback2(__X__)
-            {
-                X = __X__,
-            };
-
+            var ____result = new global::SharedData.Callback2(__X__);
             ____result.OnAfterDeserialize();
             reader.Depth--;
             return ____result;
@@ -3979,7 +3884,7 @@ namespace MessagePack.Formatters.SharedData
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -3995,12 +3900,206 @@ namespace MessagePack.Formatters.SharedData
                 }
             }
 
-            var ____result = new global::SharedData.Callback2_2(__X__)
-            {
-                X = __X__,
-            };
-
+            var ____result = new global::SharedData.Callback2_2(__X__);
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueStringKeyClassWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor>
+    {
+        // Prop1
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop1() => new byte[1 + 5] { 165, 80, 114, 111, 112, 49 };
+        // Prop2
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop2() => new byte[1 + 5] { 165, 80, 114, 111, 112, 50 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_Prop1());
+            writer.Write(value.Prop1);
+            writer.WriteRaw(GetSpan_Prop2());
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadMapHeader();
+            var __Prop1__ = default(int);
+            var __Prop2__IsInitialized = false;
+            var __Prop2__ = default(int);
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 212339749456UL:
+                                __Prop1__ = reader.ReadInt32();
+                                continue;
+                            case 216634716752UL:
+                                __Prop2__IsInitialized = true;
+                                __Prop2__ = reader.ReadInt32();
+                                continue;
+                        }
+
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueStringKeyClassWithExplicitConstructor(__Prop1__);
+            if (__Prop2__IsInitialized)
+            {
+                ____result.Prop2 = __Prop2__;
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueStringKeyClassWithoutExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor>
+    {
+        // Prop1
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop1() => new byte[1 + 5] { 165, 80, 114, 111, 112, 49 };
+        // Prop2
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop2() => new byte[1 + 5] { 165, 80, 114, 111, 112, 50 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_Prop1());
+            writer.Write(value.Prop1);
+            writer.WriteRaw(GetSpan_Prop2());
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadMapHeader();
+            var ____result = new global::SharedData.DefaultValueStringKeyClassWithoutExplicitConstructor();
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 212339749456UL:
+                                ____result.Prop1 = reader.ReadInt32();
+                                continue;
+                            case 216634716752UL:
+                                ____result.Prop2 = reader.ReadInt32();
+                                continue;
+                        }
+
+                }
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class DefaultValueStringKeyStructWithExplicitConstructorFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor>
+    {
+        // Prop1
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop1() => new byte[1 + 5] { 165, 80, 114, 111, 112, 49 };
+        // Prop2
+        private static global::System.ReadOnlySpan<byte> GetSpan_Prop2() => new byte[1 + 5] { 165, 80, 114, 111, 112, 50 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_Prop1());
+            writer.Write(value.Prop1);
+            writer.WriteRaw(GetSpan_Prop2());
+            writer.Write(value.Prop2);
+        }
+
+        public global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                throw new global::System.InvalidOperationException("typecode is null, struct not supported");
+            }
+
+            options.Security.DepthStep(ref reader);
+            var length = reader.ReadMapHeader();
+            var __Prop1__ = default(int);
+            var __Prop2__IsInitialized = false;
+            var __Prop2__ = default(int);
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 212339749456UL:
+                                __Prop1__ = reader.ReadInt32();
+                                continue;
+                            case 216634716752UL:
+                                __Prop2__IsInitialized = true;
+                                __Prop2__ = reader.ReadInt32();
+                                continue;
+                        }
+
+                }
+            }
+
+            var ____result = new global::SharedData.DefaultValueStringKeyStructWithExplicitConstructor(__Prop1__);
+            if (__Prop2__IsInitialized)
+            {
+                ____result.Prop2 = __Prop2__;
+            }
+
             reader.Depth--;
             return ____result;
         }
@@ -4008,7 +4107,6 @@ namespace MessagePack.Formatters.SharedData
 
     public sealed class Empty2Formatter : global::MessagePack.Formatters.IMessagePackFormatter<global::SharedData.Empty2>
     {
-
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.Empty2 value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -4050,7 +4148,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_MyProperty0());
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
@@ -4066,14 +4164,13 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __MyProperty0__ = default(T1);
-            var __Comparer__ = default(T2);
+            var ____result = new global::SharedData.GenericConstrainedClassStringKey<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -4083,22 +4180,16 @@ namespace MessagePack.Formatters.SharedData
                     case 11:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_MyProperty0().Slice(1))) { goto FAIL; }
 
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         continue;
                     case 8:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 8243120455795175235UL) { goto FAIL; }
 
-                        __Comparer__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.Comparer = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::SharedData.GenericConstrainedClassStringKey<T1, T2>()
-            {
-                MyProperty0 = __MyProperty0__,
-                Comparer = __Comparer__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -4116,7 +4207,7 @@ namespace MessagePack.Formatters.SharedData
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.GenericConstrainedStructStringKey<T1, T2> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_MyProperty0());
             formatterResolver.GetFormatterWithVerify<T1>().Serialize(ref writer, value.MyProperty0, options);
@@ -4132,14 +4223,13 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __MyProperty0__ = default(T1);
-            var __Comparer__ = default(T2);
+            var ____result = new global::SharedData.GenericConstrainedStructStringKey<T1, T2>();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -4149,22 +4239,16 @@ namespace MessagePack.Formatters.SharedData
                     case 11:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_MyProperty0().Slice(1))) { goto FAIL; }
 
-                        __MyProperty0__ = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
+                        ____result.MyProperty0 = formatterResolver.GetFormatterWithVerify<T1>().Deserialize(ref reader, options);
                         continue;
                     case 8:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 8243120455795175235UL) { goto FAIL; }
 
-                        __Comparer__ = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
+                        ____result.Comparer = formatterResolver.GetFormatterWithVerify<T2>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::SharedData.GenericConstrainedStructStringKey<T1, T2>()
-            {
-                MyProperty0 = __MyProperty0__,
-                Comparer = __Comparer__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -4198,11 +4282,11 @@ namespace MessagePack.Formatters.SharedData
 
             options.Security.DepthStep(ref reader);
             var length = reader.ReadMapHeader();
-            var __MyProperty__ = default(int);
+            var ____result = new global::SharedData.NonEmpty2();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -4212,16 +4296,11 @@ namespace MessagePack.Formatters.SharedData
                     case 10:
                         if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_MyProperty().Slice(1))) { goto FAIL; }
 
-                        __MyProperty__ = reader.ReadInt32();
+                        ____result.MyProperty = reader.ReadInt32();
                         continue;
 
                 }
             }
-
-            var ____result = new global::SharedData.NonEmpty2()
-            {
-                MyProperty = __MyProperty__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -4245,7 +4324,7 @@ namespace MessagePack.Formatters.SharedData
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
             writer.WriteRaw(GetSpan_Prop1());
             writer.Write(value.Prop1);
@@ -4263,15 +4342,13 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __Prop1__ = default(int);
-            var __Prop2__ = default(global::SharedData.ByteEnum);
-            var __Prop3__ = default(int);
+            var ____result = new global::SharedData.SimpleStringKeyData();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -4283,25 +4360,18 @@ namespace MessagePack.Formatters.SharedData
                         {
                             default: goto FAIL;
                             case 212339749456UL:
-                                __Prop1__ = reader.ReadInt32();
+                                ____result.Prop1 = reader.ReadInt32();
                                 continue;
                             case 216634716752UL:
-                                __Prop2__ = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
+                                ____result.Prop2 = formatterResolver.GetFormatterWithVerify<global::SharedData.ByteEnum>().Deserialize(ref reader, options);
                                 continue;
                             case 220929684048UL:
-                                __Prop3__ = reader.ReadInt32();
+                                ____result.Prop3 = reader.ReadInt32();
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::SharedData.SimpleStringKeyData()
-            {
-                Prop1 = __Prop1__,
-                Prop2 = __Prop2__,
-                Prop3 = __Prop3__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -4317,7 +4387,7 @@ namespace MessagePack.Formatters.SharedData
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::SharedData.SimpleStructStringKeyData value, global::MessagePack.MessagePackSerializerOptions options)
         {
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_X());
             writer.Write(value.X);
@@ -4333,14 +4403,13 @@ namespace MessagePack.Formatters.SharedData
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __X__ = default(int);
-            var __Y__ = default(int[]);
+            var ____result = new global::SharedData.SimpleStructStringKeyData();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -4352,21 +4421,15 @@ namespace MessagePack.Formatters.SharedData
                         {
                             default: goto FAIL;
                             case 378720052587UL:
-                                __X__ = reader.ReadInt32();
+                                ____result.X = reader.ReadInt32();
                                 continue;
                             case 383015019883UL:
-                                __Y__ = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
+                                ____result.Y = formatterResolver.GetFormatterWithVerify<int[]>().Deserialize(ref reader, options);
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::SharedData.SimpleStructStringKeyData()
-            {
-                X = __X__,
-                Y = __Y__,
-            };
 
             reader.Depth--;
             return ____result;

--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -181,10 +181,8 @@ namespace MessagePack.Formatters.TestData2
 
 namespace MessagePack.Formatters.TestData2
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
+    using global::System.Buffers;
+    using global::MessagePack;
 
     public sealed class AFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.A>
     {
@@ -203,7 +201,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
             writer.WriteRaw(GetSpan_a());
             writer.Write(value.a);
@@ -221,15 +219,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __a__ = default(int);
-            var __bs__ = default(global::System.Collections.Generic.List<global::TestData2.B>);
-            var __c__ = default(global::TestData2.C);
+            var ____result = new global::TestData2.A();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -241,27 +237,20 @@ namespace MessagePack.Formatters.TestData2
                         {
                             default: goto FAIL;
                             case 97UL:
-                                __a__ = reader.ReadInt32();
+                                ____result.a = reader.ReadInt32();
                                 continue;
                             case 99UL:
-                                __c__ = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
+                                ____result.c = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
                                 continue;
                         }
                     case 2:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 29538UL) { goto FAIL; }
 
-                        __bs__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.B>>().Deserialize(ref reader, options);
+                        ____result.bs = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.B>>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::TestData2.A()
-            {
-                a = __a__,
-                bs = __bs__,
-                c = __c__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -285,7 +274,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
             writer.WriteRaw(GetSpan_ass());
             formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>().Serialize(ref writer, value.ass, options);
@@ -303,15 +292,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __ass__ = default(global::System.Collections.Generic.List<global::TestData2.A>);
-            var __c__ = default(global::TestData2.C);
-            var __a__ = default(int);
+            var ____result = new global::TestData2.B();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -321,29 +308,22 @@ namespace MessagePack.Formatters.TestData2
                     case 3:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 7566177UL) { goto FAIL; }
 
-                        __ass__ = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>().Deserialize(ref reader, options);
+                        ____result.ass = formatterResolver.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>().Deserialize(ref reader, options);
                         continue;
                     case 1:
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
                         {
                             default: goto FAIL;
                             case 99UL:
-                                __c__ = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
+                                ____result.c = formatterResolver.GetFormatterWithVerify<global::TestData2.C>().Deserialize(ref reader, options);
                                 continue;
                             case 97UL:
-                                __a__ = reader.ReadInt32();
+                                ____result.a = reader.ReadInt32();
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::TestData2.B()
-            {
-                ass = __ass__,
-                c = __c__,
-                a = __a__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -365,7 +345,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_b());
             formatterResolver.GetFormatterWithVerify<global::TestData2.B>().Serialize(ref writer, value.b, options);
@@ -381,14 +361,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __b__ = default(global::TestData2.B);
-            var __a__ = default(int);
+            var ____result = new global::TestData2.C();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -400,21 +379,15 @@ namespace MessagePack.Formatters.TestData2
                         {
                             default: goto FAIL;
                             case 98UL:
-                                __b__ = formatterResolver.GetFormatterWithVerify<global::TestData2.B>().Deserialize(ref reader, options);
+                                ____result.b = formatterResolver.GetFormatterWithVerify<global::TestData2.B>().Deserialize(ref reader, options);
                                 continue;
                             case 97UL:
-                                __a__ = reader.ReadInt32();
+                                ____result.a = reader.ReadInt32();
                                 continue;
                         }
 
                 }
             }
-
-            var ____result = new global::TestData2.C()
-            {
-                b = __b__,
-                a = __a__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -436,7 +409,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_EnumId());
             formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.Id>().Serialize(ref writer, value.EnumId, options);
@@ -452,14 +425,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __EnumId__ = default(global::TestData2.Nest1.Id);
-            var __ClassId__ = default(global::TestData2.Nest1.IdType);
+            var ____result = new global::TestData2.Nest1();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -469,22 +441,16 @@ namespace MessagePack.Formatters.TestData2
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 110266531802693UL) { goto FAIL; }
 
-                        __EnumId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.Id>().Deserialize(ref reader, options);
+                        ____result.EnumId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.Id>().Deserialize(ref reader, options);
                         continue;
                     case 7:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 28228257876896835UL) { goto FAIL; }
 
-                        __ClassId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.IdType>().Deserialize(ref reader, options);
+                        ____result.ClassId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest1.IdType>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::TestData2.Nest1()
-            {
-                EnumId = __EnumId__,
-                ClassId = __ClassId__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -493,7 +459,6 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class Nest1_IdTypeFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.Nest1.IdType>
     {
-
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.Nest1.IdType value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -533,7 +498,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_EnumId());
             formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.Id>().Serialize(ref writer, value.EnumId, options);
@@ -549,14 +514,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __EnumId__ = default(global::TestData2.Nest2.Id);
-            var __ClassId__ = default(global::TestData2.Nest2.IdType);
+            var ____result = new global::TestData2.Nest2();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -566,22 +530,16 @@ namespace MessagePack.Formatters.TestData2
                     case 6:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 110266531802693UL) { goto FAIL; }
 
-                        __EnumId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.Id>().Deserialize(ref reader, options);
+                        ____result.EnumId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.Id>().Deserialize(ref reader, options);
                         continue;
                     case 7:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 28228257876896835UL) { goto FAIL; }
 
-                        __ClassId__ = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.IdType>().Deserialize(ref reader, options);
+                        ____result.ClassId = formatterResolver.GetFormatterWithVerify<global::TestData2.Nest2.IdType>().Deserialize(ref reader, options);
                         continue;
 
                 }
             }
-
-            var ____result = new global::TestData2.Nest2()
-            {
-                EnumId = __EnumId__,
-                ClassId = __ClassId__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -590,7 +548,6 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class Nest2_IdTypeFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.Nest2.IdType>
     {
-
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.Nest2.IdType value, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -630,7 +587,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_MyProperty1());
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.MyProperty1, options);
@@ -646,14 +603,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __MyProperty1__ = default(string);
-            var __MyProperty2__ = default(string);
+            var ____result = new global::TestData2.PropNameCheck1();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -669,10 +625,10 @@ namespace MessagePack.Formatters.TestData2
                                 {
                                     default: goto FAIL;
                                     case 3242356UL:
-                                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                     case 3307892UL:
-                                        __MyProperty2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                 }
 
@@ -680,12 +636,6 @@ namespace MessagePack.Formatters.TestData2
 
                 }
             }
-
-            var ____result = new global::TestData2.PropNameCheck1()
-            {
-                MyProperty1 = __MyProperty1__,
-                MyProperty2 = __MyProperty2__,
-            };
 
             reader.Depth--;
             return ____result;
@@ -707,7 +657,7 @@ namespace MessagePack.Formatters.TestData2
                 return;
             }
 
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
             writer.WriteRaw(GetSpan_MyProperty1());
             formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.MyProperty1, options);
@@ -723,14 +673,13 @@ namespace MessagePack.Formatters.TestData2
             }
 
             options.Security.DepthStep(ref reader);
-            IFormatterResolver formatterResolver = options.Resolver;
+            var formatterResolver = options.Resolver;
             var length = reader.ReadMapHeader();
-            var __MyProperty1__ = default(string);
-            var __MyProperty2__ = default(string);
+            var ____result = new global::TestData2.PropNameCheck2();
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
@@ -746,10 +695,10 @@ namespace MessagePack.Formatters.TestData2
                                 {
                                     default: goto FAIL;
                                     case 3242356UL:
-                                        __MyProperty1__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty1 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                     case 3307892UL:
-                                        __MyProperty2__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                                        ____result.MyProperty2 = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
                                         continue;
                                 }
 
@@ -757,12 +706,6 @@ namespace MessagePack.Formatters.TestData2
 
                 }
             }
-
-            var ____result = new global::TestData2.PropNameCheck2()
-            {
-                MyProperty1 = __MyProperty1__,
-                MyProperty2 = __MyProperty2__,
-            };
 
             reader.Depth--;
             return ____result;

--- a/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/FormatterTemplate.tt
@@ -81,13 +81,21 @@ namespace <#= Namespace #>
 <# } #>
             }
 
+<# if (objInfo.MaxKey == -1 && !objInfo.HasIMessagePackSerializationCallbackReceiver) { #>
+            reader.Skip();
+            return new <#= objInfo.GetConstructorString()  #>;
+<# } else { #>
             options.Security.DepthStep(ref reader);
 <# if (isFormatterResolverNecessary) { #>
             global::MessagePack.IFormatterResolver formatterResolver = options.Resolver;
 <# } #>
             var length = reader.ReadArrayHeader();
-<# foreach (var member in objInfo.Members) { #>
+<# var canOverwrite = objInfo.ConstructorParameters.Length == 0;
+ if (canOverwrite) { #>
+            var ____result = new <#= objInfo.GetConstructorString()  #>;
+<# } else { foreach (var member in objInfo.Members) { #>
             var __<#= member.Name #>__ = default(<#= member.Type #>);
+<# } #>
 <# } #>
 
             for (int i = 0; i < length; i++)
@@ -98,7 +106,15 @@ namespace <#= Namespace #>
   var member = objInfo.GetMember(memberIndex);
   if (member == null) { continue; } #>
                     case <#= member.IntKey #>:
+<# if (canOverwrite) {
+  if (member.IsWritable) { #>
+                        ____result.<#= member.Name #> = <#= member.GetDeserializeMethodString() #>;
+<# } else { #>
+                        <#= member.GetDeserializeMethodString() #>;
+<# } #>
+<# } else {#>
                         __<#= member.Name #>__ = <#= member.GetDeserializeMethodString() #>;
+<# } #>
                         break;
 <# } #>
                     default:
@@ -107,12 +123,25 @@ namespace <#= Namespace #>
                 }
             }
 
+<# if (!canOverwrite) { #>
             var ____result = new <#= objInfo.GetConstructorString()  #>;
-<# for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
+<# bool memberAssignExists = false;
+  for (var memberIndex = 0; memberIndex <= objInfo.MaxKey; memberIndex++) {
   var member = objInfo.GetMember(memberIndex);
-  if (member == null || !member.IsWritable) { continue; } #>
+  if (member == null || !member.IsWritable || objInfo.ConstructorParameters.Any(p => p.Equals(member))) { continue; }
+  memberAssignExists = true;#>
+            if (length <= <#= memberIndex #>)
+            {
+                goto MEMBER_ASSIGNMENT_END;
+            }
+
             ____result.<#= member.Name #> = __<#= member.Name #>__;
+<# } #>
+<# if (memberAssignExists) { #>
+
+        MEMBER_ASSIGNMENT_END:
 <# }
+ }
 
  if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
   if (objInfo.NeedsCastOnAfter) { #>
@@ -123,6 +152,7 @@ namespace <#= Namespace #>
 <# } #>
             reader.Depth--;
             return ____result;
+<# } #>
         }
     }
 <# } #>

--- a/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
+++ b/src/MessagePack.GeneratorCore/Generator/StringKey/StringKeyFormatterTemplate.tt
@@ -22,199 +22,131 @@
 
 namespace <#= Namespace #>
 {
-    using System;
-    using System.Buffers;
-    using System.Runtime.InteropServices;
-    using MessagePack;
-<#
-var list = new List<ValueTuple<MemberSerializationInfo, byte[]>>();
-foreach (var objInfo in ObjectSerializationInfos)
-{
+    using global::System.Buffers;
+    using global::MessagePack;
+<# var list = new List<ValueTuple<MemberSerializationInfo, byte[]>>();
+foreach (var objInfo in ObjectSerializationInfos) {
     list.Clear();
-    foreach (var member in objInfo.Members)
-    {
+    foreach (var member in objInfo.Members) {
         var binary = EmbedStringHelper.Utf8.GetBytes(member.StringKey);
         list.Add(new ValueTuple<MemberSerializationInfo, byte[]>(member, binary));
     }
 
     string formatterName = objInfo.Name + (objInfo.IsOpenGenericType ? $"Formatter<{string.Join(", ", objInfo.GenericTypeParameters.Select(x => x.Name))}>" : "Formatter");
-    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members);
-#>
+    bool isFormatterResolverNecessary = ShouldUseFormatterResolverHelper.ShouldUseFormatterResolver(objInfo.Members); #>
 
     public sealed class <#= formatterName #> : global::MessagePack.Formatters.IMessagePackFormatter<<#= objInfo.FullName #>>
 <# foreach (var typeArg in objInfo.GenericTypeParameters.Where(x => x.HasConstraints)) {#>
         where <#= typeArg.Name #> : <#= typeArg.Constraints #>
 <# }#>
     {
-<#
-    foreach (var memberAndBinary in list)
-    {
-        var member = memberAndBinary.Item1;
-        var binary = memberAndBinary.Item2;
-#>
+<# for (var i = 0; i < list.Count; i++) {
+        var member = list[i].Item1;
+        var binary = list[i].Item2; #>
         // <#= member.StringKey #>
         private static global::System.ReadOnlySpan<byte> GetSpan_<#= member.Name #>() => <#= EmbedStringHelper.ToByteArrayString(binary) #>;
-<#
-    }
-#>
+<# } #>
+<# if (list.Count != 0) { #>
 
+<# } #>
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, <#= objInfo.FullName #> value, global::MessagePack.MessagePackSerializerOptions options)
         {
-<#
-    if (objInfo.IsClass)
-    {
-#>
+<# if (objInfo.IsClass) { #>
             if (value is null)
             {
                 writer.WriteNil();
                 return;
             }
 
-<#
-    }
+<# }
 
-    if (isFormatterResolverNecessary)
-    {
-#>
-            IFormatterResolver formatterResolver = options.Resolver;
-<#
-    }
+    if (isFormatterResolverNecessary) { #>
+            var formatterResolver = options.Resolver;
+<# }
 
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnBefore)
-        {
-#>
+    if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+        if (objInfo.NeedsCastOnBefore) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)value).OnBeforeSerialize();
-<#
-        }
-        else
-        {
-#>
+<# } else { #>
             value.OnBeforeSerialize();
-<#
-        }
-    }
-#>
+<# } #>
+<# } #>
             writer.WriteMapHeader(<#= list.Count #>);
-<#
-    foreach (var memberAndBinary in list)
-    {
-        var member = memberAndBinary.Item1;
-#>
+<# foreach (var memberAndBinary in list) {
+        var member = memberAndBinary.Item1; #>
             writer.WriteRaw(GetSpan_<#= member.Name #>());
             <#= member.GetSerializeMethodString() #>;
-<#
-    }
-#>
+<# } #>
         }
 
         public <#= objInfo.FullName #> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
             {
-<#
-    if (objInfo.IsClass)
-    {
-#>
+<# if (objInfo.IsClass) { #>
                 return null;
-<#
-    }
-    else
-    {
-#>
+<# } else { #>
                 throw new global::System.InvalidOperationException("typecode is null, struct not supported");
-<#
-    }
-#>
+<# } #>
             }
 
-<#
-    if (objInfo.Members.Length == 0)
-    {
-#>
+<# if (objInfo.Members.Length == 0) { #>
             reader.Skip();
             var ____result = new <#= objInfo.GetConstructorString() #>;
-<#
-    }
-    else
-    {
-#>
+<# } else { #>
             options.Security.DepthStep(ref reader);
-<#
-        if (isFormatterResolverNecessary)
-        {
-#>
-            IFormatterResolver formatterResolver = options.Resolver;
-<#
-        }
-#>
+<# if (isFormatterResolverNecessary) { #>
+            var formatterResolver = options.Resolver;
+<# } #>
             var length = reader.ReadMapHeader();
-<#
-        foreach (var memberInfo in objInfo.Members)
-        {
-#>
-            var __<#= memberInfo.Name #>__ = default(<#= memberInfo.Type #>);
-<#
-        }
-#>
+<# var canOverwrite = objInfo.ConstructorParameters.Length == 0;
+        if (canOverwrite) { #>
+            var ____result = new <#= objInfo.GetConstructorString() #>;
+<# } else {
+            foreach (var member in objInfo.Members.Where(x => x.IsWritable)) { #>
+<# if (objInfo.ConstructorParameters.All(p => !p.Equals(member))) { #>
+            var __<#= member.Name #>__IsInitialized = false;
+<# } #>
+            var __<#= member.Name #>__ = default(<#= member.Type #>);
+<# } #>
+<# } #>
 
             for (int i = 0; i < length; i++)
             {
-                ReadOnlySpan<byte> stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
                 switch (stringKey.Length)
                 {
                     default:
                     FAIL:
                       reader.Skip();
                       continue;
-<#= StringKeyFormatterDeserializeHelper.Classify(objInfo.Members, "                    ") #>
+<#= StringKeyFormatterDeserializeHelper.Classify(objInfo, "                    ", canOverwrite) #>
                 }
             }
 
-            var ____result = new <#= objInfo.GetConstructorString() #>
+<# if (!canOverwrite) { #>
+            var ____result = new <#= objInfo.GetConstructorString() #>;
+<# foreach (var member in objInfo.Members.Where(x => x.IsWritable && !objInfo.ConstructorParameters.Any(p => p.Equals(x)))) { #>
+            if (__<#= member.Name #>__IsInitialized)
             {
-<#
-        // Preparation for C#9 Record class
-        foreach (var member in objInfo.Members.Where(x => x.IsWritable))
-        {
-#>
-                <#= member.Name #> = __<#= member.Name #>__,
-<#
-        }
-#>
-            };
+                ____result.<#= member.Name #> = __<#= member.Name #>__;
+            }
 
-<#
-    }
-
-    if (objInfo.HasIMessagePackSerializationCallbackReceiver)
-    {
-        if (objInfo.NeedsCastOnAfter)
-        {
-#>
+<# } #>
+<# } #>
+<# } #>
+<# if (objInfo.HasIMessagePackSerializationCallbackReceiver) {
+        if (objInfo.NeedsCastOnAfter) { #>
             ((global::MessagePack.IMessagePackSerializationCallbackReceiver)____result).OnAfterDeserialize();
-<#
-        }
-        else
-        {
-#>
+<# } else { #>
             ____result.OnAfterDeserialize();
-<#
-        }
-    }
-
-    if (objInfo.Members.Length != 0)
-    {
-#>
+<# } #>
+<# } #>
+<# if (objInfo.Members.Length != 0) { #>
             reader.Depth--;
-<#
-    }
-#>
+<# } #>
             return ____result;
         }
     }
-<#
-}
-#>
+<# } #>
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Class1.cs
@@ -116,6 +116,108 @@ namespace SharedData
     }
 
     [MessagePackObject(true)]
+    public class DefaultValueStringKeyClassWithoutExplicitConstructor
+    {
+        public const int Prop1Constant = 11;
+        public const int Prop2Constant = 45;
+
+        public int Prop1 { get; set; } = Prop1Constant;
+
+        public int Prop2 { get; set; } = Prop2Constant;
+    }
+
+    [MessagePackObject(true)]
+    public class DefaultValueStringKeyClassWithExplicitConstructor
+    {
+        public const int Prop2Constant = 1419;
+
+        public int Prop1 { get; set; }
+
+        public int Prop2 { get; set; }
+
+        public DefaultValueStringKeyClassWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = Prop2Constant;
+        }
+    }
+
+    [MessagePackObject(true)]
+    public struct DefaultValueStringKeyStructWithExplicitConstructor
+    {
+        public const int Prop2Constant = 198;
+
+        public int Prop1 { get; set; }
+
+        public int Prop2 { get; set; }
+
+        public DefaultValueStringKeyStructWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = Prop2Constant;
+        }
+    }
+
+    [MessagePackObject]
+    public class DefaultValueIntKeyClassWithoutExplicitConstructor
+    {
+        public const int Prop1Constant = 33;
+        public const int Prop2Constant = -4;
+
+        [Key(0)]
+        public int Prop1 { get; set; } = Prop1Constant;
+
+        [Key(1)]
+        public int Prop2 { get; set; } = Prop2Constant;
+    }
+
+    [MessagePackObject]
+    public class DefaultValueIntKeyClassWithExplicitConstructor
+    {
+        public const int Prop2Constant = -109;
+        public const string Prop3Constant = "生命、宇宙、そして万物についての究極の疑問の答え";
+        public const string Prop4Constant = "Hello, world! To you, From me.";
+
+        [Key(0)]
+        public int Prop1 { get; set; }
+
+        [Key(1)]
+        public int Prop2 { get; set; }
+
+        [Key(2)]
+        public string Prop3 { get; set; }
+
+        [Key(3)]
+        public string Prop4 { get; set; }
+
+        public DefaultValueIntKeyClassWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = Prop2Constant;
+            Prop3 = Prop3Constant;
+            Prop4 = Prop4Constant;
+        }
+    }
+
+    [MessagePackObject]
+    public struct DefaultValueIntKeyStructWithExplicitConstructor
+    {
+        public const int Prop2Constant = 31;
+
+        [Key(0)]
+        public int Prop1 { get; set; }
+
+        [Key(1)]
+        public int Prop2 { get; set; }
+
+        public DefaultValueIntKeyStructWithExplicitConstructor(int prop1)
+        {
+            Prop1 = prop1;
+            Prop2 = Prop2Constant;
+        }
+    }
+
+    [MessagePackObject(true)]
     public class SimpleStringKeyData
     {
         public int Prop1 { get; set; }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ContractlessStandardResolverTest.cs
@@ -33,6 +33,16 @@ namespace MessagePack.Tests
             public object[] /*Address*/ Addresses { get; set; }
         }
 
+        public class DefaultValueStringKeyClassWithoutExplicitConstructor
+        {
+            public const int Prop1Constant = 11;
+            public const int Prop2Constant = 45;
+
+            public int Prop1 { get; set; } = Prop1Constant;
+
+            public int Prop2 { get; set; } = Prop2Constant;
+        }
+
         public class V1
         {
             public int ABCDEFG1 { get; set; }
@@ -173,6 +183,18 @@ namespace MessagePack.Tests
             var d2 = (IDictionary)addresses[1];
             ((string)d1["Street"]).Is("St.");
             ((string)d2["Street"]).Is("Ave.");
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithoutExplicitConstructorTest()
+        {
+            var dictionary = new Dictionary<string, int>();
+
+            var result = MessagePackSerializer.Serialize(dictionary, Resolvers.ContractlessStandardResolver.Options);
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithoutExplicitConstructor>(result, Resolvers.ContractlessStandardResolver.Options);
+            instance.Prop1.Is(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop1Constant);
+            instance.Prop2.Is(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop2Constant);
         }
 
         [Fact]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -58,7 +58,7 @@ namespace MessagePack.Tests
 
             var instance = MessagePackSerializer.Deserialize<TwoProperties>(seq);
             Assert.Equal("Set", instance.Prop1);
-            Assert.Null(instance.Prop2);
+            Assert.Equal("Uninitialized", instance.Prop2);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace MessagePack.Tests
 
             var instance = MessagePackSerializer.Deserialize<TwoPropertiesOrdinalKey>(seq);
             Assert.Equal("Set", instance.Prop1);
-            Assert.Null(instance.Prop2);
+            Assert.Equal("Uninitialized", instance.Prop2);
         }
 
         /// <summary>
@@ -153,6 +153,246 @@ namespace MessagePack.Tests
             Assert.Equal(obj.BaseClassFieldAccessor, obj2.BaseClassFieldAccessor);
             Assert.Equal(obj.BaseClassProperty, obj2.BaseClassProperty);
             Assert.Equal(obj.Name, obj2.Name);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithoutExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(0);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithoutExplicitConstructor>(seq);
+            Assert.Equal(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop1Constant, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(1);
+            writer.Write(nameof(DefaultValueStringKeyClassWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyClassWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithExplicitConstructorSetPropertyTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(2);
+            writer.Write(nameof(DefaultValueStringKeyClassWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Write(nameof(DefaultValueStringKeyClassWithExplicitConstructor.Prop2));
+            writer.Write(int.MaxValue);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(int.MaxValue, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyStructWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(1);
+            writer.Write(nameof(DefaultValueStringKeyStructWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyStructWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyStructWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyStructWithExplicitConstructorSetPropertyTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(2);
+            writer.Write(nameof(DefaultValueStringKeyStructWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Write(nameof(DefaultValueStringKeyStructWithExplicitConstructor.Prop2));
+            writer.Write(int.MinValue);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyStructWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(int.MinValue, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithoutExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(0);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithoutExplicitConstructor>(seq);
+            Assert.Equal(DefaultValueIntKeyClassWithoutExplicitConstructor.Prop1Constant, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyClassWithoutExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyClassWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithExplicitConstructorSetPropertyTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(2);
+            writer.Write(-1);
+            writer.Write(42);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(42, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyStructWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyStructWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyStructWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyStructWithExplicitConstructorSetPropertyTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(2);
+            writer.Write(-1);
+            writer.Write(-98);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyStructWithExplicitConstructor>(seq);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(-98, instance.Prop2);
+        }
+
+        [MessagePackObject(true)]
+        public class DefaultValueStringKeyClassWithoutExplicitConstructor
+        {
+            public const int Prop1Constant = 11;
+            public const int Prop2Constant = 45;
+
+            public int Prop1 { get; set; } = Prop1Constant;
+
+            public int Prop2 { get; set; } = Prop2Constant;
+        }
+
+        [MessagePackObject(true)]
+        public class DefaultValueStringKeyClassWithExplicitConstructor
+        {
+            public const int Prop2Constant = 1419;
+
+            public int Prop1 { get; set; }
+
+            public int Prop2 { get; set; }
+
+            public DefaultValueStringKeyClassWithExplicitConstructor(int prop1)
+            {
+                Prop1 = prop1;
+                Prop2 = Prop2Constant;
+            }
+        }
+
+        [MessagePackObject(true)]
+        public struct DefaultValueStringKeyStructWithExplicitConstructor
+        {
+            public const int Prop2Constant = 198;
+
+            public int Prop1 { get; set; }
+
+            public int Prop2 { get; set; }
+
+            public DefaultValueStringKeyStructWithExplicitConstructor(int prop1)
+            {
+                Prop1 = prop1;
+                Prop2 = Prop2Constant;
+            }
+        }
+
+        [MessagePackObject]
+        public class DefaultValueIntKeyClassWithoutExplicitConstructor
+        {
+            public const int Prop1Constant = 33;
+            public const int Prop2Constant = -4;
+
+            [Key(0)]
+            public int Prop1 { get; set; } = Prop1Constant;
+
+            [Key(1)]
+            public int Prop2 { get; set; } = Prop2Constant;
+        }
+
+        [MessagePackObject]
+        public class DefaultValueIntKeyClassWithExplicitConstructor
+        {
+            public const int Prop2Constant = -109;
+
+            [Key(0)]
+            public int Prop1 { get; set; }
+
+            [Key(1)]
+            public int Prop2 { get; set; }
+
+            public DefaultValueIntKeyClassWithExplicitConstructor(int prop1)
+            {
+                Prop1 = prop1;
+                Prop2 = Prop2Constant;
+            }
+        }
+
+        [MessagePackObject]
+        public struct DefaultValueIntKeyStructWithExplicitConstructor
+        {
+            public const int Prop2Constant = 31;
+
+            [Key(0)]
+            public int Prop1 { get; set; }
+
+            [Key(1)]
+            public int Prop2 { get; set; }
+
+            public DefaultValueIntKeyStructWithExplicitConstructor(int prop1)
+            {
+                Prop1 = prop1;
+                Prop2 = Prop2Constant;
+            }
         }
 
         [DataContract]

--- a/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
+++ b/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sandbox\Sandbox\Sandbox.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MessagePack.GeneratedCode.Tests/MissingPropertiesTest.cs
+++ b/tests/MessagePack.GeneratedCode.Tests/MissingPropertiesTest.cs
@@ -1,0 +1,105 @@
+// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MessagePack.Resolvers;
+using Nerdbank.Streams;
+using SharedData;
+using Xunit;
+
+namespace MessagePack.GeneratedCode.Tests
+{
+    public class MissingPropertiesTest
+    {
+        private readonly MessagePackSerializerOptions options;
+
+        public MissingPropertiesTest()
+        {
+            var resolver = CompositeResolver.Create(GeneratedResolver.Instance, StandardResolver.Instance);
+            options = MessagePackSerializerOptions.Standard.WithResolver(resolver);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithoutExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(0);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithoutExplicitConstructor>(seq, options);
+            Assert.Equal(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop1Constant, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyClassWithoutExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyClassWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(1);
+            writer.Write(nameof(DefaultValueStringKeyClassWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyClassWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyClassWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueStringKeyStructWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteMapHeader(1);
+            writer.Write(nameof(DefaultValueStringKeyStructWithExplicitConstructor.Prop1));
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueStringKeyStructWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueStringKeyStructWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithoutExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(0);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithoutExplicitConstructor>(seq, options);
+            Assert.Equal(DefaultValueIntKeyClassWithoutExplicitConstructor.Prop1Constant, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyClassWithoutExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyClassWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyClassWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyClassWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+
+        [Fact]
+        public void DefaultValueIntKeyStructWithExplicitConstructorTest()
+        {
+            var seq = new Sequence<byte>();
+            var writer = new MessagePackWriter(seq);
+            writer.WriteArrayHeader(1);
+            writer.Write(-1);
+            writer.Flush();
+
+            var instance = MessagePackSerializer.Deserialize<DefaultValueIntKeyStructWithExplicitConstructor>(seq, options);
+            Assert.Equal(-1, instance.Prop1);
+            Assert.Equal(DefaultValueIntKeyStructWithExplicitConstructor.Prop2Constant, instance.Prop2);
+        }
+    }
+}


### PR DESCRIPTION
# Background

```csharp
// Psuedo code.
[MessagePackObject(true)]
public class X
{
    public string Prop1 { get; set; } = "Uninitialized";
    public string Prop2 { get; set; } = "Uninitialized";
}
```

The old MessagePack-CSharp deserialize input `{ "Prop1": "Set" }`  as `{ "Prop1": "Set", "Prop2": null }`.
It sets default value when the corresponging properties do not show in the input `byte[]`.

This behaviour is undocumented and undesirable.
There are 2 draft PRs.
- #1091 Dynamic
- #1092 mpc.exe

Fixes #1085 