### PR TITLE
Remove assembly version info from generic type arguments

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -15,7 +15,7 @@ namespace MessagePack
     public class MessagePackSerializerOptions
     {
         // see:http://msdn.microsoft.com/en-us/library/w3f99sx1.aspx
-        internal static readonly Regex AssemblyNameVersionSelectorRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=[\w-]+, PublicKeyToken=(?:null|[a-f0-9]{16})$", RegexOptions.Compiled);
+        internal static readonly Regex AssemblyNameVersionSelectorRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=[\w-]+, PublicKeyToken=(?:null|[a-f0-9]{16})", RegexOptions.Compiled);
 
         /// <summary>
         /// A collection of known dangerous types that are not expected in a typical MessagePack stream,


### PR DESCRIPTION
We need to remove the version information in multiple places in the assembly-qualified type name. In a generic type, which may look like this:

> "System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"

We need to get it down to looking like this:

> "System.Collections.Generic.List`1[[System.Int32, mscorlib]], mscorlib"

Note that means that the regex we were using cannot require that the match end at the end of the string.

Fixes #1190