### PR TITLE
Refactory ObjectSerializationInfo.CreateOrNull

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1711,94 +1711,121 @@ namespace MessagePack.Internal
             var intMembers = new Dictionary<int, EmittableMember>();
             var stringMembers = new Dictionary<string, EmittableMember>();
 
-            if (forceStringKey || contractless || (contractAttr != null && contractAttr.KeyAsPropertyName))
+            // When returning false, it means should ignoring this member.
+            bool AddEmittableMemberOrIgnore(bool isIntKeyMode, EmittableMember member, bool checkConflicting)
+            {
+                if (checkConflicting)
+                {
+                    if (isIntKeyMode ? intMembers.TryGetValue(member.IntKey, out var conflictingMember) : stringMembers.TryGetValue(member.StringKey, out conflictingMember))
+                    {
+                        // Quietly skip duplicate if this is an override property.
+                        if (member.PropertyInfo != null && ((conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) || (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false)))
+                        {
+                            return false;
+                        }
+
+                        var memberInfo = (MemberInfo)member.PropertyInfo ?? member.FieldInfo;
+                        throw new MessagePackDynamicObjectResolverException($"key is duplicated, all members key must be unique. type:{type.FullName} member:{memberInfo.Name}");
+                    }
+                }
+
+                if (isIntKeyMode)
+                {
+                    intMembers.Add(member.IntKey, member);
+                }
+                else
+                {
+                    stringMembers.Add(member.StringKey, member);
+                }
+
+                return true;
+            }
+
+            EmittableMember CreateEmittableMember(MemberInfo m)
+            {
+                if (m.IsDefined(typeof(IgnoreMemberAttribute), true) || m.IsDefined(typeof(IgnoreDataMemberAttribute), true))
+                {
+                    return null;
+                }
+
+                EmittableMember result;
+                switch (m)
+                {
+                    case PropertyInfo property:
+                        if (property.IsIndexer())
+                        {
+                            return null;
+                        }
+
+                        if (isClassRecord && property.Name == "EqualityContract")
+                        {
+                            return null;
+                        }
+
+                        var getMethod = property.GetGetMethod(true);
+                        var setMethod = property.GetSetMethod(true);
+                        result = new EmittableMember(dynamicMethod)
+                        {
+                            PropertyInfo = property,
+                            IsReadable = (getMethod != null) && (allowPrivate || getMethod.IsPublic) && !getMethod.IsStatic,
+                            IsWritable = (setMethod != null) && (allowPrivate || setMethod.IsPublic) && !setMethod.IsStatic,
+                        };
+                        break;
+                    case FieldInfo field:
+                        if (field.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>(true) != null)
+                        {
+                            return null;
+                        }
+
+                        if (field.IsStatic)
+                        {
+                            return null;
+                        }
+
+                        result = new EmittableMember(dynamicMethod)
+                        {
+                            FieldInfo = field,
+                            IsReadable = allowPrivate || field.IsPublic,
+                            IsWritable = (allowPrivate || field.IsPublic) && !field.IsInitOnly,
+                        };
+                        break;
+                    default:
+                        throw new MessagePackSerializationException("unexpected member type");
+                }
+
+                return result.IsReadable || result.IsWritable ? result : null;
+            }
+
+            // Determine whether to ignore MessagePackObjectAttribute or DataContract.
+            if (forceStringKey || contractless || (contractAttr?.KeyAsPropertyName == true))
             {
                 // All public members are serialize target except [Ignore] member.
                 isIntKey = !(forceStringKey || (contractAttr != null && contractAttr.KeyAsPropertyName));
-
                 var hiddenIntKey = 0;
 
                 // Group the properties and fields by name to qualify members of the same name
                 // (declared with the 'new' keyword) with the declaring type.
-                IEnumerable<IGrouping<string, MemberInfo>> membersByName = type.GetRuntimeProperties()
-                    .Concat(type.GetRuntimeFields().Cast<MemberInfo>())
+                var membersByName = type.GetRuntimeProperties().Concat(type.GetRuntimeFields().Cast<MemberInfo>())
                     .OrderBy(m => m.DeclaringType, OrderBaseTypesBeforeDerivedTypes.Instance)
                     .GroupBy(m => m.Name);
                 foreach (var memberGroup in membersByName)
                 {
-                    bool firstMemberByName = true;
-                    foreach (MemberInfo item in memberGroup)
+                    var first = true;
+                    foreach (var member in memberGroup.Select(CreateEmittableMember).Where(n => n != null))
                     {
-                        if (item.GetCustomAttribute<IgnoreMemberAttribute>(true) != null)
+                        var memberInfo = (MemberInfo)member.PropertyInfo ?? member.FieldInfo;
+                        if (first)
                         {
-                            continue;
-                        }
-
-                        if (item.GetCustomAttribute<IgnoreDataMemberAttribute>(true) != null)
-                        {
-                            continue;
-                        }
-
-                        EmittableMember member;
-                        if (item is PropertyInfo property)
-                        {
-                            if (property.IsIndexer())
-                            {
-                                continue;
-                            }
-
-                            MethodInfo getMethod = property.GetGetMethod(true);
-                            MethodInfo setMethod = property.GetSetMethod(true);
-
-                            member = new EmittableMember(dynamicMethod)
-                            {
-                                PropertyInfo = property,
-                                IsReadable = (getMethod != null) && (allowPrivate || getMethod.IsPublic) && !getMethod.IsStatic,
-                                IsWritable = (setMethod != null) && (allowPrivate || setMethod.IsPublic) && !setMethod.IsStatic,
-                                StringKey = firstMemberByName ? item.Name : $"{item.DeclaringType.FullName}.{item.Name}",
-                            };
-                        }
-                        else if (item is FieldInfo field)
-                        {
-                            if (item.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>(true) != null)
-                            {
-                                continue;
-                            }
-
-                            if (field.IsStatic)
-                            {
-                                continue;
-                            }
-
-                            member = new EmittableMember(dynamicMethod)
-                            {
-                                FieldInfo = field,
-                                IsReadable = allowPrivate || field.IsPublic,
-                                IsWritable = (allowPrivate || field.IsPublic) && !field.IsInitOnly,
-                                StringKey = firstMemberByName ? item.Name : $"{item.DeclaringType.FullName}.{item.Name}",
-                            };
+                            first = false;
+                            member.StringKey = memberInfo.Name;
                         }
                         else
                         {
-                            throw new MessagePackSerializationException("unexpected member type");
-                        }
-
-                        if (!member.IsReadable && !member.IsWritable)
-                        {
-                            continue;
+                            member.StringKey = $"{memberInfo.DeclaringType.FullName}.{memberInfo.Name}";
                         }
 
                         member.IntKey = hiddenIntKey++;
-                        if (isIntKey)
-                        {
-                            intMembers.Add(member.IntKey, member);
-                        }
-                        else
-                        {
-                            stringMembers.Add(member.StringKey, member);
-                        }
-
-                        firstMemberByName = false;
+                        AddEmittableMemberOrIgnore(isIntKey, member, false);
                     }
                 }
             }
@@ -1808,246 +1835,62 @@ namespace MessagePack.Internal
                 var searchFirst = true;
                 var hiddenIntKey = 0;
 
-                foreach (PropertyInfo item in GetAllProperties(type))
+                var memberInfos = GetAllProperties(type).Cast<MemberInfo>().Concat(GetAllFields(type));
+                foreach (var member in memberInfos.Select(CreateEmittableMember).Where(n => n != null))
                 {
-                    if (item.GetCustomAttribute<IgnoreMemberAttribute>(true) != null)
-                    {
-                        continue;
-                    }
-
-                    if (item.GetCustomAttribute<IgnoreDataMemberAttribute>(true) != null)
-                    {
-                        continue;
-                    }
-
-                    if (isClassRecord && item.Name == "EqualityContract")
-                    {
-                        // This is a special compiler-generated property that the user cannot add
-                        // [IgnoreMember] to, nor do we want to serialize it.
-                        continue;
-                    }
-
-                    if (item.IsIndexer())
-                    {
-                        continue;
-                    }
-
-                    MethodInfo getMethod = item.GetGetMethod(true);
-                    MethodInfo setMethod = item.GetSetMethod(true);
-
-                    var member = new EmittableMember(dynamicMethod)
-                    {
-                        PropertyInfo = item,
-                        IsReadable = (getMethod != null) && (allowPrivate || getMethod.IsPublic) && !getMethod.IsStatic,
-                        IsWritable = (setMethod != null) && (allowPrivate || setMethod.IsPublic) && !setMethod.IsStatic,
-                    };
-                    if (!member.IsReadable && !member.IsWritable)
-                    {
-                        continue;
-                    }
+                    var memberInfo = (MemberInfo)member.PropertyInfo ?? member.FieldInfo;
 
                     KeyAttribute key;
                     if (contractAttr != null)
                     {
-                        // MessagePackObjectAttribute
-                        key = item.GetCustomAttribute<KeyAttribute>(true);
-                        if (key == null)
-                        {
-                            throw new MessagePackDynamicObjectResolverException("all public members must mark KeyAttribute or IgnoreMemberAttribute." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-
-                        member.IsExplicitContract = true;
+                        // MessagePackObjectAttribute. KeyAttribute must be marked, and IntKey or StringKey must be set.
+                        key = memberInfo.GetCustomAttribute<KeyAttribute>(true) ??
+                            throw new MessagePackDynamicObjectResolverException($"all public members must mark KeyAttribute or IgnoreMemberAttribute. type:{type.FullName} member:{memberInfo.Name}");
                         if (key.IntKey == null && key.StringKey == null)
                         {
-                            throw new MessagePackDynamicObjectResolverException("both IntKey and StringKey are null." + " type: " + type.FullName + " member:" + item.Name);
+                            throw new MessagePackDynamicObjectResolverException($"both IntKey and StringKey are null. type: {type.FullName} member:{memberInfo.Name}");
                         }
                     }
                     else
                     {
-                        // DataContractAttribute
-                        DataMemberAttribute pseudokey = item.GetCustomAttribute<DataMemberAttribute>(true);
-                        if (pseudokey == null)
-                        {
-                            // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
-                            // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
-                            continue;
-                        }
+                        // DataContractAttribute. Try to use the DataMemberAttribute to fake KeyAttribute.
+                        // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
+                        // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
+                        var pseudokey = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
+                        if (pseudokey == null) continue;
 
-                        member.IsExplicitContract = true;
-
-                        // use Order first
-                        if (pseudokey.Order != -1)
-                        {
-                            key = new KeyAttribute(pseudokey.Order);
-                        }
-                        else if (pseudokey.Name != null)
-                        {
-                            key = new KeyAttribute(pseudokey.Name);
-                        }
-                        else
-                        {
-                            key = new KeyAttribute(item.Name); // use property name
-                        }
+                        key =
+                            pseudokey.Order != -1 ? new KeyAttribute(pseudokey.Order) :
+                            pseudokey.Name != null ? new KeyAttribute(pseudokey.Name) :
+                            new KeyAttribute(memberInfo.Name);
                     }
 
+                    member.IsExplicitContract = true;
+
+                    // Cannot assign StringKey and IntKey at the same time.
                     if (searchFirst)
                     {
                         searchFirst = false;
                         isIntKey = key.IntKey != null;
                     }
-                    else
+                    else if ((isIntKey && key.IntKey == null) || (!isIntKey && key.StringKey == null))
                     {
-                        if ((isIntKey && key.IntKey == null) || (!isIntKey && key.StringKey == null))
-                        {
-                            throw new MessagePackDynamicObjectResolverException("all members key type must be same." + " type: " + type.FullName + " member:" + item.Name);
-                        }
+                        throw new MessagePackDynamicObjectResolverException($"all members key type must be same. type: {type.FullName} member:{memberInfo.Name}");
                     }
 
                     if (isIntKey)
                     {
                         member.IntKey = key.IntKey.Value;
-                        if (intMembers.TryGetValue(member.IntKey, out EmittableMember conflictingMember))
-                        {
-                            // Quietly skip duplicate if this is an override property.
-                            if ((conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) || (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false))
-                            {
-                                continue;
-                            }
-
-                            throw new MessagePackDynamicObjectResolverException("key is duplicated, all members key must be unique." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-
-                        intMembers.Add(member.IntKey, member);
                     }
                     else
                     {
                         member.StringKey = key.StringKey;
-                        if (stringMembers.TryGetValue(member.StringKey, out EmittableMember conflictingMember))
-                        {
-                            // Quietly skip duplicate if this is an override property.
-                            if ((conflictingMember.PropertyInfo.SetMethod?.IsVirtual ?? false) || (conflictingMember.PropertyInfo.GetMethod?.IsVirtual ?? false))
-                            {
-                                continue;
-                            }
-
-                            throw new MessagePackDynamicObjectResolverException("key is duplicated, all members key must be unique." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-
                         member.IntKey = hiddenIntKey++;
-                        stringMembers.Add(member.StringKey, member);
                     }
-                }
 
-                foreach (FieldInfo item in GetAllFields(type))
-                {
-                    if (item.GetCustomAttribute<IgnoreMemberAttribute>(true) != null)
+                    if (!AddEmittableMemberOrIgnore(isIntKey, member, true))
                     {
                         continue;
-                    }
-
-                    if (item.GetCustomAttribute<IgnoreDataMemberAttribute>(true) != null)
-                    {
-                        continue;
-                    }
-
-                    if (item.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>(true) != null)
-                    {
-                        continue;
-                    }
-
-                    if (item.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    var member = new EmittableMember(dynamicMethod)
-                    {
-                        FieldInfo = item,
-                        IsReadable = allowPrivate || item.IsPublic,
-                        IsWritable = (allowPrivate || item.IsPublic) && !item.IsInitOnly,
-                    };
-                    if (!member.IsReadable && !member.IsWritable)
-                    {
-                        continue;
-                    }
-
-                    KeyAttribute key;
-                    if (contractAttr != null)
-                    {
-                        // MessagePackObjectAttribute
-                        key = item.GetCustomAttribute<KeyAttribute>(true);
-                        if (key == null)
-                        {
-                            throw new MessagePackDynamicObjectResolverException("all public members must mark KeyAttribute or IgnoreMemberAttribute." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-
-                        member.IsExplicitContract = true;
-                        if (key.IntKey == null && key.StringKey == null)
-                        {
-                            throw new MessagePackDynamicObjectResolverException("both IntKey and StringKey are null." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-                    }
-                    else
-                    {
-                        // DataContractAttribute
-                        DataMemberAttribute pseudokey = item.GetCustomAttribute<DataMemberAttribute>(true);
-                        if (pseudokey == null)
-                        {
-                            // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
-                            // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
-                            continue;
-                        }
-
-                        member.IsExplicitContract = true;
-
-                        // use Order first
-                        if (pseudokey.Order != -1)
-                        {
-                            key = new KeyAttribute(pseudokey.Order);
-                        }
-                        else if (pseudokey.Name != null)
-                        {
-                            key = new KeyAttribute(pseudokey.Name);
-                        }
-                        else
-                        {
-                            key = new KeyAttribute(item.Name); // use property name
-                        }
-                    }
-
-                    if (searchFirst)
-                    {
-                        searchFirst = false;
-                        isIntKey = key.IntKey != null;
-                    }
-                    else
-                    {
-                        if ((isIntKey && key.IntKey == null) || (!isIntKey && key.StringKey == null))
-                        {
-                            throw new MessagePackDynamicObjectResolverException("all members key type must be same." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-                    }
-
-                    if (isIntKey)
-                    {
-                        member.IntKey = key.IntKey.Value;
-                        if (intMembers.ContainsKey(member.IntKey))
-                        {
-                            throw new MessagePackDynamicObjectResolverException("key is duplicated, all members key must be unique." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-
-                        intMembers.Add(member.IntKey, member);
-                    }
-                    else
-                    {
-                        member.StringKey = key.StringKey;
-                        if (stringMembers.ContainsKey(member.StringKey))
-                        {
-                            throw new MessagePackDynamicObjectResolverException("key is duplicated, all members key must be unique." + " type: " + type.FullName + " member:" + item.Name);
-                        }
-
-                        member.IntKey = hiddenIntKey++;
-                        stringMembers.Add(member.StringKey, member);
                     }
                 }
             }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/DynamicObjectResolver.cs
@@ -1857,7 +1857,10 @@ namespace MessagePack.Internal
                         // This member has no DataMemberAttribute nor IgnoreMemberAttribute.
                         // But the type *did* have a DataContractAttribute on it, so no attribute implies the member should not be serialized.
                         var pseudokey = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
-                        if (pseudokey == null) continue;
+                        if (pseudokey == null)
+                        {
+                            continue;
+                        }
 
                         key =
                             pseudokey.Order != -1 ? new KeyAttribute(pseudokey.Order) :


### PR DESCRIPTION
Refactoring of ObjectSerializationInfo.CreateOrNull for #1297 

Mainly to reduce some repetitive code. 
The logic remains the same.