### PR TITLE
Enable SPAN_BUILTIN code for Unity 2021.2+

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StringInterningFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/StringInterningFormatter.cs
@@ -31,7 +31,7 @@ namespace MessagePack.Formatters
 
                     Span<char> chars = stackalloc char[bytes.Length];
                     int charLength;
-#if SPAN_BUILTIN
+#if SPAN_BUILTIN || UNITY_2021_2_OR_NEWER
                     charLength = StringEncoding.UTF8.GetChars(bytes, chars);
 #else
                     unsafe

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StreamPolyfillExtensions.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/StreamPolyfillExtensions.cs
@@ -13,7 +13,7 @@ using Microsoft;
 
 namespace MessagePack
 {
-#if !SPAN_BUILTIN
+#if !SPAN_BUILTIN && !UNITY_2021_2_OR_NEWER
     internal static class StreamPolyfillExtensions
     {
         /// <summary>


### PR DESCRIPTION
I've noticed that those paths were disabled in the current unity release despite the runtime having support for them.