### PR TITLE
Benchmark cleanup

### DIFF
--- a/benchmark/SerializerBenchmark/BenchmarkConfig.cs
+++ b/benchmark/SerializerBenchmark/BenchmarkConfig.cs
@@ -27,13 +27,13 @@ namespace Benchmark
             Job baseConfig = Job.ShortRun.WithIterationCount(1).WithWarmupCount(1);
 
             // Add(baseConfig.With(Runtime.Clr).With(Jit.RyuJit).With(Platform.X64));
-            this.Add(baseConfig.With(CoreRuntime.Core31).With(Jit.RyuJit).With(Platform.X64));
+            this.AddJob(baseConfig.WithRuntime(CoreRuntime.Core31).WithJit(Jit.RyuJit).WithPlatform(Platform.X64));
 
-            this.Add(MarkdownExporter.GitHub);
-            this.Add(CsvExporter.Default);
-            this.Add(MemoryDiagnoser.Default);
+            this.AddExporter(MarkdownExporter.GitHub);
+            this.AddExporter(CsvExporter.Default);
+            this.AddDiagnoser(MemoryDiagnoser.Default);
 
-            this.Add(new DataSizeColumn());
+            this.AddColumn(new DataSizeColumn());
 
             this.Orderer = new CustomOrderer();
         }
@@ -105,11 +105,13 @@ namespace Benchmark
                 mi.DeclaringType.GetField("Serializer").SetValue(instance, benchmarkCase.Parameters[0].Value);
                 mi.DeclaringType.GetMethod("Setup").Invoke(instance, null);
 
-                var bytes = (byte[]) mi.Invoke(instance, null);
+                var bytes = (byte[])mi.Invoke(instance, null);
                 var byteSize = bytes.Length;
                 var cultureInfo = summary.GetCultureInfo();
                 if (style.PrintUnitsInContent)
+                {
                     return SizeValue.FromBytes(byteSize).ToString(style.SizeUnit, cultureInfo);
+                }
 
                 return byteSize.ToString("0.##", cultureInfo);
             }

--- a/benchmark/SerializerBenchmark/Program.cs
+++ b/benchmark/SerializerBenchmark/Program.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Benchmark;
-using Benchmark.Models;
 using BenchmarkDotNet.Running;
 
-namespace ConsoleApp1
+namespace Benchmark
 {
-    internal class Program
+    internal static class Program
     {
         private static void Main(string[] args)
         {

--- a/benchmark/SerializerBenchmark/SerializerBenchmark.cs
+++ b/benchmark/SerializerBenchmark/SerializerBenchmark.cs
@@ -21,7 +21,7 @@ namespace Benchmark
         [ParamsSource(nameof(Serializers))]
         public SerializerBase Serializer;
 
-        // Currently BenchmarkdDotNet does not detect inherited ParamsSource so use copy and paste:)
+        // Currently BenchmarkDotNet does not detect inherited ParamsSource so use copy and paste:)
         public IEnumerable<SerializerBase> Serializers => new SerializerBase[]
         {
             new MessagePack_v1(),
@@ -568,7 +568,7 @@ namespace Benchmark
         [ParamsSource(nameof(Serializers))]
         public SerializerBase Serializer;
 
-        // Currently BenchmarkdDotNet does not detect inherited ParamsSource so use copy and paste:)
+        // Currently BenchmarkDotNet does not detect inherited ParamsSource so use copy and paste:)
         public IEnumerable<SerializerBase> Serializers => new SerializerBase[]
         {
             new MessagePack_v1(),
@@ -1099,7 +1099,7 @@ namespace Benchmark
 
         private bool isContractless;
 
-        // Currently BenchmarkdDotNet does not detect inherited ParamsSource so use copy and paste:)
+        // Currently BenchmarkDotNet does not detect inherited ParamsSource so use copy and paste:)
         public IEnumerable<SerializerBase> Serializers => new SerializerBase[]
         {
             new MessagePack_v1(),
@@ -1197,7 +1197,7 @@ namespace Benchmark
         [ParamsSource(nameof(Serializers))]
         public SerializerBase Serializer;
 
-        // Currently BenchmarkdDotNet does not detect inherited ParamsSource so use copy and paste:)
+        // Currently BenchmarkDotNet does not detect inherited ParamsSource so use copy and paste:)
         public IEnumerable<SerializerBase> Serializers => new SerializerBase[]
         {
             new MessagePack_v1(),

--- a/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
+++ b/benchmark/SerializerBenchmark/SerializerBenchmark.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Ceras" Version="4.1.7" />
     <PackageReference Include="FsPickler" Version="5.2.2" />
     <PackageReference Include="Hyperion" Version="0.9.11" />


### PR DESCRIPTION
This is a proposal for small changes in the benchmark project.
Note, that the BenchmarkDotNet version changes from 0.12.0 to 0.12.1, not sure if that is wanted or should be avoided. With the change, we can save ourselves a few lines of code.