### PR TITLE
Support Unity netstandard21

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/HashCode.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/HashCode.cs
@@ -42,7 +42,7 @@ https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b
 
 */
 
-#if !NETCOREAPP
+#if !(NETCOREAPP || NET_STANDARD)
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DataContractTest.cs
@@ -191,6 +191,8 @@ namespace MessagePack.Tests
             public bool Equals(Detail other) => other != null && this.B1 == other.B1 && this.B2 == other.B2;
         }
 
+#if !UNITY_2018_3_OR_NEWER
+
         [Fact]
         public void DataContractSerializerCompatibility()
         {
@@ -218,6 +220,8 @@ namespace MessagePack.Tests
 
             Assert.Equal(dcsValue, mpValue);
         }
+
+#endif
 
         private static T DataContractSerializerRoundTrip<T>(T value)
         {

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/DynamicObjectFallbackTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !ENABLE_IL2CPP
+#if !UNITY_2018_3_OR_NEWER
 
 using System;
 using System.Collections.Generic;

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExpandoObjectTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/ExpandoObjectTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !UNITY_2018_3_OR_NEWER
+
 using System.Dynamic;
 using System.Runtime.Serialization;
 using MessagePack.Resolvers;
@@ -115,3 +117,5 @@ namespace MessagePack.Tests
         }
     }
 }
+
+#endif

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef
@@ -13,6 +13,11 @@
     "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [
+        "System.Memory.dll",
+        "System.Buffers.dll",
+        "System.Threading.Tasks.Extensions.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll",
+        "System.Runtime.Extensions.dll",
         "nunit.framework.dll",
         "MsgPack.dll"
     ],

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/Tests.asmdef
@@ -1,19 +1,25 @@
 {
     "name": "MessagePack.Tests",
+    "rootNamespace": "",
     "references": [
         "MessagePack",
         "MessagePack.Annotations",
-        "RuntimeUnitTestToolkit"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "RuntimeUnitTestToolkit",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
-    "overrideReferences": false,
-    "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": []
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "MsgPack.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
related to #1343
Latest unity adds .NET Standard 2.1 support, it causes some warnings.
Especially `HashCode`'s `#if !NETCOREAPP` does not work on Unity.

If Unity targets `netstandard2.1`, defines `NET_STANDARD_2_0` and `NET_STANDARD`.
Unity that does not support `netstandard2.1` will not define `NET_STANDARD`.
So we can use `NET_STANDARD` to detect `netstandard2.1`.

Othes, `Tests.asmdef` defines `MsgPack.dll`.