### PR TITLE
disable HashCode.cs if UNITY_2021_2_OR_NEWER

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/HashCode.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/HashCode.cs
@@ -42,7 +42,7 @@ https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b
 
 */
 
-#if !(NETCOREAPP || NET_STANDARD)
+#if !(NETCOREAPP || UNITY_2021_2_OR_NEWER)
 
 using System.Collections.Generic;
 using System.ComponentModel;


### PR DESCRIPTION
related to #1343 #1346
Unity 2021.2's netframework is superset of netstandard 2.1(union of netframework and netstandard 2.1).
So disable HashCode when Unity2021.2.