### PR TITLE
Way to set custom array pool was added.

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
@@ -14,13 +14,13 @@ namespace MessagePack
     internal class SequencePool
     {
         /// <summary>
-        /// A thread-safe pool of reusable <see cref="Sequence{T}"/> objects.
+        /// Gets or sets a thread-safe pool of reusable <see cref="Sequence{T}"/> objects.
         /// </summary>
         /// <remarks>
         /// We use a <see cref="maxSize"/> that allows every processor to be involved in messagepack serialization concurrently,
         /// plus one nested serialization per processor (since LZ4 and sometimes other nested serializations may exist).
         /// </remarks>
-        internal static SequencePool Shared = new SequencePool(Environment.ProcessorCount * 2);
+        internal static SequencePool Shared { get; set; } = new SequencePool(Environment.ProcessorCount * 2);
 
         /// <summary>
         /// The value to use for <see cref="Sequence{T}.MinimumSpanLength"/>.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
@@ -20,7 +20,7 @@ namespace MessagePack
         /// We use a <see cref="maxSize"/> that allows every processor to be involved in messagepack serialization concurrently,
         /// plus one nested serialization per processor (since LZ4 and sometimes other nested serializations may exist).
         /// </remarks>
-        internal static readonly SequencePool Shared = new SequencePool(Environment.ProcessorCount * 2);
+        internal static SequencePool Shared = new SequencePool(Environment.ProcessorCount * 2);
 
         /// <summary>
         /// The value to use for <see cref="Sequence{T}.MinimumSpanLength"/>.
@@ -41,18 +41,29 @@ namespace MessagePack
         /// <summary>
         /// The array pool which we share with all <see cref="Sequence{T}"/> objects created by this <see cref="SequencePool"/> instance.
         /// </summary>
-        /// <devremarks>
-        /// We allow 100 arrays to be shared (instead of the default 50) and reduce the max array length from the default 1MB to something more reasonable for our expected use.
-        /// </devremarks>
-        private readonly ArrayPool<byte> arrayPool = ArrayPool<byte>.Create(80 * 1024, 100);
+        private readonly ArrayPool<byte> arrayPool;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SequencePool"/> class.
         /// </summary>
         /// <param name="maxSize">The maximum size to allow the pool to grow.</param>
+        /// <devremarks>
+        /// We allow 100 arrays to be shared (instead of the default 50) and reduce the max array length from the default 1MB to something more reasonable for our expected use.
+        /// </devremarks>
         internal SequencePool(int maxSize)
+            : this(maxSize, ArrayPool<byte>.Create(80 * 1024, 100))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequencePool"/> class.
+        /// </summary>
+        /// <param name="maxSize">The maximum size to allow the pool to grow.</param>
+        /// <param name="arrayPool">Array pool that will be used.</param>
+        internal SequencePool(int maxSize, ArrayPool<byte> arrayPool)
         {
             this.maxSize = maxSize;
+            this.arrayPool = arrayPool;
         }
 
         /// <summary>

--- a/src/MessagePack/Pool.cs
+++ b/src/MessagePack/Pool.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+
+namespace MessagePack
+{
+    public static class Pool
+    {
+        /// <summary>
+        /// Reinitializes internal shared pool.
+        /// </summary>
+        /// <param name="maxSize">The maximum size to allow the pool to grow. Default value is "<see cref="System.Environment.ProcessorCount"/> * 2".</param>
+        /// <param name="arrayPool">Array pool that will be used.</param>
+        public static void Use(int maxSize, ArrayPool<byte> arrayPool) =>
+            SequencePool.Shared = new SequencePool(maxSize, arrayPool);
+    }
+}

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -72,6 +72,7 @@ MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.InterfaceImmutableSetFormatter() -> void
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.InterfaceImmutableStackFormatter() -> void
+MessagePack.Pool
 MessagePack.Resolvers.ExpandoObjectResolver
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>
@@ -114,6 +115,7 @@ override MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.Creat
 override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Add(T[] collection, int index, T value, MessagePack.MessagePackSerializerOptions options) -> void
 override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Complete(T[] intermediateCollection) -> System.Collections.Immutable.IImmutableStack<T>
 override MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> T[]
+static MessagePack.Pool.Use(int maxSize, System.Buffers.ArrayPool<byte> arrayPool) -> void
 static readonly MessagePack.Formatters.ByteMemoryFormatter.Instance -> MessagePack.Formatters.ByteMemoryFormatter
 static readonly MessagePack.Formatters.ByteReadOnlyMemoryFormatter.Instance -> MessagePack.Formatters.ByteReadOnlyMemoryFormatter
 static readonly MessagePack.Formatters.ByteReadOnlySequenceFormatter.Instance -> MessagePack.Formatters.ByteReadOnlySequenceFormatter


### PR DESCRIPTION
Hey! We have had problems on our production server with ArrayPool<T> from the .net framework in the MP library.
GC couldn't stop some message pack threads that were in spin lock in the critical section, so the server had random long Stop The World sometimes (some of them reached up to 10 seconds).

So we want to use TlsOverPerCoreLockedStacksArrayPool<T> from .net core. We can take it from core repo to our code, but we can't change DefaultArrayPool to that pool in MP. That’s why I decided to add the possibility to change ArrayPool<T> implementation.

However, I'm not sure about the namings and public API. Please check them out.

P.S. We are using .net 4.7.2.

![zlRabcJ](https://user-images.githubusercontent.com/6016431/99068085-858ec780-25b4-11eb-894b-465ed0d10c1b.png)



