### PR TITLE
Add support for C# 9 record types in mpc

### DIFF
--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -49,7 +49,7 @@ namespace MessagePack.Resolvers
 
         static GeneratedResolverGetFormatterHelper()
         {
-            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(13)
+            lookup = new global::System.Collections.Generic.Dictionary<Type, int>(14)
             {
                 { typeof(global::System.Collections.Generic.List<global::TestData2.A>), 0 },
                 { typeof(global::System.Collections.Generic.List<global::TestData2.B>), 1 },
@@ -64,6 +64,7 @@ namespace MessagePack.Resolvers
                 { typeof(global::TestData2.Nest2.IdType), 10 },
                 { typeof(global::TestData2.PropNameCheck1), 11 },
                 { typeof(global::TestData2.PropNameCheck2), 12 },
+                { typeof(global::TestData2.Record), 13 },
             };
         }
 
@@ -90,6 +91,7 @@ namespace MessagePack.Resolvers
                 case 10: return new MessagePack.Formatters.TestData2.Nest2_IdTypeFormatter();
                 case 11: return new MessagePack.Formatters.TestData2.PropNameCheck1Formatter();
                 case 12: return new MessagePack.Formatters.TestData2.PropNameCheck2Formatter();
+                case 13: return new MessagePack.Formatters.TestData2.RecordFormatter();
                 default: return null;
             }
         }
@@ -707,6 +709,61 @@ namespace MessagePack.Formatters.TestData2
                 }
             }
 
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class RecordFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.Record>
+    {
+        // SomeProperty
+        private static global::System.ReadOnlySpan<byte> GetSpan_SomeProperty() => new byte[1 + 12] { 172, 83, 111, 109, 101, 80, 114, 111, 112, 101, 114, 116, 121 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.Record value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            var formatterResolver = options.Resolver;
+            writer.WriteMapHeader(1);
+            writer.WriteRaw(GetSpan_SomeProperty());
+            formatterResolver.GetFormatterWithVerify<string>().Serialize(ref writer, value.SomeProperty, options);
+        }
+
+        public global::TestData2.Record Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
+            var length = reader.ReadMapHeader();
+            var __SomeProperty__ = default(string);
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 12:
+                        if (!global::System.MemoryExtensions.SequenceEqual(stringKey, GetSpan_SomeProperty().Slice(1))) { goto FAIL; }
+
+                        __SomeProperty__ = formatterResolver.GetFormatterWithVerify<string>().Deserialize(ref reader, options);
+                        continue;
+
+                }
+            }
+
+            var ____result = new global::TestData2.Record(__SomeProperty__);
             reader.Depth--;
             return ____result;
         }

--- a/sandbox/TestData2/Record.cs
+++ b/sandbox/TestData2/Record.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MessagePack;
+
+namespace TestData2
+{
+    [MessagePackObject]
+    public record Record([property: Key("SomeProperty")] string SomeProperty);
+}

--- a/sandbox/TestData2/TestData2.csproj
+++ b/sandbox/TestData2/TestData2.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.1.90" />
+    <PackageReference Include="IsExternalInit" Version="1.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -19,10 +19,10 @@
 
   <ItemGroup>
     <PackageReference Include="ConsoleAppFramework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.5.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" Version="16.5.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -244,7 +244,9 @@ namespace MessagePackCompiler.CodeAnalysis
         private readonly HashSet<string> externalIgnoreTypeNames;
 
         // visitor workspace:
-        private readonly HashSet<ITypeSymbol> alreadyCollected = new();
+#pragma warning disable RS1024 // Compare symbols correctly (https://github.com/dotnet/roslyn-analyzers/issues/5246)
+        private readonly HashSet<ITypeSymbol> alreadyCollected = new(SymbolEqualityComparer.Default);
+#pragma warning restore RS1024 // Compare symbols correctly
         private readonly List<ObjectSerializationInfo> collectedObjectInfo = new();
         private readonly List<EnumSerializationInfo> collectedEnumInfo = new();
         private readonly List<GenericSerializationInfo> collectedGenericInfo = new();

--- a/src/MessagePack.GeneratorCore/MessagePack.GeneratorCore.csproj
+++ b/src/MessagePack.GeneratorCore/MessagePack.GeneratorCore.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
     <PackageReference Include="Microsoft.Build" Version="15.9.20" />
     <PackageReference Include="System.CodeDom" Version="4.7.0" />
   </ItemGroup>

--- a/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
+++ b/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 


### PR DESCRIPTION
Update mpc roslyn dependency to 3.10.0

This fixes #1274 by updating to a compiler version that supports C# 9 `record` type declarations.