### PR TITLE
Allow deserializing `byte[]` from a msgpack array

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/StandardClassLibraryFormatterTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/StandardClassLibraryFormatterTests.cs
@@ -2,12 +2,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MessagePack.Tests
 {
     public class StandardClassLibraryFormatterTests : TestBase
     {
+        private readonly ITestOutputHelper logger;
+
+        public StandardClassLibraryFormatterTests(ITestOutputHelper logger)
+        {
+            this.logger = logger;
+        }
+
         [Fact]
         public void SystemType_Serializable()
         {
@@ -24,6 +33,49 @@ namespace MessagePack.Tests
             byte[] msgpack = MessagePackSerializer.Serialize(type, MessagePackSerializerOptions.Standard);
             Type type2 = MessagePackSerializer.Deserialize<Type>(msgpack, MessagePackSerializerOptions.Standard);
             Assert.Equal(type, type2);
+        }
+
+        [Fact]
+        public void DeserializeByteArrayFromFixArray()
+        {
+            var input = new byte[] { 0x93, 0x01, 0x02, 0x03 };
+            byte[] byte_array = MessagePackSerializer.Deserialize<byte[]>(input);
+            Assert.Equal(new byte[] { 1, 2, 3 }, byte_array);
+        }
+
+        [Fact]
+        public void DeserializeByteArrayFromFixArray_LargerNumbers()
+        {
+            var input = new byte[] { 0x93, 0x01, 0x02, 0xCC, 0xD4 };
+            byte[] byte_array = MessagePackSerializer.Deserialize<byte[]>(input);
+            Assert.Equal(new byte[] { 1, 2, 212 }, byte_array);
+        }
+
+        [Fact]
+        public void DeserializeByteArrayFromFixArray_LargerThanByte()
+        {
+            var input = new byte[] { 0x93, 0x01, 0x02, 0xCD, 0x08, 0x48 }; // 1, 2, 2120
+            var ex = Assert.Throws<MessagePackSerializationException>(() => MessagePackSerializer.Deserialize<byte[]>(input));
+            this.logger.WriteLine(ex.ToString());
+        }
+
+        [Fact]
+        public void DeserializeByteArrayFromFixArray_ZeroLength()
+        {
+            var input = new byte[] { 0x90 }; // [ ]
+            byte[] actual = MessagePackSerializer.Deserialize<byte[]>(input);
+            Assert.Empty(actual);
+
+            // Make sure we're optimized to reuse singleton empty arrays.
+            Assert.Same(Array.Empty<byte>(), actual);
+        }
+
+        [Fact]
+        public void DeserializeByteArrayFromFixArray_Array32()
+        {
+            var input = new byte[] { 0xDD, 0, 0, 0, 3, 1, 2, 3 };
+            byte[] byte_array = MessagePackSerializer.Deserialize<byte[]>(input);
+            Assert.Equal(new byte[] { 1, 2, 3 }, byte_array);
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Shims/XUnit.cs
@@ -87,6 +87,11 @@ namespace Xunit
             NUnit.Framework.Assert.IsNull(expected);
         }
 
+        public static void Empty(System.Collections.IEnumerable enumerable)
+        {
+            Assert.False(enumerable.GetEnumerator().MoveNext());
+        }
+
         public static T IsType<T>(object o)
         {
             NUnit.Framework.Assert.AreEqual(typeof(T), o.GetType());


### PR DESCRIPTION
Prior to this change, we only could deserialize `byte[]` from a msgpack `bin` type.
We still always serialize `byte[]` with the `bin` type.

Fixes #1251
