### PR TITLE
UriFormatter should use Uri.OriginalString when serializing

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -300,7 +300,7 @@ namespace MessagePack.Formatters
             }
             else
             {
-                writer.Write(value.ToString());
+                writer.Write(value.OriginalString);
             }
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FormatterTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/FormatterTest.cs
@@ -294,11 +294,14 @@ namespace MessagePack.Tests
             }
         }
 
-        [Fact]
-        public void UriTest_Absolute()
+        [Theory]
+        [InlineData("http://google.com/")]
+        [InlineData("http://google.com:80/")]
+        [InlineData("https://example.com:443/")]
+        public void UriTest_Absolute(string url)
         {
-            var absolute = new Uri("http://google.com/");
-            this.Convert(absolute).ToString().Is("http://google.com/");
+            var absolute = new Uri(url);
+            this.Convert(absolute).OriginalString.Is(url);
         }
 
         [SkippableFact]


### PR DESCRIPTION
Fixes #1105 

- Use `Uri.OriginalString` during serialization
- `Uri.OriginalString` survives serialization roundtrip so using OriginalString in the tests 