### PR TITLE
Remove MessagePack.Annotations.asmdef on Unity

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef
@@ -1,3 +1,0 @@
-﻿{
-	"name": "MessagePack.Annotations"
-}

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef.meta
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Annotations/MessagePack.Annotations.asmdef.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 5a46ad82eac024e4fbb6a0516a5def17
-AssemblyDefinitionImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePack.asmdef
@@ -1,7 +1,6 @@
 {
     "name": "MessagePack",
     "references": [
-        "MessagePack.Annotations"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],


### PR DESCRIPTION
After https://github.com/neuecc/MessagePack-CSharp/pull/1071, `MessagePack.Annotations.asmdef` was added in Unity.

However, there is little merit in separating them in Unity, and it seems to be causing confusion.
Also, due to the lack of an easy-to-use package manager in Unity, such a change in the 2.x makes it difficult to handle references to internal libraries that depend on MessagePack between versions.

Therefore, I would like to revert this change.
Is there any strong advantage to use Annotaions.asmdef? @hikarin522