### PR TITLE
fix duplicate registration of named tuples

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -463,12 +463,19 @@ namespace MessagePackCompiler.CodeAnalysis
                 return compilation.CreateArrayTypeSymbol(ToTupleUnderlyingType(array.ElementType), array.Rank);
             }
 
-            if (typeSymbol is INamedTypeSymbol namedType && namedType.IsGenericType)
+            if (typeSymbol is not INamedTypeSymbol namedType || !namedType.IsGenericType)
             {
-                return namedType.ConstructedFrom.Construct(namedType.TypeArguments.Select(ToTupleUnderlyingType).ToArray());
+                return typeSymbol;
             }
 
-            return typeSymbol;
+            namedType = namedType.TupleUnderlyingType ?? namedType;
+            var newTypeArguments = namedType.TypeArguments.Select(ToTupleUnderlyingType).ToArray();
+            if (!namedType.TypeArguments.SequenceEqual(newTypeArguments))
+            {
+                return namedType.ConstructedFrom.Construct(newTypeArguments);
+            }
+
+            return namedType;
         }
 
         private void CollectGeneric(INamedTypeSymbol type)


### PR DESCRIPTION
Example
```csharp
using MessagePack;
using System.Collections.Generic;

[MessagePackObject]
public class Test
{
    [Key(0)] public Dictionary<((int A, int B) C, (int D, int E) F), ((int G, int H) I, (int J, int K) L)> Hoge;
    [Key(1)] public ((int M, int N) O, (int P, int Q) R)[,] Fuga;
}
```

Before
```csharp
        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(12)
            {
                { typeof(((int A, int B) C, (int D, int E) F)), 0 },
                { typeof(((int G, int H) I, (int J, int K) L)), 1 },
                { typeof(((int M, int N) O, (int P, int Q) R)), 2 },
                { typeof(((int M, int N) O, (int P, int Q) R)[,]), 3 },
                { typeof((int A, int B)), 4 },
                { typeof((int D, int E)), 5 },
                { typeof((int G, int H)), 6 },
                { typeof((int J, int K)), 7 },
                { typeof((int M, int N)), 8 },
                { typeof((int P, int Q)), 9 },
                { typeof(global::System.Collections.Generic.Dictionary<((int A, int B) C, (int D, int E) F), ((int G, int H) I, (int J, int K) L)>), 10 },
                { typeof(global::Test), 11 },
            };
        }
```

This is runtime error
```ArgumentException: An item with the same key has already been added. Key: System.ValueTuple`2[System.Int32,System.Int32]```

After
```csharp
        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(5)
            {
                { typeof(((int, int), (int, int))), 0 },
                { typeof(((int, int), (int, int))[,]), 1 },
                { typeof((int, int)), 2 },
                { typeof(global::System.Collections.Generic.Dictionary<((int, int), (int, int)), ((int, int), (int, int))>), 3 },
                { typeof(global::Test), 4 },
            };
        }
```