### PR TITLE
Add test to document ctor+property setter behavior

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverTests.cs
@@ -84,6 +84,18 @@ namespace MessagePack.Tests
             Assert.Null(instance.Prop2);
         }
 
+        [Fact]
+        public void CtorParameterAndPropertySetterExists()
+        {
+            var m1 = new ClassWithPropertySetterAndDummyCtor(999) { MyProperty = 100 };
+            byte[] bin = MessagePackSerializer.Serialize(m1);
+            var m2 = MessagePackSerializer.Deserialize<ClassWithPropertySetterAndDummyCtor>(bin);
+
+            // In this version of the deserializer, we expect the property setter to be invoked
+            // and reaffirm the value already passed to the constructor.
+            Assert.Equal(m1.MyProperty, m2.MyProperty);
+        }
+
         /// <summary>
         /// Verifies that virtual and overridden properties do not cause the dynamic resolver to malfunction.
         /// </summary>
@@ -356,6 +368,17 @@ namespace MessagePack.Tests
         {
             [DataMember]
             public string Name { get; set; }
+        }
+
+        [MessagePackObject(true)]
+        public class ClassWithPropertySetterAndDummyCtor
+        {
+            public int MyProperty { get; set; }
+
+            public ClassWithPropertySetterAndDummyCtor(int myProperty)
+            {
+                // This constructor intentionally left blank.
+            }
         }
     }
 }


### PR DESCRIPTION
This documents v2.2 behavior as @neuecc called out in https://github.com/neuecc/MessagePack-CSharp/pull/1137#issuecomment-733565126

This behavior changes in v2.3, so I will update this test when this merges into the `develop` branch.