### PR TITLE
Fix handling of readonly private fields

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1492,7 +1492,7 @@ namespace MessagePack.Internal
                             {
                                 FieldInfo = field,
                                 IsReadable = allowPrivate || field.IsPublic,
-                                IsWritable = allowPrivate || (field.IsPublic && !field.IsInitOnly),
+                                IsWritable = (allowPrivate || field.IsPublic) && !field.IsInitOnly,
                                 StringKey = firstMemberByName ? item.Name : $"{item.DeclaringType.FullName}.{item.Name}",
                             };
                         }
@@ -1675,7 +1675,7 @@ namespace MessagePack.Internal
                     {
                         FieldInfo = item,
                         IsReadable = allowPrivate || item.IsPublic,
-                        IsWritable = allowPrivate || (item.IsPublic && !item.IsInitOnly),
+                        IsWritable = (allowPrivate || item.IsPublic) && !item.IsInitOnly,
                     };
                     if (!member.IsReadable && !member.IsWritable)
                     {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/AllowPrivateTest.cs
@@ -157,6 +157,28 @@ namespace MessagePack.Tests
             internal InternalEnum EnumProperty { get; set; }
         }
 
+        [MessagePackObject]
+        public class PrivateReadonlyField
+        {
+            public static PrivateReadonlyField WithNullValue { get; } = new PrivateReadonlyField();
+
+            [Key(0)]
+            private readonly string field;
+
+            [SerializationConstructor]
+            public PrivateReadonlyField(string field)
+            {
+                this.field = field ?? "not null";
+            }
+
+            private PrivateReadonlyField()
+            {
+            }
+
+            [IgnoreMember]
+            public string Field => field;
+        }
+
 #if !ENABLE_IL2CPP
 
         [MessagePackObject]
@@ -308,6 +330,15 @@ namespace MessagePack.Tests
             byte[] bytes = MessagePackSerializer.Serialize(expected, StandardResolverAllowPrivate.Options);
             InternalClass actual = MessagePackSerializer.Deserialize<InternalClass>(bytes, StandardResolverAllowPrivate.Options);
             Assert.Equal(expected.EnumProperty, actual.EnumProperty);
+        }
+
+        [Fact]
+        public void PrivateReadonlyFieldSetInConstructor()
+        {
+            PrivateReadonlyField initial = PrivateReadonlyField.WithNullValue;
+            var bin = MessagePackSerializer.Serialize(initial, StandardResolverAllowPrivate.Options);
+            var deserialized = MessagePackSerializer.Deserialize<PrivateReadonlyField>(bin, StandardResolverAllowPrivate.Options);
+            Assert.Equal("not null", deserialized.Field);
         }
 
 #if !ENABLE_IL2CPP


### PR DESCRIPTION
Disallow writing to readonly private fields even when using a resolver
that allows using private fields.

Fixes: #1218