### PR TITLE
Make cctor defer Reflection that fails in AOT

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSecurity.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSecurity.cs
@@ -255,7 +255,7 @@ namespace MessagePack
         /// </summary>
         private class ObjectFallbackEqualityComparer : IEqualityComparer<object>, IEqualityComparer
         {
-            private static readonly MethodInfo GetHashCollisionResistantEqualityComparerOpenGenericMethod = typeof(MessagePackSecurity).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(MessagePackSecurity.GetHashCollisionResistantEqualityComparer) && m.IsGenericMethod);
+            private static readonly Lazy<MethodInfo> GetHashCollisionResistantEqualityComparerOpenGenericMethod = new Lazy<MethodInfo>(() => typeof(MessagePackSecurity).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(MessagePackSecurity.GetHashCollisionResistantEqualityComparer) && m.IsGenericMethod));
             private readonly MessagePackSecurity security;
             private readonly ThreadsafeTypeKeyHashTable<IEqualityComparer> equalityComparerCache = new ThreadsafeTypeKeyHashTable<IEqualityComparer>();
 
@@ -288,7 +288,7 @@ namespace MessagePack
                 {
                     try
                     {
-                        equalityComparer = (IEqualityComparer)GetHashCollisionResistantEqualityComparerOpenGenericMethod.MakeGenericMethod(valueType).Invoke(this.security, Array.Empty<object>());
+                        equalityComparer = (IEqualityComparer)GetHashCollisionResistantEqualityComparerOpenGenericMethod.Value.MakeGenericMethod(valueType).Invoke(this.security, Array.Empty<object>());
                     }
                     catch (TargetInvocationException ex)
                     {


### PR DESCRIPTION
This makes it possible that the reflection is never called. In AOT environments where it may still be called (just later) then this too can be avoided in the app by overriding the `MessagePackSecurity.GetHashCollisionResistantEqualityComparer` method and implementing it such that when `T` is `object` it can do something other than invoking the reflection-invoking `ObjectFallbackEqualityComparer` class.

Fixes #1168