### PR TITLE
[mpc] support for reference project union type

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -425,21 +425,15 @@ namespace MessagePackCompiler.CodeAnalysis
         private void CollectGenericUnion(INamedTypeSymbol type)
         {
             var unionAttrs = type.GetAttributes().Where(x => x.AttributeClass.ApproximatelyEqual(this.typeReferences.UnionAttribute)).Select(x => x.ConstructorArguments);
-            using var enumerator = unionAttrs.GetEnumerator();
-            if (!enumerator.MoveNext())
-            {
-                return;
-            }
 
-            do
+            //collect subtypes
+            foreach (var unionAttr in unionAttrs)
             {
-                var x = enumerator.Current;
-                if (x[1] is { Value: INamedTypeSymbol unionType } && alreadyCollected.Contains(unionType) == false)
+                if (unionAttr[1].Value is ITypeSymbol subType)
                 {
-                    CollectCore(unionType);
+                    CollectCore(subType);
                 }
             }
-            while (enumerator.MoveNext());
         }
 
         private void CollectArray(IArrayTypeSymbol array)

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -410,6 +410,16 @@ namespace MessagePackCompiler.CodeAnalysis
             var info = new UnionSerializationInfo(type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString(), type.Name, type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), unionAttrs.Select(UnionSubTypeInfoSelector).OrderBy(x => x.Key).ToArray());
 
             this.collectedUnionInfo.Add(info);
+
+            //collect subtypes
+            //needed for a union type, defined outside the target project.
+            foreach (var unionAttr in unionAttrs)
+            {
+                if (unionAttr[1].Value is ITypeSymbol subType)
+                {
+                    CollectCore(subType);
+                }
+            }
         }
 
         private void CollectGenericUnion(INamedTypeSymbol type)

--- a/tests/MessagePack.Generator.Tests/GenerateUnionFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateUnionFormatterTest.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MessagePack.Generator.Tests
+{
+    public class GenerateUnionFormatterTest
+    {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public GenerateUnionFormatterTest(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Union_Defined_In_TargetProject(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var defineContents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    public class Dummy
+    {
+    }
+}
+";
+            tempWorkarea.AddFileToReferencedProject("Dummy.cs", defineContents);
+
+            var usageContents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyObject
+    {
+        [Key(0)]
+        public IUnionObject Value { get; set; }
+    }
+
+    [Union(0, typeof(UnionDerived1))]
+    [Union(1, typeof(UnionDerived2))]
+    public interface IUnionObject
+    {
+        string Name { get; }
+    }
+
+    [MessagePackObject]
+    public class UnionDerived1 : IUnionObject
+    {
+        [Key(0)]
+        public int Id { get; set; }
+        [Key(1)]
+        public string Name { get; set; }
+    }
+
+    [MessagePackObject]
+    public class UnionDerived2 : IUnionObject
+    {
+        [Key(0)]
+        public string Name { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToTargetProject("MyObject.cs", usageContents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.GetOutputCompilation().Compilation,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty,
+                Array.Empty<string>());
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            symbols.Select(x => x.ToDisplayString()).Should().Contain(new[]
+            {
+                "TempProject.Generated.Formatters.TempProject.MyObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.IUnionObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived1Formatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived2Formatter",
+            });
+
+            symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).Should().Contain(new[]
+            {
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.MyObject>",
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.IUnionObject>",
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.UnionDerived1>",
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.UnionDerived2>",
+            });
+
+            compilation.GetResolverKnownFormatterTypes().Should().Contain(new[]
+            {
+                "TempProject.Generated.Formatters.TempProject.MyObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.IUnionObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived1Formatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived2Formatter",
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Union_Defined_In_ReferencedProject(bool isSingleFileOutput)
+        {
+            using var tempWorkarea = TemporaryProjectWorkarea.Create();
+            var defineContents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [Union(0, typeof(UnionDerived1))]
+    [Union(1, typeof(UnionDerived2))]
+    public interface IUnionObject
+    {
+        string Name { get; }
+    }
+
+    [MessagePackObject]
+    public class UnionDerived1 : IUnionObject
+    {
+        [Key(0)]
+        public int Id { get; set; }
+        [Key(1)]
+        public string Name { get; set; }
+    }
+
+    [MessagePackObject]
+    public class UnionDerived2 : IUnionObject
+    {
+        [Key(0)]
+        public string Name { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToReferencedProject("IUnionObject.cs", defineContents);
+
+            var usageContents = @"
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace TempProject
+{
+    [MessagePackObject]
+    public class MyObject
+    {
+        [Key(0)]
+        public IUnionObject Value { get; set; }
+    }
+}
+            ";
+            tempWorkarea.AddFileToTargetProject("MyObject.cs", usageContents);
+
+            var compiler = new MessagePackCompiler.CodeGenerator(testOutputHelper.WriteLine, CancellationToken.None);
+            await compiler.GenerateFileAsync(
+                tempWorkarea.GetOutputCompilation().Compilation,
+                isSingleFileOutput ? Path.Combine(tempWorkarea.OutputDirectory, "Generated.cs") : tempWorkarea.OutputDirectory,
+                "TempProjectResolver",
+                "TempProject.Generated",
+                false,
+                string.Empty,
+                Array.Empty<string>());
+
+            var compilation = tempWorkarea.GetOutputCompilation();
+            compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
+
+            var symbols = compilation.GetNamedTypeSymbolsFromGenerated();
+
+            symbols.Select(x => x.ToDisplayString()).Should().Contain(new[]
+            {
+                "TempProject.Generated.Formatters.TempProject.MyObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.IUnionObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived1Formatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived2Formatter",
+            });
+
+            symbols.SelectMany(x => x.Interfaces).Select(x => x.ToDisplayString()).Should().Contain(new[]
+            {
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.MyObject>",
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.IUnionObject>",
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.UnionDerived1>",
+                "MessagePack.Formatters.IMessagePackFormatter<TempProject.UnionDerived2>",
+            });
+
+            compilation.GetResolverKnownFormatterTypes().Should().Contain(new[]
+            {
+                "TempProject.Generated.Formatters.TempProject.MyObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.IUnionObjectFormatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived1Formatter",
+                "TempProject.Generated.Formatters.TempProject.UnionDerived2Formatter",
+            });
+        }
+    }
+}

--- a/tests/MessagePack.Generator.Tests/GenerateUnionFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateUnionFormatterTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;


### PR DESCRIPTION
## Relates
https://github.com/neuecc/MessagePack-CSharp/pull/994
https://github.com/neuecc/MessagePack-CSharp/pull/1192

## Overview

The two projects exists.
- MyApp.Models.csproj
- MyApp.Referenced.csproj that referenced by MyApp.Models.csproj

At this time, mpc will generate `IUnionObjectFormatter`, `UnionDerived1Formatter` and `UnionDerived2Formatter`.

##### in MyApp.Unity.csproj
```C#
[MessagePackObject]
public class MyObject
{
  [Key(0)]
  public IUnionObject Value { get; set; }
}
```

##### in MyApp.Referenced.csproj
```C#
[Union(0, typeof(UnionDerived1))]
[Union(1, typeof(UnionDerived2))]
public interface IUnionObject
{
  string Name { get; }
}

[MessagePackObject]
public class UnionDerived1 : IUnionObject
{
  [Key(0)]
  public int Id { get; set; }
  [Key(1)]
  public string Name { get; set; }
}

[MessagePackObject]
public class UnionDerived2 : IUnionObject
{
  [Key(0)]
  public string Name { get; set; }
}
```
