### PR TITLE
Skip type collection if property has MessagePackFormatterAttribute

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -720,7 +720,12 @@ namespace MessagePackCompiler.CodeAnalysis
                         stringMembers.Add(member.StringKey, member);
                     }
 
-                    this.CollectCore(item.Type); // recursive collect
+                    var messagePackFormatter = item.GetAttributes().FirstOrDefault(x => x.AttributeClass.ApproximatelyEqual(this.typeReferences.MessagePackFormatterAttribute))?.ConstructorArguments[0];
+
+                    if (messagePackFormatter == null)
+                    {
+                        this.CollectCore(item.Type); // recursive collect
+                    }
                 }
 
                 foreach (IFieldSymbol item in type.GetAllMembers().OfType<IFieldSymbol>())


### PR DESCRIPTION
The MessagePackFormatterAttribute defines a custom formatter so there is no reason to handle it automatically.