### PR TITLE
MessagePack.Generator RollForward to Major

### DIFF
--- a/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -9,6 +9,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>mpc</ToolCommandName>
+    <RollForward>Major</RollForward>
 
     <!-- NuGet Info -->
     <PackageId>MessagePack.Generator</PackageId>


### PR DESCRIPTION
Currently, there are reports that mpc stops working after each .NET major version upgrade.
How about setting the RollForward in the CLI tool to Major to prevent this?