### PR TITLE
Add built-in support for .NET 6 `DateOnly` and `TimeOnly` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1499,24 +1499,36 @@ var resolver = MessagePack.Resolvers.CompositeResolver.Create(
 
 ## Reserved Extension Types
 
-MessagePack for C# already used some MessagePack extension type codes, be careful to use same ext code.
+MessagePack for C# already used some MessagePack extension type codes, be careful to avoid using the same ext code for other purposes.
+
+Range | Reserved for
+--|--
+\[-128, -1\] | Reserved by the msgpack spec for predefined types
+\[30, 120) | Reserved for this library's use to support common types in .NET
+
+This leaves the following ranges for your use:
+
+- \[0, 30)
+- \[120, 127]
+
+Within the *reserved* ranges, this library defines or implements extensions that use these type codes:
 
 | Code | Type | Use by |
-| ---  | ---  | --- |
-| -1 | DateTime | MessagePack-spec reserved for timestamp |
-| 30 | Vector2[] | for Unity, UnsafeBlitFormatter |
-| 31 | Vector3[] | for Unity, UnsafeBlitFormatter |
-| 32 | Vector4[] | for Unity, UnsafeBlitFormatter |
-| 33 | Quaternion[] | for Unity, UnsafeBlitFormatter |
-| 34 | Color[] | for Unity, UnsafeBlitFormatter |
-| 35 | Bounds[] | for Unity, UnsafeBlitFormatter |
-| 36 | Rect[] | for Unity, UnsafeBlitFormatter |
-| 37 | Int[] | for Unity, UnsafeBlitFormatter |
-| 38 | Float[] | for Unity, UnsafeBlitFormatter |
-| 39 | Double[] | for Unity, UnsafeBlitFormatter |
-| 98 | All | MessagePackCompression.Lz4BlockArray |
-| 99 | All | MessagePackCompression.Lz4Block |
-| 100 | object | TypelessFormatter |
+| ---- | ---- | --- |
+| -1   | DateTime | MessagePack-spec reserved for timestamp |
+| 30   | Vector2[] | for Unity, UnsafeBlitFormatter |
+| 31   | Vector3[] | for Unity, UnsafeBlitFormatter |
+| 32   | Vector4[] | for Unity, UnsafeBlitFormatter |
+| 33   | Quaternion[] | for Unity, UnsafeBlitFormatter |
+| 34   | Color[] | for Unity, UnsafeBlitFormatter |
+| 35   | Bounds[] | for Unity, UnsafeBlitFormatter |
+| 36   | Rect[] | for Unity, UnsafeBlitFormatter |
+| 37   | Int[] | for Unity, UnsafeBlitFormatter |
+| 38   | Float[] | for Unity, UnsafeBlitFormatter |
+| 39   | Double[] | for Unity, UnsafeBlitFormatter |
+| 98   | All | MessagePackCompression.Lz4BlockArray |
+| 99   | All | MessagePackCompression.Lz4Block |
+| 100  | object | TypelessFormatter |
 
 ## Unity support
 

--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -143,7 +143,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.57" />
     <PackageReference Include="Microsoft.NET.StringTools" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
+++ b/sandbox/PerfBenchmarkDotNet/PerfBenchmarkDotNet.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Jil" version="2.15.4" />
     <PackageReference Include="MessagePack" version="1.4.3" />
     <PackageReference Include="MsgPack.Cli" version="0.9.0-rc1" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.57" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="protobuf-net" version="2.3.2" />
     <PackageReference Include="RandomFixtureKit" Version="1.0.0" />

--- a/sandbox/PerfNetFramework/PerfNetFramework.csproj
+++ b/sandbox/PerfNetFramework/PerfNetFramework.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" version="0.9.0-beta2" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.57" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="protobuf-net" version="2.1.0" />
     <PackageReference Include="ZeroFormatter" version="1.6.4" />

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DateTimeFormatters.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/DateTimeFormatters.cs
@@ -70,4 +70,50 @@ namespace MessagePack.Formatters
             return array;
         }
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Serializes a <see cref="DateOnly"/> value as an ordinary <see cref="int"/> using the <see cref="DateOnly.DayNumber"/>.
+    /// </summary>
+    public sealed class DateOnlyFormatter : IMessagePackFormatter<DateOnly>
+    {
+        public static readonly DateOnlyFormatter Instance = new DateOnlyFormatter();
+
+        private DateOnlyFormatter()
+        {
+        }
+
+        public void Serialize(ref MessagePackWriter writer, DateOnly value, MessagePackSerializerOptions options)
+        {
+            writer.Write(value.DayNumber);
+        }
+
+        public DateOnly Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            return DateOnly.FromDayNumber(reader.ReadInt32());
+        }
+    }
+
+    /// <summary>
+    /// Serializes a <see cref="TimeOnly"/> value as an extension, recording either seconds or ticks depending on the resolution required.
+    /// </summary>
+    public sealed class TimeOnlyFormatter : IMessagePackFormatter<TimeOnly>
+    {
+        public static readonly TimeOnlyFormatter Instance = new TimeOnlyFormatter();
+
+        private TimeOnlyFormatter()
+        {
+        }
+
+        public void Serialize(ref MessagePackWriter writer, TimeOnly value, MessagePackSerializerOptions options)
+        {
+            writer.Write(value.Ticks);
+        }
+
+        public TimeOnly Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            return new TimeOnly(reader.ReadInt64());
+        }
+    }
+#endif
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/BuiltinResolver.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Resolvers/BuiltinResolver.cs
@@ -64,9 +64,13 @@ namespace MessagePack.Internal
             { typeof(byte), ByteFormatter.Instance },
             { typeof(sbyte), SByteFormatter.Instance },
             { typeof(DateTime), DateTimeFormatter.Instance },
+#if NET6_0_OR_GREATER
+            { typeof(DateOnly), DateOnlyFormatter.Instance },
+            { typeof(TimeOnly), TimeOnlyFormatter.Instance },
+#endif
             { typeof(char), CharFormatter.Instance },
 
-            // Nulllable Primitive
+            // Nullable Primitive
             { typeof(Int16?), NullableInt16Formatter.Instance },
             { typeof(Int32?), NullableInt32Formatter.Instance },
             { typeof(Int64?), NullableInt64Formatter.Instance },

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/MessagePackWriterTests.cs
@@ -33,7 +33,7 @@ namespace MessagePack.Tests
 #endif
 
         /// <summary>
-        /// Verifies that <see cref="MessagePackWriter.WriteRaw(ReadOnlySpan{byte})"/>
+        /// Verifies that <c>MessagePackWriter.WriteRaw(ReadOnlySpan{byte})</c>
         /// accepts a span that came from stackalloc.
         /// </summary>
         [Fact]

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
@@ -15,6 +15,8 @@ namespace MessagePack.Tests
         /// Gets a value indicating whether the mono runtime is executing this code.
         /// </summary>
         internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+
+        internal static string ToHex(byte[] buffer) => BitConverter.ToString(buffer).Replace("-", string.Empty).ToLowerInvariant();
     }
 
     public class NullTestOutputHelper : ITestOutputHelper

--- a/src/MessagePack/net6.0/PublicAPI.Unshipped.txt
+++ b/src/MessagePack/net6.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,14 @@
+MessagePack.Formatters.DateOnlyFormatter
+MessagePack.Formatters.DateOnlyFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.DateOnly
+MessagePack.Formatters.DateOnlyFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.DateOnly value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.Formatters.StringInterningFormatter
 MessagePack.Formatters.StringInterningFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> string
 MessagePack.Formatters.StringInterningFormatter.Serialize(ref MessagePack.MessagePackWriter writer, string value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.Formatters.StringInterningFormatter.StringInterningFormatter() -> void
+MessagePack.Formatters.TimeOnlyFormatter
+MessagePack.Formatters.TimeOnlyFormatter.Deserialize(ref MessagePack.MessagePackReader reader, MessagePack.MessagePackSerializerOptions options) -> System.TimeOnly
+MessagePack.Formatters.TimeOnlyFormatter.Serialize(ref MessagePack.MessagePackWriter writer, System.TimeOnly value, MessagePack.MessagePackSerializerOptions options) -> void
 MessagePack.MessagePackSerializerOptions.CompressionMinLength.get -> int
 MessagePack.MessagePackSerializerOptions.WithCompressionMinLength(int compressionMinLength) -> MessagePack.MessagePackSerializerOptions
+static readonly MessagePack.Formatters.DateOnlyFormatter.Instance -> MessagePack.Formatters.DateOnlyFormatter
+static readonly MessagePack.Formatters.TimeOnlyFormatter.Instance -> MessagePack.Formatters.TimeOnlyFormatter

--- a/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
+++ b/tests/MessagePack.GeneratedCode.Tests/MessagePack.GeneratedCode.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.57" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
+++ b/tests/MessagePack.Generator.Tests/MessagePack.Generator.Tests.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.57" />
 
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/tests/MessagePack.Tests/MessagePack.Tests.csproj
+++ b/tests/MessagePack.Tests/MessagePack.Tests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MsgPack.Cli" version="0.9.0-beta2" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.4.48" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.57" />
     <PackageReference Include="ReactiveProperty" version="4.2.2" />
     <PackageReference Include="xunit" version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />


### PR DESCRIPTION
`DateOnly` requires 5 bytes (typically).
`TimeOnly` requires 6 bytes for second resolution or 8 bytes for ticks resolution. This is automatically selected based on the original value.

Because `TimeOnly` uses an extension, I claim another extension type code. I venture to add documentation to the README to actually reserve a range of type codes for this and future use, where this previously wasn't done, which makes every additional type code we use risky because it may collide with a user of this library's custom extensions.

Closes #1240