### PR TITLE
Suppress the only build warning we have

### DIFF
--- a/benchmark/ExperimentalBenchmark/ExperimentalBenchmark.csproj
+++ b/benchmark/ExperimentalBenchmark/ExperimentalBenchmark.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Benchmark</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);MSB3243</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As far as I know, there's no way to "fix" this and it's actually by design because we are comparing two versions of MessagePack.