### PR TITLE
Use AssemblyBuilderAccess.RunAndCollect instead of AssemblyBuilderAccess.Run

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/DynamicAssembly.cs
@@ -26,7 +26,7 @@ namespace MessagePack.Internal
             AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.RunAndSave;
             this.moduleName = moduleName;
 #else
-            AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.Run;
+            AssemblyBuilderAccess builderAccess = AssemblyBuilderAccess.RunAndCollect;
 #endif
             this.assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(moduleName), builderAccess);
             this.moduleBuilder = this.assemblyBuilder.DefineDynamicModule(moduleName + ".dll");


### PR DESCRIPTION
resolves #1150

I'm having same issue as above, with .NET 5.
I think RunAndCollect should be good to go :)
(Appendix: https://github.com/protobuf-net/protobuf-net.Grpc/issues/159 .NET Grpc had same issue, finally fixed with RunAndCollect.)