### PR TITLE
Add CompressionMinLength parameter to MessagePackSerializerOptions

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.Json.cs
@@ -171,7 +171,7 @@ namespace MessagePack
                     }
 
                     scratchWriter.Flush();
-                    ToLZ4BinaryCore(scratchRental.Value, ref writer, options.Compression);
+                    ToLZ4BinaryCore(scratchRental.Value, ref writer, options.Compression, options.CompressionMinLength);
                 }
             }
             else

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -556,14 +556,14 @@ namespace MessagePack
 
         private static void ToLZ4BinaryCore(in ReadOnlySequence<byte> msgpackUncompressedData, ref MessagePackWriter writer, MessagePackCompression compression, int minCompressionSize)
         {
+            if (msgpackUncompressedData.Length < minCompressionSize)
+            {
+                writer.WriteRaw(msgpackUncompressedData);
+                return;
+            }
+
             if (compression == MessagePackCompression.Lz4Block)
             {
-                if (msgpackUncompressedData.Length < minCompressionSize)
-                {
-                    writer.WriteRaw(msgpackUncompressedData);
-                    return;
-                }
-
                 var maxCompressedLength = LZ4Codec.MaximumOutputLength((int)msgpackUncompressedData.Length);
                 var lz4Span = ArrayPool<byte>.Shared.Rent(maxCompressedLength);
                 try

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializer.cs
@@ -18,7 +18,6 @@ namespace MessagePack
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Each overload has sufficiently unique required parameters.")]
     public static partial class MessagePackSerializer
     {
-        private const int LZ4NotCompressionSizeInLz4BlockType = 64;
         private const int MaxHintSize = 1024 * 1024;
 
         /// <summary>
@@ -85,7 +84,7 @@ namespace MessagePack
                         MessagePackWriter scratchWriter = writer.Clone(scratch);
                         options.Resolver.GetFormatterWithVerify<T>().Serialize(ref scratchWriter, value, options);
                         scratchWriter.Flush();
-                        ToLZ4BinaryCore(scratch, ref writer, options.Compression);
+                        ToLZ4BinaryCore(scratch, ref writer, options.Compression, options.CompressionMinLength);
                     }
                 }
                 else
@@ -555,11 +554,11 @@ namespace MessagePack
             return false;
         }
 
-        private static void ToLZ4BinaryCore(in ReadOnlySequence<byte> msgpackUncompressedData, ref MessagePackWriter writer, MessagePackCompression compression)
+        private static void ToLZ4BinaryCore(in ReadOnlySequence<byte> msgpackUncompressedData, ref MessagePackWriter writer, MessagePackCompression compression, int minCompressionSize)
         {
             if (compression == MessagePackCompression.Lz4Block)
             {
-                if (msgpackUncompressedData.Length < LZ4NotCompressionSizeInLz4BlockType)
+                if (msgpackUncompressedData.Length < minCompressionSize)
                 {
                     writer.WriteRaw(msgpackUncompressedData);
                     return;

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackSerializerOptions.cs
@@ -41,6 +41,7 @@ namespace MessagePack
         protected internal MessagePackSerializerOptions(IFormatterResolver resolver)
         {
             this.Resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+            this.CompressionMinLength = 64;
         }
 
         /// <summary>
@@ -57,6 +58,7 @@ namespace MessagePack
 
             this.Resolver = copyFrom.Resolver;
             this.Compression = copyFrom.Compression;
+            this.CompressionMinLength = copyFrom.CompressionMinLength;
             this.OldSpec = copyFrom.OldSpec;
             this.OmitAssemblyVersion = copyFrom.OmitAssemblyVersion;
             this.AllowAssemblyVersionMismatch = copyFrom.AllowAssemblyVersionMismatch;
@@ -80,6 +82,14 @@ namespace MessagePack
         /// and serialization may not compress if msgpack sequences are short enough that compression would not likely be advantageous.
         /// </remarks>
         public MessagePackCompression Compression { get; private set; }
+
+        /// <summary>
+        /// Gets the min sequence length allowed for compression.
+        /// </summary>
+        /// <remarks>
+        /// Sequences with length less then this value will skip block compression.
+        /// </remarks>
+        public int CompressionMinLength { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether to serialize with <see cref="MessagePackWriter.OldSpec"/> set to some value
@@ -191,6 +201,23 @@ namespace MessagePack
 
             var result = this.Clone();
             result.Compression = compression;
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a copy of these options with the <see cref="CompressionMinLength"/> property set to a new value.
+        /// </summary>
+        /// <param name="compressionMinLength">The new value for the <see cref="CompressionMinLength"/> property.</param>
+        /// <returns>The new instance; or the original if the value is unchanged.</returns>
+        public MessagePackSerializerOptions WithCompressionMinLength(int compressionMinLength)
+        {
+            if (this.CompressionMinLength == compressionMinLength)
+            {
+                return this;
+            }
+
+            var result = this.Clone();
+            result.CompressionMinLength = compressionMinLength;
             return result;
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerOptionsTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackSerializerOptionsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) All contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using MessagePack;
 using MessagePack.Resolvers;
 using Xunit;
@@ -34,6 +35,16 @@ public class MessagePackSerializerOptionsTests
     {
         Assert.Equal(MessagePackCompression.None, MessagePackSerializerOptions.Standard.Compression);
         Assert.Equal(MessagePackCompression.Lz4Block, MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block).Compression);
+    }
+
+    [Fact]
+    public void CompressionMinLength()
+    {
+        Assert.Equal(64, MessagePackSerializerOptions.Standard.CompressionMinLength);
+        Assert.Throws<ArgumentOutOfRangeException>(() => MessagePackSerializerOptions.Standard.WithCompressionMinLength(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => MessagePackSerializerOptions.Standard.WithCompressionMinLength(-1));
+        MessagePackSerializerOptions options = MessagePackSerializerOptions.Standard.WithCompressionMinLength(128);
+        Assert.Equal(128, options.CompressionMinLength);
     }
 
     [Fact]

--- a/src/MessagePack/net5.0/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/net5.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ MessagePack.Formatters.InterfaceReadOnlySetFormatter<T>.InterfaceReadOnlySetForm
 MessagePack.MessagePackReader.MessagePackReader() -> void
 MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool
 MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool pool) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
 MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen, MessagePack.SequencePool sequencePool) -> void
 MessagePack.MessagePackStreamReader.ReadArrayHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 MessagePack.MessagePackStreamReader.ReadMapHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>

--- a/src/MessagePack/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(Syst
 MessagePack.MessagePackReader.MessagePackReader() -> void
 MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool
 MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool pool) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
 MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen, MessagePack.SequencePool sequencePool) -> void
 MessagePack.MessagePackWriter.MessagePackWriter() -> void
 MessagePack.SequencePool

--- a/src/MessagePack/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(Syst
 MessagePack.MessagePackReader.MessagePackReader() -> void
 MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool
 MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool pool) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
 MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen, MessagePack.SequencePool sequencePool) -> void
 MessagePack.MessagePackStreamReader.ReadArrayHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 MessagePack.MessagePackStreamReader.ReadMapHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>

--- a/src/MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ MessagePack.FormatterNotRegisteredException.FormatterNotRegisteredException(Syst
 MessagePack.MessagePackReader.MessagePackReader() -> void
 MessagePack.MessagePackSerializerOptions.SequencePool.get -> MessagePack.SequencePool
 MessagePack.MessagePackSerializerOptions.WithPool(MessagePack.SequencePool pool) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions
+MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
 MessagePack.MessagePackStreamReader.MessagePackStreamReader(System.IO.Stream stream, bool leaveOpen, MessagePack.SequencePool sequencePool) -> void
 MessagePack.MessagePackStreamReader.ReadArrayHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 MessagePack.MessagePackStreamReader.ReadMapHeaderAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>


### PR DESCRIPTION
Following the discussion here https://github.com/neuecc/MessagePack-CSharp/issues/1349
