### PR TITLE
Simplify #if netcoreapp filters

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StandardClassLibraryFormatter.cs
@@ -476,7 +476,7 @@ namespace MessagePack.Formatters
 
         public void Serialize(ref MessagePackWriter writer, System.Numerics.BigInteger value, MessagePackSerializerOptions options)
         {
-#if NETCOREAPP2_1
+#if NETCOREAPP
             if (!writer.OldSpec)
             {
                 // try to get bin8 buffer.
@@ -504,7 +504,7 @@ namespace MessagePack.Formatters
         public System.Numerics.BigInteger Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
             ReadOnlySequence<byte> bytes = reader.ReadBytes().Value;
-#if NETCOREAPP2_1
+#if NETCOREAPP
             if (bytes.IsSingleSegment)
             {
                 return new System.Numerics.BigInteger(bytes.First.Span);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackReader.cs
@@ -1109,7 +1109,7 @@ namespace MessagePack
                 int bytesRead = Math.Min(remainingByteLength, this.reader.UnreadSpan.Length);
                 remainingByteLength -= bytesRead;
                 bool flush = remainingByteLength == 0;
-#if NETCOREAPP2_1
+#if NETCOREAPP
                 initializedChars += decoder.GetChars(this.reader.UnreadSpan.Slice(0, bytesRead), charArray.AsSpan(initializedChars), flush);
 #else
                 unsafe

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StringEncoding.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StringEncoding.cs
@@ -13,7 +13,7 @@ namespace MessagePack
     {
         internal static readonly Encoding UTF8 = new UTF8Encoding(false);
 
-#if !NETCOREAPP2_1 // Define the extension method only where an instance method does not already exist.
+#if !NETCOREAPP // Define the extension method only where an instance method does not already exist.
         internal static unsafe string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
         {
             if (bytes.Length == 0)


### PR DESCRIPTION
This allows code that compiles for netcoreapp3.1 or later to still execute the optimized code that is intended for .NET Core.