### PR TITLE
Allow object that has either `[MessagePackObject]` or a valid `[MessagePackFormatter()]`

### DIFF
--- a/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
+++ b/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
@@ -16,6 +16,7 @@ namespace MessagePackAnalyzer
         public const string UseMessagePackObjectAttributeId = "MsgPack003";
         public const string AttributeMessagePackObjectMembersId = "MsgPack004";
         public const string InvalidMessagePackObjectId = "MsgPack005";
+        public const string MessagePackFormatterMustBeMessagePackFormatterId = "MsgPack006";
 
         internal const string Category = "Usage";
 
@@ -31,6 +32,16 @@ namespace MessagePackAnalyzer
             category: Category,
             messageFormat: "Type must be marked with MessagePackObjectAttribute. {0}.", // type.Name
             description: "Type must be marked with MessagePackObjectAttribute.",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            helpLinkUri: AnalyzerUtilities.GetHelpLink(UseMessagePackObjectAttributeId));
+
+        internal static readonly DiagnosticDescriptor MessageFormatterMustBeMessagePackFormatter = new DiagnosticDescriptor(
+            id: MessagePackFormatterMustBeMessagePackFormatterId,
+            title: "Must be IMessageFormatter",
+            category: Category,
+            messageFormat: "Type must be of IMessagePackFormatter. {0}.", // type.Name
+            description: "Type must be of IMessagePackFormatter.",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true,
             helpLinkUri: AnalyzerUtilities.GetHelpLink(UseMessagePackObjectAttributeId));
@@ -58,7 +69,9 @@ namespace MessagePackAnalyzer
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
             TypeMustBeMessagePackObject,
             PublicMemberNeedsKey,
-            InvalidMessagePackObject);
+            InvalidMessagePackObject,
+            MessageFormatterMustBeMessagePackFormatter
+            );
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
+++ b/src/MessagePackAnalyzer/MessagePackAnalyzer.cs
@@ -70,8 +70,7 @@ namespace MessagePackAnalyzer
             TypeMustBeMessagePackObject,
             PublicMemberNeedsKey,
             InvalidMessagePackObject,
-            MessageFormatterMustBeMessagePackFormatter
-            );
+            MessageFormatterMustBeMessagePackFormatter);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/MessagePackAnalyzer/ReferenceSymbols.cs
+++ b/src/MessagePackAnalyzer/ReferenceSymbols.cs
@@ -14,6 +14,7 @@ namespace MessagePackAnalyzer
             INamedTypeSymbol keyAttribute,
             INamedTypeSymbol ignoreAttribute,
             INamedTypeSymbol formatterAttribute,
+            INamedTypeSymbol messagePackFormatter,
             INamedTypeSymbol ignoreDataMemberAttribute)
         {
             this.MessagePackObjectAttribute = messagePackObjectAttribute;
@@ -21,6 +22,7 @@ namespace MessagePackAnalyzer
             this.KeyAttribute = keyAttribute;
             this.IgnoreAttribute = ignoreAttribute;
             this.FormatterAttribute = formatterAttribute;
+            this.MessagePackFormatter = messagePackFormatter;
             this.IgnoreDataMemberAttribute = ignoreDataMemberAttribute;
         }
 
@@ -33,6 +35,8 @@ namespace MessagePackAnalyzer
         internal INamedTypeSymbol IgnoreAttribute { get; }
 
         internal INamedTypeSymbol FormatterAttribute { get; }
+
+        internal INamedTypeSymbol MessagePackFormatter { get; }
 
         internal INamedTypeSymbol IgnoreDataMemberAttribute { get; }
 
@@ -70,6 +74,12 @@ namespace MessagePackAnalyzer
                 return false;
             }
 
+            var messageFormatter = compilation.GetTypeByMetadataName("MessagePack.Formatters.IMessagePackFormatter");
+            if (messageFormatter is null)
+            {
+                return false;
+            }
+
             var ignoreDataMemberAttribute = compilation.GetTypeByMetadataName("System.Runtime.Serialization.IgnoreDataMemberAttribute");
             if (ignoreDataMemberAttribute is null)
             {
@@ -82,6 +92,7 @@ namespace MessagePackAnalyzer
                 keyAttribute,
                 ignoreAttribute,
                 formatterAttribute,
+                messageFormatter,
                 ignoreDataMemberAttribute);
             return true;
         }

--- a/src/MessagePackAnalyzer/ReferenceSymbols.cs
+++ b/src/MessagePackAnalyzer/ReferenceSymbols.cs
@@ -13,12 +13,14 @@ namespace MessagePackAnalyzer
             INamedTypeSymbol unionAttribute,
             INamedTypeSymbol keyAttribute,
             INamedTypeSymbol ignoreAttribute,
+            INamedTypeSymbol formatterAttribute,
             INamedTypeSymbol ignoreDataMemberAttribute)
         {
             this.MessagePackObjectAttribute = messagePackObjectAttribute;
             this.UnionAttribute = unionAttribute;
             this.KeyAttribute = keyAttribute;
             this.IgnoreAttribute = ignoreAttribute;
+            this.FormatterAttribute = formatterAttribute;
             this.IgnoreDataMemberAttribute = ignoreDataMemberAttribute;
         }
 
@@ -29,6 +31,8 @@ namespace MessagePackAnalyzer
         internal INamedTypeSymbol KeyAttribute { get; }
 
         internal INamedTypeSymbol IgnoreAttribute { get; }
+
+        internal INamedTypeSymbol FormatterAttribute { get; }
 
         internal INamedTypeSymbol IgnoreDataMemberAttribute { get; }
 
@@ -60,6 +64,12 @@ namespace MessagePackAnalyzer
                 return false;
             }
 
+            var formatterAttribute = compilation.GetTypeByMetadataName("MessagePack.MessagePackFormatterAttribute");
+            if (formatterAttribute is null)
+            {
+                return false;
+            }
+
             var ignoreDataMemberAttribute = compilation.GetTypeByMetadataName("System.Runtime.Serialization.IgnoreDataMemberAttribute");
             if (ignoreDataMemberAttribute is null)
             {
@@ -71,6 +81,7 @@ namespace MessagePackAnalyzer
                 unionAttribute,
                 keyAttribute,
                 ignoreAttribute,
+                formatterAttribute,
                 ignoreDataMemberAttribute);
             return true;
         }

--- a/src/MessagePackAnalyzer/TypeCollector.cs
+++ b/src/MessagePackAnalyzer/TypeCollector.cs
@@ -183,6 +183,13 @@ namespace MessagePackAnalyzer
         {
             var isClass = !type.IsValueType;
 
+            AttributeData formatterAttr = type.GetAttributes().FirstOrDefault(x => Equals(x.AttributeClass, this.typeReferences.FormatterAttribute));
+            if( formatterAttr != null )
+            {
+                // TODO: Validate that ConstructorArguments[0] is in fact of type IMessagePackFormatter
+                return;
+            }
+
             AttributeData contractAttr = type.GetAttributes().FirstOrDefault(x => Equals(x.AttributeClass, this.typeReferences.MessagePackObjectAttribute));
             if (contractAttr == null)
             {

--- a/src/MessagePackAnalyzer/TypeCollector.cs
+++ b/src/MessagePackAnalyzer/TypeCollector.cs
@@ -191,8 +191,9 @@ namespace MessagePackAnalyzer
                 var isMessagePackFormatter = formatterType.AllInterfaces.Any(x => x.Equals(this.typeReferences.MessagePackFormatter));
                 if (!isMessagePackFormatter)
                 {
+                    var location = formatterAttr.ApplicationSyntaxReference.SyntaxTree.GetLocation(formatterAttr.ApplicationSyntaxReference.Span);
                     var typeInfo = ImmutableDictionary.Create<string, string>().Add("type", formatterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
-                    this.ReportContext.Add(Diagnostic.Create(MessagePackAnalyzer.MessageFormatterMustBeMessagePackFormatter, formatterType.Locations[0], typeInfo));
+                    this.ReportContext.Add(Diagnostic.Create(MessagePackAnalyzer.MessageFormatterMustBeMessagePackFormatter, location, typeInfo));
                 }
 
                 return;

--- a/src/MessagePackAnalyzer/TypeCollector.cs
+++ b/src/MessagePackAnalyzer/TypeCollector.cs
@@ -184,16 +184,17 @@ namespace MessagePackAnalyzer
             var isClass = !type.IsValueType;
 
             AttributeData formatterAttr = type.GetAttributes().FirstOrDefault(x => Equals(x.AttributeClass, this.typeReferences.FormatterAttribute));
-            if( formatterAttr != null )
+            if (formatterAttr != null)
             {
                 // Validate that the typed formatter is actually of `IMessagePackFormatter`
                 var formatterType = (ITypeSymbol)formatterAttr.ConstructorArguments[0].Value;
                 var isMessagePackFormatter = formatterType.AllInterfaces.Any(x => x.Equals(this.typeReferences.MessagePackFormatter));
-                if( !isMessagePackFormatter )
+                if (!isMessagePackFormatter)
                 {
                     var typeInfo = ImmutableDictionary.Create<string, string>().Add("type", formatterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
                     this.ReportContext.Add(Diagnostic.Create(MessagePackAnalyzer.MessageFormatterMustBeMessagePackFormatter, formatterType.Locations[0], typeInfo));
                 }
+
                 return;
             }
 

--- a/src/MessagePackAnalyzer/TypeCollector.cs
+++ b/src/MessagePackAnalyzer/TypeCollector.cs
@@ -179,7 +179,7 @@ namespace MessagePackAnalyzer
             return;
         }
 
-        private void ICollectObject(INamedTypeSymbol type, ISymbol? callerSymbol)
+        private void CollectObject(INamedTypeSymbol type, ISymbol? callerSymbol)
         {
             var isClass = !type.IsValueType;
 

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -37,7 +37,29 @@ public class FooFormatter : IMessagePackFormatter<Foo> {
 }
 
 
-[MessagePackFormatter(typeof(Foo))]
+[MessagePackFormatter(typeof(FooFormatter))]
+public struct Foo
+{
+}
+
+[MessagePackObject]
+public class SomeClass {
+    [Key(0)]
+    public Foo SomeFoo { get; set; }
+}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(input);
+    }
+
+    [Fact]
+    public async Task InvalidMessageFormatterType()
+    {
+        string input = Preamble + @"using MessagePack.Formatters;
+
+public class {|MsgPack006:InvalidMessageFormatter|} { }
+
+[MessagePackFormatter(typeof(InvalidMessageFormatter))]
 public struct Foo
 {
 }

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -57,9 +57,9 @@ public class SomeClass {
     {
         string input = Preamble + @"using MessagePack.Formatters;
 
-public class {|MsgPack006:InvalidMessageFormatter|} { }
+public class InvalidMessageFormatter { }
 
-[MessagePackFormatter(typeof(InvalidMessageFormatter))]
+[{|MsgPack006:MessagePackFormatter(typeof(InvalidMessageFormatter))|}]
 public struct Foo
 {
 }
@@ -73,7 +73,6 @@ public class SomeClass {
 
         await VerifyCS.VerifyAnalyzerAsync(input);
     }
-
 
     [Fact]
     public async Task NullStringKey()

--- a/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
+++ b/tests/MessagePackAnalyzer.Tests/MessagePackAnalyzerTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using VerifyCS = CSharpCodeFixVerifier<MessagePackAnalyzer.MessagePackAnalyzer, MessagePackAnalyzer.MessagePackCodeFixProvider>;
+using VerifyCS =
+    CSharpCodeFixVerifier<MessagePackAnalyzer.MessagePackAnalyzer, MessagePackAnalyzer.MessagePackCodeFixProvider>;
 
 public class MessagePackAnalyzerTests
 {
@@ -22,6 +25,33 @@ public class Foo
 
         await VerifyCS.VerifyAnalyzerWithoutMessagePackReferenceAsync(input);
     }
+
+    [Fact]
+    public async Task MessageFormatterAttribute()
+    {
+        string input = Preamble + @"using MessagePack.Formatters;
+
+public class FooFormatter : IMessagePackFormatter<Foo> {
+	public void Serialize(ref MessagePackWriter writer, Foo value, MessagePackSerializerOptions options) {}
+	public Foo Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options) => default;
+}
+
+
+[MessagePackFormatter(typeof(Foo))]
+public struct Foo
+{
+}
+
+[MessagePackObject]
+public class SomeClass {
+    [Key(0)]
+    public Foo SomeFoo { get; set; }
+}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(input);
+    }
+
 
     [Fact]
     public async Task NullStringKey()
@@ -106,12 +136,13 @@ public class Bar
     {
         var inputs = new string[]
         {
-                @"
+            @"
 public class Foo
 {
     public int {|MsgPack004:Member1|} { get; set; }
 }
-", @"using MessagePack;
+",
+            @"using MessagePack;
 
 [MessagePackObject]
 public class Bar : Foo
@@ -122,13 +153,14 @@ public class Bar : Foo
         };
         var outputs = new string[]
         {
-                @"
+            @"
 public class Foo
 {
     [MessagePack.Key(1)]
     public int Member1 { get; set; }
 }
-", @"using MessagePack;
+",
+            @"using MessagePack;
 
 [MessagePackObject]
 public class Bar : Foo


### PR DESCRIPTION
 - [x] Allow object that are annotated with `[MessagePackFormatter()]`
 - [x] Verify that the actual MessagePackFormatter(typeof(T)) is a valid `IMessagePackFormatter` (`MsgPack006` diagnostic)