### PR TITLE
Way to set custom array pool was added.

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -346,7 +346,7 @@ namespace MessagePack.Formatters
                     }
                     else
                     {
-                        using (var scratchRental = options.Pool.Rent())
+                        using (var scratchRental = options.SequencePool.Rent())
                         {
                             var scratch = scratchRental.Value;
                             MessagePackWriter scratchWriter = writer.Clone(scratch);
@@ -950,7 +950,7 @@ namespace MessagePack.Formatters
 
             IMessagePackFormatter<object> formatter = options.Resolver.GetFormatterWithVerify<object>();
 
-            using (var scratchRental = options.Pool.Rent())
+            using (var scratchRental = options.SequencePool.Rent())
             {
                 var scratch = scratchRental.Value;
                 MessagePackWriter scratchWriter = writer.Clone(scratch);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -346,7 +346,7 @@ namespace MessagePack.Formatters
                     }
                     else
                     {
-                        using (var scratchRental = SequencePool.Shared.Rent())
+                        using (var scratchRental = options.Pool.Rent())
                         {
                             var scratch = scratchRental.Value;
                             MessagePackWriter scratchWriter = writer.Clone(scratch);
@@ -950,7 +950,7 @@ namespace MessagePack.Formatters
 
             IMessagePackFormatter<object> formatter = options.Resolver.GetFormatterWithVerify<object>();
 
-            using (var scratchRental = SequencePool.Shared.Rent())
+            using (var scratchRental = options.Pool.Rent())
             {
                 var scratch = scratchRental.Value;
                 MessagePackWriter scratchWriter = writer.Clone(scratch);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -202,7 +202,7 @@ namespace MessagePack.Formatters
             }
 
             // mark will be written at the end, when size is known
-            using (var scratchRental = SequencePool.Shared.Rent())
+            using (var scratchRental = options.Pool.Rent())
             {
                 MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                 scratchWriter.WriteString(typeName);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/TypelessFormatter.cs
@@ -202,7 +202,7 @@ namespace MessagePack.Formatters
             }
 
             // mark will be written at the end, when size is known
-            using (var scratchRental = options.Pool.Rent())
+            using (var scratchRental = options.SequencePool.Rent())
             {
                 MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                 scratchWriter.WriteString(typeName);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -23,7 +23,7 @@ namespace MessagePack
         {
             options = options ?? DefaultOptions;
 
-            using (var sequenceRental = options.Pool.Rent())
+            using (var sequenceRental = options.SequencePool.Rent())
             {
                 var msgpackWriter = new MessagePackWriter(sequenceRental.Value)
                 {
@@ -87,7 +87,7 @@ namespace MessagePack
             {
                 if (options.Compression.IsCompression())
                 {
-                    using (var scratchRental = options.Pool.Rent())
+                    using (var scratchRental = options.SequencePool.Rent())
                     {
                         if (TryDecompress(ref reader, scratchRental.Value))
                         {
@@ -137,7 +137,7 @@ namespace MessagePack
         {
             options = options ?? DefaultOptions;
 
-            using (var scratchRental = options.Pool.Rent())
+            using (var scratchRental = options.SequencePool.Rent())
             {
                 var writer = new MessagePackWriter(scratchRental.Value)
                 {
@@ -162,7 +162,7 @@ namespace MessagePack
 
             if (options.Compression.IsCompression())
             {
-                using (var scratchRental = options.Pool.Rent())
+                using (var scratchRental = options.SequencePool.Rent())
                 {
                     MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                     using (var jr = new TinyJsonReader(reader, false))
@@ -194,7 +194,7 @@ namespace MessagePack
                         break;
                     case TinyJsonToken.StartObject:
                         // Set up a scratch area to serialize the collection since we don't know its length yet, which must be written first.
-                        using (var scratchRental = options.Pool.Rent())
+                        using (var scratchRental = options.SequencePool.Rent())
                         {
                             MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                             var mapCount = FromJsonCore(jr, ref scratchWriter, options);
@@ -211,7 +211,7 @@ namespace MessagePack
                         return count; // break
                     case TinyJsonToken.StartArray:
                         // Set up a scratch area to serialize the collection since we don't know its length yet, which must be written first.
-                        using (var scratchRental = options.Pool.Rent())
+                        using (var scratchRental = options.SequencePool.Rent())
                         {
                             MessagePackWriter scratchWriter = writer.Clone(scratchRental.Value);
                             var arrayCount = FromJsonCore(jr, ref scratchWriter, options);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -79,7 +79,7 @@ namespace MessagePack
             {
                 if (options.Compression.IsCompression() && !PrimitiveChecker<T>.IsMessagePackFixedSizePrimitive)
                 {
-                    using (var scratchRental = options.Pool.Rent())
+                    using (var scratchRental = options.SequencePool.Rent())
                     {
                         var scratch = scratchRental.Value;
                         MessagePackWriter scratchWriter = writer.Clone(scratch);
@@ -120,7 +120,7 @@ namespace MessagePack
             }
 
             options = options ?? DefaultOptions;
-            var msgpackWriter = new MessagePackWriter(options.Pool, array)
+            var msgpackWriter = new MessagePackWriter(options.SequencePool, array)
             {
                 CancellationToken = cancellationToken,
             };
@@ -141,7 +141,7 @@ namespace MessagePack
             options = options ?? DefaultOptions;
             cancellationToken.ThrowIfCancellationRequested();
 
-            using (SequencePool.Rental sequenceRental = options.Pool.Rent())
+            using (SequencePool.Rental sequenceRental = options.SequencePool.Rent())
             {
                 Serialize<T>(sequenceRental.Value, value, options, cancellationToken);
 
@@ -174,7 +174,7 @@ namespace MessagePack
             options = options ?? DefaultOptions;
             cancellationToken.ThrowIfCancellationRequested();
 
-            using (SequencePool.Rental sequenceRental = options.Pool.Rent())
+            using (SequencePool.Rental sequenceRental = options.SequencePool.Rent())
             {
                 Serialize<T>(sequenceRental.Value, value, options, cancellationToken);
 
@@ -227,7 +227,7 @@ namespace MessagePack
             {
                 if (options.Compression.IsCompression())
                 {
-                    using (var msgPackUncompressedRental = options.Pool.Rent())
+                    using (var msgPackUncompressedRental = options.SequencePool.Rent())
                     {
                         var msgPackUncompressed = msgPackUncompressedRental.Value;
                         if (TryDecompress(ref reader, msgPackUncompressed))
@@ -327,7 +327,7 @@ namespace MessagePack
                 return result;
             }
 
-            using (var sequenceRental = options.Pool.Rent())
+            using (var sequenceRental = options.SequencePool.Rent())
             {
                 var sequence = sequenceRental.Value;
                 try
@@ -376,7 +376,7 @@ namespace MessagePack
                 return result;
             }
 
-            using (var sequenceRental = options.Pool.Rent())
+            using (var sequenceRental = options.SequencePool.Rent())
             {
                 var sequence = sequenceRental.Value;
                 try

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Nerdbank.Streams;
 
 namespace MessagePack
 {
@@ -60,6 +61,7 @@ namespace MessagePack
             this.OmitAssemblyVersion = copyFrom.OmitAssemblyVersion;
             this.AllowAssemblyVersionMismatch = copyFrom.AllowAssemblyVersionMismatch;
             this.Security = copyFrom.Security;
+            this.Pool = copyFrom.Pool;
         }
 
         /// <summary>
@@ -112,6 +114,11 @@ namespace MessagePack
         /// The default value is to use <see cref="MessagePackSecurity.TrustedData"/>.
         /// </value>
         public MessagePackSecurity Security { get; private set; } = MessagePackSecurity.TrustedData;
+
+        /// <summary>
+        /// Gets a thread-safe pool of reusable <see cref="Sequence{T}"/> objects.
+        /// </summary>
+        public SequencePool Pool { get; private set; } = new SequencePool();
 
         /// <summary>
         /// Gets a type given a string representation of the type.
@@ -256,6 +263,23 @@ namespace MessagePack
 
             var result = this.Clone();
             result.Security = security;
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a copy of these options with the <see cref="Pool"/> property set to a new value.
+        /// </summary>
+        /// <param name="pool">The new value for the <see cref="Pool"/> property.</param>
+        /// <returns>The new instance.</returns>
+        public MessagePackSerializerOptions WithPool(SequencePool pool)
+        {
+            if (pool is null)
+            {
+                throw new ArgumentNullException(nameof(pool));
+            }
+
+            var result = this.Clone();
+            result.Pool = pool;
             return result;
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -61,7 +61,7 @@ namespace MessagePack
             this.OmitAssemblyVersion = copyFrom.OmitAssemblyVersion;
             this.AllowAssemblyVersionMismatch = copyFrom.AllowAssemblyVersionMismatch;
             this.Security = copyFrom.Security;
-            this.Pool = copyFrom.Pool;
+            this.SequencePool = copyFrom.SequencePool;
         }
 
         /// <summary>
@@ -118,7 +118,8 @@ namespace MessagePack
         /// <summary>
         /// Gets a thread-safe pool of reusable <see cref="Sequence{T}"/> objects.
         /// </summary>
-        public SequencePool Pool { get; private set; } = new SequencePool();
+        /// <value>The default value is the <see cref="SequencePool.Shared"/> instance.</value>
+        public SequencePool SequencePool { get; private set; } = SequencePool.Shared;
 
         /// <summary>
         /// Gets a type given a string representation of the type.
@@ -267,9 +268,9 @@ namespace MessagePack
         }
 
         /// <summary>
-        /// Gets a copy of these options with the <see cref="Pool"/> property set to a new value.
+        /// Gets a copy of these options with the <see cref="SequencePool"/> property set to a new value.
         /// </summary>
-        /// <param name="pool">The new value for the <see cref="Pool"/> property.</param>
+        /// <param name="pool">The new value for the <see cref="SequencePool"/> property.</param>
         /// <returns>The new instance.</returns>
         public MessagePackSerializerOptions WithPool(SequencePool pool)
         {
@@ -278,13 +279,13 @@ namespace MessagePack
                 throw new ArgumentNullException(nameof(pool));
             }
 
-            if (this.Pool == pool)
+            if (this.SequencePool == pool)
             {
                 return this;
             }
 
             var result = this.Clone();
-            result.Pool = pool;
+            result.SequencePool = pool;
             return result;
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -278,6 +278,11 @@ namespace MessagePack
                 throw new ArgumentNullException(nameof(pool));
             }
 
+            if (this.Pool == pool)
+            {
+                return this;
+            }
+
             var result = this.Clone();
             result.Pool = pool;
             return result;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -21,7 +21,7 @@ namespace MessagePack
     {
         private readonly Stream stream;
         private readonly bool leaveOpen;
-        private SequencePool.Rental sequenceRental = MessagePackSerializer.DefaultOptions.Pool.Rent();
+        private SequencePool.Rental sequenceRental;
         private SequencePosition? endOfLastMessage;
 
         /// <summary>
@@ -39,9 +39,36 @@ namespace MessagePack
         /// <param name="stream">The stream to read from.</param>
         /// <param name="leaveOpen">If true, leaves the stream open after this <see cref="MessagePackStreamReader"/> is disposed; otherwise, false.</param>
         public MessagePackStreamReader(Stream stream, bool leaveOpen)
+            : this(stream, SequencePool.Shared, leaveOpen)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
+        /// </summary>
+        /// <param name="stream">The stream to read from. This stream will be disposed of when this <see cref="MessagePackStreamReader"/> is disposed.</param>
+        /// <param name="pool">The pool to get result.</param>
+        public MessagePackStreamReader(Stream stream, SequencePool pool)
+            : this(stream, pool, leaveOpen: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
+        /// </summary>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="pool">The pool to get result.</param>
+        /// <param name="leaveOpen">If true, leaves the stream open after this <see cref="MessagePackStreamReader"/> is disposed; otherwise, false.</param>
+        public MessagePackStreamReader(Stream stream, SequencePool pool, bool leaveOpen)
+        {
+            if (pool == null)
+            {
+                throw new ArgumentNullException(nameof(pool));
+            }
+
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
             this.leaveOpen = leaveOpen;
+            this.sequenceRental = pool.Rent();
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -39,17 +39,7 @@ namespace MessagePack
         /// <param name="stream">The stream to read from.</param>
         /// <param name="leaveOpen">If true, leaves the stream open after this <see cref="MessagePackStreamReader"/> is disposed; otherwise, false.</param>
         public MessagePackStreamReader(Stream stream, bool leaveOpen)
-            : this(stream, SequencePool.Shared, leaveOpen)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
-        /// </summary>
-        /// <param name="stream">The stream to read from. This stream will be disposed of when this <see cref="MessagePackStreamReader"/> is disposed.</param>
-        /// <param name="pool">The pool to get result.</param>
-        public MessagePackStreamReader(Stream stream, SequencePool pool)
-            : this(stream, pool, leaveOpen: false)
+            : this(stream, leaveOpen, SequencePool.Shared)
         {
         }
 
@@ -57,18 +47,18 @@ namespace MessagePack
         /// Initializes a new instance of the <see cref="MessagePackStreamReader"/> class.
         /// </summary>
         /// <param name="stream">The stream to read from.</param>
-        /// <param name="pool">The pool to get result.</param>
         /// <param name="leaveOpen">If true, leaves the stream open after this <see cref="MessagePackStreamReader"/> is disposed; otherwise, false.</param>
-        public MessagePackStreamReader(Stream stream, SequencePool pool, bool leaveOpen)
+        /// <param name="sequencePool">The pool to rent a <see cref="Sequence{T}"/> object from.</param>
+        public MessagePackStreamReader(Stream stream, bool leaveOpen, SequencePool sequencePool)
         {
-            if (pool == null)
+            if (sequencePool == null)
             {
-                throw new ArgumentNullException(nameof(pool));
+                throw new ArgumentNullException(nameof(sequencePool));
             }
 
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
             this.leaveOpen = leaveOpen;
-            this.sequenceRental = pool.Rent();
+            this.sequenceRental = sequencePool.Rent();
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackStreamReader.cs
@@ -21,7 +21,7 @@ namespace MessagePack
     {
         private readonly Stream stream;
         private readonly bool leaveOpen;
-        private SequencePool.Rental sequenceRental = SequencePool.Shared.Rent();
+        private SequencePool.Rental sequenceRental = MessagePackSerializer.DefaultOptions.Pool.Rent();
         private SequencePosition? endOfLastMessage;
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -475,7 +475,7 @@ namespace MessagePack.Internal
                 var i = 0;
                 foreach (ObjectSerializationInfo.EmittableMember item in serializationInfo.Members.Where(x => x.IsReadable))
                 {
-                    stringByteKeysField.Add(Utilities.GetWriterBytes(item.StringKey, (ref MessagePackWriter writer, string arg) => writer.Write(arg)));
+                    stringByteKeysField.Add(Utilities.GetWriterBytes(item.StringKey, (ref MessagePackWriter writer, string arg) => writer.Write(arg), SequencePool.Shared));
                     i++;
                 }
             }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
@@ -19,6 +19,11 @@ namespace MessagePack
     class SequencePool
     {
         /// <summary>
+        /// A thread-safe pool of reusable <see cref="Sequence{T}"/> objects.
+        /// </summary>
+        internal static readonly SequencePool Shared = new SequencePool();
+
+        /// <summary>
         /// The value to use for <see cref="Sequence{T}.MinimumSpanLength"/>.
         /// </summary>
         /// <remarks>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
@@ -8,14 +8,14 @@ using Nerdbank.Streams;
 
 namespace MessagePack
 {
+    /// <summary>
+    /// A thread-safe, alloc-free reusable object pool.
+    /// </summary>
 #if MESSAGEPACK_INTERNAL
     internal
 #else
     public
 #endif
-    /// <summary>
-    /// A thread-safe, alloc-free reusable object pool.
-    /// </summary>
     class SequencePool
     {
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/SequencePool.cs
@@ -8,20 +8,16 @@ using Nerdbank.Streams;
 
 namespace MessagePack
 {
+#if MESSAGEPACK_INTERNAL
+    internal
+#else
+    public
+#endif
     /// <summary>
     /// A thread-safe, alloc-free reusable object pool.
     /// </summary>
-    internal class SequencePool
+    class SequencePool
     {
-        /// <summary>
-        /// A thread-safe pool of reusable <see cref="Sequence{T}"/> objects.
-        /// </summary>
-        /// <remarks>
-        /// We use a <see cref="maxSize"/> that allows every processor to be involved in messagepack serialization concurrently,
-        /// plus one nested serialization per processor (since LZ4 and sometimes other nested serializations may exist).
-        /// </remarks>
-        internal static readonly SequencePool Shared = new SequencePool(Environment.ProcessorCount * 2);
-
         /// <summary>
         /// The value to use for <see cref="Sequence{T}.MinimumSpanLength"/>.
         /// </summary>
@@ -41,18 +37,41 @@ namespace MessagePack
         /// <summary>
         /// The array pool which we share with all <see cref="Sequence{T}"/> objects created by this <see cref="SequencePool"/> instance.
         /// </summary>
-        /// <devremarks>
-        /// We allow 100 arrays to be shared (instead of the default 50) and reduce the max array length from the default 1MB to something more reasonable for our expected use.
-        /// </devremarks>
-        private readonly ArrayPool<byte> arrayPool = ArrayPool<byte>.Create(80 * 1024, 100);
+        private readonly ArrayPool<byte> arrayPool;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequencePool"/> class.
+        /// </summary>
+        /// <remarks>
+        /// We use a <see cref="maxSize"/> that allows every processor to be involved in messagepack serialization concurrently,
+        /// plus one nested serialization per processor (since LZ4 and sometimes other nested serializations may exist).
+        /// </remarks>
+        public SequencePool()
+            : this(Environment.ProcessorCount * 2, ArrayPool<byte>.Create(80 * 1024, 100))
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SequencePool"/> class.
         /// </summary>
         /// <param name="maxSize">The maximum size to allow the pool to grow.</param>
-        internal SequencePool(int maxSize)
+        /// <devremarks>
+        /// We allow 100 arrays to be shared (instead of the default 50) and reduce the max array length from the default 1MB to something more reasonable for our expected use.
+        /// </devremarks>
+        public SequencePool(int maxSize)
+            : this(maxSize, ArrayPool<byte>.Create(80 * 1024, 100))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequencePool"/> class.
+        /// </summary>
+        /// <param name="maxSize">The maximum size to allow the pool to grow.</param>
+        /// <param name="arrayPool">Array pool that will be used.</param>
+        public SequencePool(int maxSize, ArrayPool<byte> arrayPool)
         {
             this.maxSize = maxSize;
+            this.arrayPool = arrayPool;
         }
 
         /// <summary>

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -20,11 +20,17 @@ namespace MessagePack
         internal static readonly bool IsMono = Type.GetType("Mono.Runtime") is Type;
 #endif
 
+#if MESSAGEPACK_INTERNAL || DYNAMICCODEDUMPER
+        internal static SequencePool Pool { get; } = new SequencePool();
+#else
+        internal static SequencePool Pool => MessagePackSerializer.DefaultOptions.Pool;
+#endif
+
         internal delegate void GetWriterBytesAction<TArg>(ref MessagePackWriter writer, TArg argument);
 
         internal static byte[] GetWriterBytes<TArg>(TArg arg, GetWriterBytesAction<TArg> action)
         {
-            using (var sequenceRental = SequencePool.Shared.Rent())
+            using (var sequenceRental = Pool.Rent())
             {
                 var writer = new MessagePackWriter(sequenceRental.Value);
                 action(ref writer, arg);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -22,9 +22,9 @@ namespace MessagePack
 
         internal delegate void GetWriterBytesAction<TArg>(ref MessagePackWriter writer, TArg argument);
 
-        internal static byte[] GetWriterBytes<TArg>(TArg arg, GetWriterBytesAction<TArg> action)
+        internal static byte[] GetWriterBytes<TArg>(TArg arg, GetWriterBytesAction<TArg> action, SequencePool pool)
         {
-            using (var sequenceRental = SequencePool.Shared.Rent())
+            using (var sequenceRental = pool.Rent())
             {
                 var writer = new MessagePackWriter(sequenceRental.Value);
                 action(ref writer, arg);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -20,17 +20,11 @@ namespace MessagePack
         internal static readonly bool IsMono = Type.GetType("Mono.Runtime") is Type;
 #endif
 
-#if MESSAGEPACK_INTERNAL || DYNAMICCODEDUMPER
-        internal static SequencePool Pool { get; } = new SequencePool();
-#else
-        internal static SequencePool Pool => MessagePackSerializer.DefaultOptions.Pool;
-#endif
-
         internal delegate void GetWriterBytesAction<TArg>(ref MessagePackWriter writer, TArg argument);
 
         internal static byte[] GetWriterBytes<TArg>(TArg arg, GetWriterBytesAction<TArg> action)
         {
-            using (var sequenceRental = Pool.Rent())
+            using (var sequenceRental = SequencePool.Shared.Rent())
             {
                 var writer = new MessagePackWriter(sequenceRental.Value);
                 action(ref writer, arg);

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -72,14 +72,13 @@ MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.InterfaceImmutableSetFormatter() -> void
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.InterfaceImmutableStackFormatter() -> void
-MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, MessagePack.SequencePool pool) -> void
-MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, MessagePack.SequencePool pool, bool leaveOpen) -> void
+MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen, MessagePack.SequencePool sequencePool) -> void
 MessagePack.Resolvers.ExpandoObjectResolver
 MessagePack.SequencePool
 MessagePack.SequencePool.SequencePool() -> void
 MessagePack.SequencePool.SequencePool(int maxSize) -> void
 MessagePack.SequencePool.SequencePool(int maxSize, System.Buffers.ArrayPool<byte> arrayPool) -> void
-MessagePack.MessagePackSerializerOptions.Pool.get -> MessagePack.SequencePool
 MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool pool) -> MessagePack.MessagePackSerializerOptions
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -73,6 +73,12 @@ MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.InterfaceImmut
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.InterfaceImmutableStackFormatter() -> void
 MessagePack.Resolvers.ExpandoObjectResolver
+MessagePack.SequencePool
+MessagePack.SequencePool.SequencePool() -> void
+MessagePack.SequencePool.SequencePool(int maxSize) -> void
+MessagePack.SequencePool.SequencePool(int maxSize, System.Buffers.ArrayPool<byte> arrayPool) -> void
+MessagePack.MessagePackSerializerOptions.Pool.get -> MessagePack.SequencePool
+MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool pool) -> MessagePack.MessagePackSerializerOptions
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Add(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder collection, int index, TKey key, TValue value, MessagePack.MessagePackSerializerOptions options) -> void
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Complete(System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder intermediateCollection) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>
 override MessagePack.ImmutableCollection.ImmutableDictionaryFormatter<TKey, TValue>.Create(int count, MessagePack.MessagePackSerializerOptions options) -> System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder

--- a/src/MessagePack/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/PublicAPI.Unshipped.txt
@@ -72,6 +72,8 @@ MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableSetFormatter<T>.InterfaceImmutableSetFormatter() -> void
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>
 MessagePack.ImmutableCollection.InterfaceImmutableStackFormatter<T>.InterfaceImmutableStackFormatter() -> void
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, MessagePack.SequencePool pool) -> void
+MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, MessagePack.SequencePool pool, bool leaveOpen) -> void
 MessagePack.Resolvers.ExpandoObjectResolver
 MessagePack.SequencePool
 MessagePack.SequencePool.SequencePool() -> void


### PR DESCRIPTION
Hey! We have had problems on our production server with ArrayPool from the .net framework in the MP library.
GC couldn't stop some message pack threads that were in spin lock in the critical section, so the server had random long Stop The World sometimes (some of them reached up to 10 seconds).

So we want to use TlsOverPerCoreLockedStacksArrayPool from .net core. We can take it from core repo to our code, but we can't change DefaultArrayPool to that pool in MP. That’s why I decided to add the possibility to change ArrayPool implementation.

P.S. We are using .net 4.7.2.

![zlRabcJ](https://user-images.githubusercontent.com/6016431/99068085-858ec780-25b4-11eb-894b-465ed0d10c1b.png)