### PR TITLE
Define SPAN_BUILTIN for net5.0

### DIFF
--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'net5.0' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <LangVersion>8.0</LangVersion>
 


### PR DESCRIPTION
This just drops a few internal methods from the net5.0 build of the assembly that the compiler wouldn't have used anyway since instance methods exist where these were polyfill extension methods.