### PR TITLE
Allows client code to avoid tripping over StandardResolver

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -20,6 +20,7 @@ namespace MessagePack
     {
         private const int LZ4NotCompressionSizeInLz4BlockType = 64;
         private const int MaxHintSize = 1024 * 1024;
+        private static MessagePackSerializerOptions defaultOptions;
 
         /// <summary>
         /// Gets or sets the default set of options to use when not explicitly specified for a method call.
@@ -33,7 +34,20 @@ namespace MessagePack
         /// If you are an app author, realize that setting this property impacts the entire application so it should only be
         /// set once, and before any use of <see cref="MessagePackSerializer"/> occurs.
         /// </remarks>
-        public static MessagePackSerializerOptions DefaultOptions { get; set; } = MessagePackSerializerOptions.Standard;
+        public static MessagePackSerializerOptions DefaultOptions
+        {
+            get
+            {
+                if (defaultOptions is null)
+                {
+                    defaultOptions = MessagePackSerializerOptions.Standard;
+                }
+
+                return defaultOptions;
+            }
+
+            set => defaultOptions = value;
+        }
 
         /// <summary>
         /// A thread-local, recyclable array that may be used for short bursts of code.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -38,7 +38,7 @@ namespace MessagePack
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackSerializerOptions"/> class.
         /// </summary>
-        protected internal MessagePackSerializerOptions(IFormatterResolver resolver)
+        public MessagePackSerializerOptions(IFormatterResolver resolver)
         {
             this.Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
         }


### PR DESCRIPTION
In AOT-only environments it seems it was impossible to avoid loading `StandardResolver` because the `MessagePackSerializer` had a static property with an initializer that loaded the `StandardResolver`.
After this change, if the `DefaultOptions` getter is never called, or its setter is called first, then the `StandardResolver` can be avoided.

Fixes #832