### PR TITLE
Allow private constructors for the ContractlessStandardResolver, when using ctor attribute

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ReflectionExtensions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ReflectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -47,6 +48,12 @@ namespace MessagePack.Internal
         public static MethodInfo GetSetMethod(this PropertyInfo propInfo)
         {
             return propInfo.SetMethod;
+        }
+
+        public static bool HasPrivateCtorForSerialization(this TypeInfo type)
+        {
+            var markedCtor = type.DeclaredConstructors.SingleOrDefault(x => x.GetCustomAttribute<SerializationConstructorAttribute>(false) != null);
+            return markedCtor?.Attributes.HasFlag(MethodAttributes.Private) ?? false;
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -224,7 +224,7 @@ namespace MessagePack.Resolvers
                     return;
                 }
 
-                if (ti.IsAnonymous())
+                if (ti.IsAnonymous() || ti.HasPrivateCtorForSerialization())
                 {
                     Formatter = (IMessagePackFormatter<T>)DynamicObjectTypeBuilder.BuildFormatterToDynamicMethod(typeof(T), true, true, false);
                     return;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
@@ -193,6 +193,25 @@ namespace MessagePack.Tests
             public bool CreatedUsingPrivateCtor { get; }
         }
 
+        public class ContractlessClassPrivateCtor
+        {
+            public int X { get; private set; }
+
+            public int Y { get; private set; }
+
+            [SerializationConstructor]
+            private ContractlessClassPrivateCtor(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public static ContractlessClassPrivateCtor Create(int x, int y)
+            {
+                return new ContractlessClassPrivateCtor(x, y);
+            }
+        }
+
         [MessagePackObject]
         public class CompletelyPrivateConstructor
         {
@@ -331,6 +350,17 @@ namespace MessagePack.Tests
             var p1 = CompletelyPrivateConstructor.Create(10, 20);
             var bin = MessagePackSerializer.Serialize(p1, StandardResolverAllowPrivate.Options);
             var p2 = MessagePackSerializer.Deserialize<CompletelyPrivateConstructor>(bin, StandardResolverAllowPrivate.Options);
+
+            Assert.Equal(p1.X, p2.X);
+            Assert.Equal(p1.Y, p2.Y);
+        }
+
+        [Fact]
+        public void ContractlessAttributedPrivateConstructor()
+        {
+            var p1 = ContractlessClassPrivateCtor.Create(10, 20);
+            var bin = MessagePackSerializer.Serialize(p1, ContractlessStandardResolver.Options);
+            var p2 = MessagePackSerializer.Deserialize<ContractlessClassPrivateCtor>(bin, ContractlessStandardResolver.Options);
 
             Assert.Equal(p1.X, p2.X);
             Assert.Equal(p1.Y, p2.Y);


### PR DESCRIPTION
Similar to #530, but allows this feature for the ContractlessStandardResolver.

Private constructors explicitly marked with the `[SerializationConstructor]` attribute should be honored, without requiring a private member option / resolver.

Related #40 