### PR TITLE
record note to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,16 @@ public struct Point
 }
 ```
 
+C# 9.0 record with primary constructor is similar immutable object, also supports serialize/deserialize.
+
+```csharp
+// use key as property name
+[MessagePackObject(true)]public record Point(int X, int Y);
+
+// use property: to set KeyAttribute
+[MessagePackObject] public record Point([property:Key(0)] int X, [property: Key(1)] int Y);
+```
+
 ## Serialization Callback
 
 Objects implementing the `IMessagePackSerializationCallbackReceiver` interface will received `OnBeforeSerialize` and `OnAfterDeserialize` calls during serialization/deserialization.


### PR DESCRIPTION
C# 9.0 record and primary constructor is already supported MessagePack-CSharp.
But `property:` notation is slightly tricky, so add note to ReadMe.

Question: @AArnott 
Emitted resolver is already supported but mpc(Roslyn) is not.
I've update `Microsoft.CodeAnalysis.CSharp` to latest, it can collect record type and can get by `IPropertySymbol`.
However `.GetAttributes` returns empty if set attribute to primary constructor's parameter(like `[property:Key(0)] int X`).
Do you know any info?