### PR TITLE
Drop unsupported platforms

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,9 @@ stages:
   - job: Unity
     pool:
       name: CustomAgents
-      demands: UNITYHUB_EDITORS_FOLDER_LOCATION
+      demands:
+      - UNITYHUB_EDITORS_FOLDER_LOCATION
+      - UNITYVERSION -equals 2019.1
     steps:
     - checkout: self
       clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
 
   - job: Linux
     pool:
-      vmImage: Ubuntu 16.04
+      vmImage: Ubuntu 18.04
     steps:
     - checkout: self
       clean: true

--- a/azure-pipelines/build_nonWindows.yml
+++ b/azure-pipelines/build_nonWindows.yml
@@ -6,12 +6,20 @@ steps:
     arguments: --no-restore -c $(BuildConfiguration)
 
 - task: DotNetCoreCLI@2
-  displayName: Run MessagePack.Tests (netcoreapp2.1)
+  displayName: Run MessagePack.Tests (netcoreapp3.1)
   inputs:
     command: test
     projects: tests/MessagePack.Tests/MessagePack.Tests.csproj
-    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp2.1 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
-    testRunTitle: netcoreapp2.1-$(Agent.JobName)
+    arguments: --no-build -c $(BuildConfiguration) -f netcoreapp3.1 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
+    testRunTitle: netcoreapp3.1-$(Agent.JobName)
+
+- task: DotNetCoreCLI@2
+  displayName: Run MessagePack.Tests (net5.0)
+  inputs:
+    command: test
+    projects: tests/MessagePack.Tests/MessagePack.Tests.csproj
+    arguments: --no-build -c $(BuildConfiguration) -f net5.0 -v n --settings "$(Build.Repository.LocalPath)/azure-pipelines/$(Agent.OS).runsettings"
+    testRunTitle: net5.0-$(Agent.JobName)
 
 - bash: mono ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe bin/MessagePack.Tests/$(BuildConfiguration)/net472/MessagePack.Tests.dll -html $(BUILD.ARTIFACTSTAGINGDIRECTORY)/build_logs/mono_testrun.html
   displayName: Run MessagePack.Tests (mono)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.201",
+    "version": "5.0.401",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
+++ b/sandbox/MessagePack.Internal/MessagePack.Internal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SPAN_BUILTIN;MESSAGEPACK_INTERNAL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>

--- a/sandbox/PerfBenchmarkDotNet/MessagePackWriterBenchmark.cs
+++ b/sandbox/PerfBenchmarkDotNet/MessagePackWriterBenchmark.cs
@@ -4,6 +4,7 @@
 extern alias newmsgpack;
 extern alias oldmsgpack;
 
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Nerdbank.Streams;
@@ -12,7 +13,7 @@ namespace PerfBenchmarkDotNet
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
-    public class MessagePackWriterBenchmark
+    public sealed class MessagePackWriterBenchmark : IDisposable
     {
         private const int RepsOverArray = 300 * 1024;
         private readonly Sequence<byte> sequence = new Sequence<byte>();
@@ -147,6 +148,11 @@ namespace PerfBenchmarkDotNet
 
                 offset = 0;
             }
+        }
+
+        public void Dispose()
+        {
+            this.sequence.Dispose();
         }
     }
 }

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/sandbox/PerfNetFramework/PerfNetFramework.csproj
+++ b/sandbox/PerfNetFramework/PerfNetFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/sandbox/Sandbox/Sandbox.csproj
+++ b/sandbox/Sandbox/Sandbox.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
+++ b/src/MessagePack.AspNetCoreMvcFormatter/MessagePackOutputFormatter.cs
@@ -34,6 +34,12 @@ namespace MessagePack.AspNetCoreMvcFormatter
                     return Task.CompletedTask;
 #else
                     var writer = context.HttpContext.Response.BodyWriter;
+                    if (writer == null)
+                    {
+                        context.HttpContext.Response.Body.WriteByte(MessagePackCode.Nil);
+                        return Task.CompletedTask;
+                    }
+
                     var span = writer.GetSpan(1);
                     span[0] = MessagePackCode.Nil;
                     writer.Advance(1);
@@ -46,6 +52,11 @@ namespace MessagePack.AspNetCoreMvcFormatter
                     return MessagePackSerializer.SerializeAsync(context.Object.GetType(), context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
 #else
                     var writer = context.HttpContext.Response.BodyWriter;
+                    if (writer == null)
+                    {
+                        return MessagePackSerializer.SerializeAsync(context.Object.GetType(), context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
+                    }
+
                     MessagePackSerializer.Serialize(context.Object.GetType(), writer, context.Object, this.options, context.HttpContext.RequestAborted);
                     return writer.FlushAsync().AsTask();
 #endif
@@ -57,6 +68,11 @@ namespace MessagePack.AspNetCoreMvcFormatter
                 return MessagePackSerializer.SerializeAsync(context.ObjectType, context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
 #else
                 var writer = context.HttpContext.Response.BodyWriter;
+                if (writer == null)
+                {
+                    return MessagePackSerializer.SerializeAsync(context.ObjectType, context.HttpContext.Response.Body, context.Object, this.options, context.HttpContext.RequestAborted);
+                }
+
                 MessagePackSerializer.Serialize(context.ObjectType, writer, context.Object, this.options, context.HttpContext.RequestAborted);
                 return writer.FlushAsync().AsTask();
 #endif

--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants Condition=" '$(TargetFramework)' != 'netstandard2.0' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.2" PrivateAssets="all" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp2.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />

--- a/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
+++ b/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\MessagePack.Tests\MessagePack.Tests.ruleset</CodeAnalysisRuleSet>

--- a/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
+++ b/tests/MessagePack.AspNetCoreMvcFormatter.Tests/MessagePack.AspNetCoreMvcFormatter.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>

--- a/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
+++ b/tests/MessagePack.Internal.Tests/MessagePack.Internal.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <CodeAnalysisRuleSet>..\MessagePack.Tests\MessagePack.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -208,6 +208,22 @@ $windowsDesktopRuntimeVersions | Sort-Object -Unique |% {
     }
 }
 
+$aspnetRuntimeSwitches = $switches + '-Runtime','aspnetcore'
+
+$runtimeVersions | Sort-Object -Unique |% {
+    if ($PSCmdlet.ShouldProcess(".NET Core ASP.NET runtime $_", "Install")) {
+        $anythingInstalled = $true
+        Invoke-Expression -Command "$DotNetInstallScriptPathExpression -Channel $_ $aspnetRuntimeSwitches"
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error ".NET SDK installation failure: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
+    } else {
+        Invoke-Expression -Command "$DotNetInstallScriptPathExpression -Channel $_ $aspnetRuntimeSwitches -DryRun"
+    }
+}
+
 if ($PSCmdlet.ShouldProcess("Set DOTNET environment variables to discover these installed runtimes?")) {
     & "$PSScriptRoot/Set-EnvVars.ps1" -Variables $envVars -PrependPath $DotNetInstallDir | Out-Null
 }


### PR DESCRIPTION
This should get Azure Pipelines working again.

- Use Ubuntu 18 instead of 16 in AzP
- Drop netcoreapp2.1 support
  netcoreapp2.1 is no longer under LTS support by Microsoft and no one should be using it.