### PR TITLE
Fix `[MessagePackFormatter(TypelessFormatter)]`

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -50,11 +50,11 @@ namespace MessagePack.Formatters
         /// </summary>
         public static readonly IMessagePackFormatter<object> Instance = new TypelessFormatter();
 
-        private readonly ThreadsafeTypeKeyHashTable<SerializeMethod> serializers = new ThreadsafeTypeKeyHashTable<SerializeMethod>();
-        private readonly ThreadsafeTypeKeyHashTable<DeserializeMethod> deserializers = new ThreadsafeTypeKeyHashTable<DeserializeMethod>();
-        private readonly ThreadsafeTypeKeyHashTable<byte[]> fullTypeNameCache = new ThreadsafeTypeKeyHashTable<byte[]>();
-        private readonly ThreadsafeTypeKeyHashTable<byte[]> shortenedTypeNameCache = new ThreadsafeTypeKeyHashTable<byte[]>();
-        private readonly AsymmetricKeyHashTable<byte[], ArraySegment<byte>, Type> typeCache = new AsymmetricKeyHashTable<byte[], ArraySegment<byte>, Type>(new StringArraySegmentByteAscymmetricEqualityComparer());
+        private static readonly ThreadsafeTypeKeyHashTable<SerializeMethod> Serializers = new ThreadsafeTypeKeyHashTable<SerializeMethod>();
+        private static readonly ThreadsafeTypeKeyHashTable<DeserializeMethod> Deserializers = new ThreadsafeTypeKeyHashTable<DeserializeMethod>();
+        private static readonly ThreadsafeTypeKeyHashTable<byte[]> FullTypeNameCache = new ThreadsafeTypeKeyHashTable<byte[]>();
+        private static readonly ThreadsafeTypeKeyHashTable<byte[]> ShortenedTypeNameCache = new ThreadsafeTypeKeyHashTable<byte[]>();
+        private static readonly AsymmetricKeyHashTable<byte[], ArraySegment<byte>, Type> TypeCache = new AsymmetricKeyHashTable<byte[], ArraySegment<byte>, Type>(new StringArraySegmentByteAscymmetricEqualityComparer());
 
         private static readonly HashSet<Type> UseBuiltinTypes = new HashSet<Type>
         {
@@ -107,10 +107,10 @@ namespace MessagePack.Formatters
         // mscorlib or System.Private.CoreLib
         private static readonly bool IsMscorlib = typeof(int).AssemblyQualifiedName.Contains("mscorlib");
 
-        private TypelessFormatter()
+        static TypelessFormatter()
         {
-            this.serializers.TryAdd(typeof(object), _ => (object p1, ref MessagePackWriter p2, object p3, MessagePackSerializerOptions p4) => { });
-            this.deserializers.TryAdd(typeof(object), _ => (object p1, ref MessagePackReader p2, MessagePackSerializerOptions p3) => new object());
+            Serializers.TryAdd(typeof(object), _ => (object p1, ref MessagePackWriter p2, object p3, MessagePackSerializerOptions p4) => { });
+            Deserializers.TryAdd(typeof(object), _ => (object p1, ref MessagePackReader p2, MessagePackSerializerOptions p3) => new object());
         }
 
         private string BuildTypeName(Type type, MessagePackSerializerOptions options)
@@ -145,7 +145,7 @@ namespace MessagePack.Formatters
             Type type = value.GetType();
 
             byte[] typeName;
-            var typeNameCache = options.OmitAssemblyVersion ? this.shortenedTypeNameCache : this.fullTypeNameCache;
+            var typeNameCache = options.OmitAssemblyVersion ? ShortenedTypeNameCache : FullTypeNameCache;
             if (!typeNameCache.TryGetValue(type, out typeName))
             {
                 TypeInfo ti = type.GetTypeInfo();
@@ -170,12 +170,12 @@ namespace MessagePack.Formatters
             var formatter = options.Resolver.GetFormatterDynamicWithVerify(type);
 
             // don't use GetOrAdd for avoid closure capture.
-            if (!this.serializers.TryGetValue(type, out SerializeMethod serializeMethod))
+            if (!Serializers.TryGetValue(type, out SerializeMethod serializeMethod))
             {
                 // double check locking...
-                lock (this.serializers)
+                lock (Serializers)
                 {
-                    if (!this.serializers.TryGetValue(type, out serializeMethod))
+                    if (!Serializers.TryGetValue(type, out serializeMethod))
                     {
                         TypeInfo ti = type.GetTypeInfo();
 
@@ -196,7 +196,7 @@ namespace MessagePack.Formatters
 
                         serializeMethod = Expression.Lambda<SerializeMethod>(body, param0, param1, param2, param3).Compile();
 
-                        this.serializers.TryAdd(type, serializeMethod);
+                        Serializers.TryAdd(type, serializeMethod);
                     }
                 }
             }
@@ -263,7 +263,7 @@ namespace MessagePack.Formatters
         {
             // try get type with assembly name, throw if not found
             Type type;
-            if (!this.typeCache.TryGetValue(typeName, out type))
+            if (!TypeCache.TryGetValue(typeName, out type))
             {
                 var buffer = new byte[typeName.Count];
                 Buffer.BlockCopy(typeName.Array, typeName.Offset, buffer, 0, buffer.Length);
@@ -287,18 +287,18 @@ namespace MessagePack.Formatters
                     }
                 }
 
-                this.typeCache.TryAdd(buffer, type);
+                TypeCache.TryAdd(buffer, type);
             }
 
             options.ThrowIfDeserializingTypeIsDisallowed(type);
 
             var formatter = options.Resolver.GetFormatterDynamicWithVerify(type);
 
-            if (!this.deserializers.TryGetValue(type, out DeserializeMethod deserializeMethod))
+            if (!Deserializers.TryGetValue(type, out DeserializeMethod deserializeMethod))
             {
-                lock (this.deserializers)
+                lock (Deserializers)
                 {
-                    if (!this.deserializers.TryGetValue(type, out deserializeMethod))
+                    if (!Deserializers.TryGetValue(type, out deserializeMethod))
                     {
                         TypeInfo ti = type.GetTypeInfo();
 
@@ -323,7 +323,7 @@ namespace MessagePack.Formatters
 
                         deserializeMethod = Expression.Lambda<DeserializeMethod>(body, param0, param1, param2).Compile();
 
-                        this.deserializers.TryAdd(type, deserializeMethod);
+                        Deserializers.TryAdd(type, deserializeMethod);
                     }
                 }
             }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerTypelessTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Runtime.Serialization;
 using MessagePack;
+using MessagePack.Formatters;
 using MessagePack.Resolvers;
 using Xunit;
 using Xunit.Abstractions;
@@ -104,6 +105,14 @@ public class MessagePackSerializerTypelessTests
         Assert.IsType(boxedValue.GetType(), roundTripValue);
     }
 
+    [Fact]
+    public void TypelessFormatterAsAttribute()
+    {
+        byte[] msgpack = MessagePackSerializer.Serialize(new ClassWithTypelessField { Value = "hi" }, MessagePackSerializerOptions.Standard);
+        var deserialized = MessagePackSerializer.Deserialize<ClassWithTypelessField>(msgpack, MessagePackSerializerOptions.Standard);
+        Assert.Equal("hi", deserialized.Value);
+    }
+
     public class MyObject
     {
         public object SomeValue { get; set; }
@@ -164,6 +173,14 @@ public class MessagePackSerializerTypelessTests
     public class TypelessNonAbstract : TypelessAbstract
     {
         public int Y { get; set; }
+    }
+
+    [MessagePackObject]
+    public class ClassWithTypelessField
+    {
+        [Key("Value")]
+        [MessagePackFormatter(typeof(TypelessFormatter))]
+        public object Value;
     }
 }
 

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -36,6 +36,7 @@ MessagePack.Formatters.ReadOnlySequenceFormatter<T>.Serialize(ref MessagePack.Me
 MessagePack.Formatters.TypeFormatter<T>
 MessagePack.Formatters.TypeFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> T
 MessagePack.Formatters.TypeFormatter<T>.Serialize(ref MessagePack.MessagePackWriter writer, T value, MessagePack.MessagePackSerializerOptions options) -> void
+MessagePack.Formatters.TypelessFormatter.TypelessFormatter() -> void
 MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>
 MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableArray<T>
 MessagePack.ImmutableCollection.ImmutableArrayFormatter<T>.ImmutableArrayFormatter() -> void


### PR DESCRIPTION
This corrects a regression from 1.x to 2.0.

Fixes #1097