### PR TITLE
Updating constructor matching for int keys

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1812,7 +1812,7 @@ namespace MessagePack.Internal
                                     if (ctorEnumerator != null)
                                     {
                                         ctor = null;
-                                        continue;
+                                        break;
                                     }
                                     else
                                     {
@@ -1825,7 +1825,7 @@ namespace MessagePack.Internal
                                 if (ctorEnumerator != null)
                                 {
                                     ctor = null;
-                                    continue;
+                                    break;
                                 }
                                 else
                                 {
@@ -1858,7 +1858,7 @@ namespace MessagePack.Internal
                                     if (ctorEnumerator != null)
                                     {
                                         ctor = null;
-                                        continue;
+                                        break;
                                     }
                                     else
                                     {
@@ -1876,7 +1876,7 @@ namespace MessagePack.Internal
                                     if (ctorEnumerator != null)
                                     {
                                         ctor = null;
-                                        continue;
+                                        break;
                                     }
                                     else
                                     {
@@ -1889,7 +1889,7 @@ namespace MessagePack.Internal
                                 if (ctorEnumerator != null)
                                 {
                                     ctor = null;
-                                    continue;
+                                    break;
                                 }
                                 else
                                 {

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1787,6 +1787,7 @@ namespace MessagePack.Internal
             var constructorParameters = new List<EmittableMemberAndConstructorParameter>();
             if (ctor != null)
             {
+                IReadOnlyDictionary<int, EmittableMember> ctorParamIndexIntMembersDictionary = intMembers.OrderBy(x => x.Key).Select((x, i) => (Key: x.Value, Index: i)).ToDictionary(x => x.Index, x => x.Key);
                 ILookup<string, KeyValuePair<string, EmittableMember>> constructorLookupByKeyDictionary = stringMembers.ToLookup(x => x.Key, x => x, StringComparer.OrdinalIgnoreCase);
                 ILookup<string, KeyValuePair<string, EmittableMember>> constructorLookupByMemberNameDictionary = stringMembers.ToLookup(x => x.Value.Name, x => x, StringComparer.OrdinalIgnoreCase);
                 do
@@ -1798,7 +1799,7 @@ namespace MessagePack.Internal
                         EmittableMember paramMember;
                         if (isIntKey)
                         {
-                            if (intMembers.TryGetValue(ctorParamIndex, out paramMember))
+                            if (ctorParamIndexIntMembersDictionary.TryGetValue(ctorParamIndex, out paramMember))
                             {
                                 if ((item.ParameterType == paramMember.Type ||
                                     item.ParameterType.GetTypeInfo().IsAssignableFrom(paramMember.Type))

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectResolverConstructorTest.cs
@@ -255,6 +255,30 @@ namespace MessagePack.Tests
             }
         }
 
+        /// <summary>
+        /// This constructor tests the case where there are missing int keys, to ensure that
+        /// the correct ctor is still found using index numbers of the keys, not their values.
+        /// </summary>
+        [MessagePackObject]
+        public class TestConstructor10
+        {
+            [Key(0)]
+            public int X { get; }
+
+            [Key(2)]
+            public int Y { get; }
+
+            [Key(5)]
+            public int Z { get; }
+
+            public TestConstructor10(int x, int y, int z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+        }
+
         [Fact]
         public void StringKey()
         {
@@ -349,6 +373,18 @@ namespace MessagePack.Tests
             r.X.Is(7);
             r.Y.Is(8);
             r.Z.Is(9);
+        }
+
+        [Fact]
+        public void MatchedClassCtorFoundWithMissingIntKeys()
+        {
+            var ctor = new TestConstructor10(10, 11, 12);
+            var bin = MessagePackSerializer.Serialize(ctor);
+            var r = MessagePackSerializer.Deserialize<TestConstructor10>(bin);
+
+            r.X.Is(10);
+            r.Y.Is(11);
+            r.Z.Is(12);
         }
     }
 }


### PR DESCRIPTION
The following example works fine for mutable objects.
```c#
[MessagePackObject]
public class Example
{
    [Key(0)]
    public int IntProperty { get; set; }

    [Key(2)]
    public string StringProperty { get; set; }
}
```

Unfortunately, it is impossible to repeat the same thing for immutable objects. Serializing the following example throws an exception: MessagePack.MessagePackSerializationException {"Failed to serialize Example value."}. InnerException: MessagePack.Internal.MessagePackDynamicObjectResolverException {"can't find matched constructor. type:Example "}.
```c#
[MessagePackObject]
public class Example
{
    [Key(0)]
    public int IntProperty { get; }

    [Key(2)]
    public string StringProperty { get; }

    public Example(int intProperty, string stringProperty)
    {
        IntProperty = intProperty;
        StringProperty = stringProperty;
    }
}
```

The current implementation searches for the matched  constructor according to the following logic: for each constructor parameter, there must be int key with value of the index of this parameter. So for immutable types, keys must start with 0 and have no gaps. It becomes more difficult to support changes for such types.

I propose a new implementation without breaking backward compatibility. We determine the indexes of the constructor parameters corresponding to the int keys in ascending order of their values.

This implementation does not break the current serialization logic and supports missing keys in the previous example.