### PR TITLE
Support string interning when deserializing string as object.

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/PrimitiveObjectFormatter.cs
@@ -263,7 +263,8 @@ namespace MessagePack.Formatters
                     }
 
                 case MessagePackType.String:
-                    return reader.ReadString();
+                    var stringFormatter = resolver.GetFormatter<string>();
+                    return stringFormatter.Deserialize(ref reader, options);
                 case MessagePackType.Binary:
                     // We must copy the sequence returned by ReadBytes since the reader's sequence is only valid during deserialization.
                     return reader.ReadBytes()?.ToArray();

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/StringInterningTests.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/StringInterningTests.cs
@@ -65,14 +65,16 @@ namespace MessagePack.Tests
         [Fact]
         public void StringMemberInterning()
         {
-            ClassOfStrings before = new ClassOfStrings { InternedString = "abc", OrdinaryString = "def" };
+            ClassOfStrings before = new ClassOfStrings { InternedString = "abc", OrdinaryString = "def", ObjectString = "obj" };
             ClassOfStrings after1 = MessagePackSerializer.Deserialize<ClassOfStrings>(MessagePackSerializer.Serialize(before, MessagePackSerializerOptions.Standard), MessagePackSerializerOptions.Standard);
             ClassOfStrings after2 = MessagePackSerializer.Deserialize<ClassOfStrings>(MessagePackSerializer.Serialize(before, MessagePackSerializerOptions.Standard), MessagePackSerializerOptions.Standard);
             Assert.Equal(after1.InternedString, after2.InternedString);
             Assert.Equal(after1.OrdinaryString, after2.OrdinaryString);
+            Assert.Equal(after1.ObjectString, after2.ObjectString);
 
             Assert.Same(after1.InternedString, after2.InternedString);
             Assert.NotSame(after1.OrdinaryString, after2.OrdinaryString);
+            Assert.NotSame(after1.ObjectString, after2.ObjectString);
         }
 
         [Fact]
@@ -83,14 +85,16 @@ namespace MessagePack.Tests
                     new IMessagePackFormatter[] { new StringInterningFormatter() },
                     new IFormatterResolver[] { StandardResolver.Instance }));
 
-            ClassOfStrings before = new ClassOfStrings { InternedString = "abc", OrdinaryString = "def" };
+            ClassOfStrings before = new ClassOfStrings { InternedString = "abc", OrdinaryString = "def", ObjectString = "obj" };
             ClassOfStrings after1 = MessagePackSerializer.Deserialize<ClassOfStrings>(MessagePackSerializer.Serialize(before, options), options);
             ClassOfStrings after2 = MessagePackSerializer.Deserialize<ClassOfStrings>(MessagePackSerializer.Serialize(before, options), options);
             Assert.Equal(after1.InternedString, after2.InternedString);
             Assert.Equal(after1.OrdinaryString, after2.OrdinaryString);
+            Assert.Equal(after1.ObjectString, after2.ObjectString);
 
             Assert.Same(after1.InternedString, after2.InternedString);
             Assert.Same(after1.OrdinaryString, after2.OrdinaryString);
+            Assert.Same(after1.ObjectString, after2.ObjectString);
         }
 
         [MessagePackObject]
@@ -102,6 +106,9 @@ namespace MessagePack.Tests
 
             [Key(1)]
             public string OrdinaryString { get; set; }
+
+            [Key(2)]
+            public object ObjectString { get; set; }
         }
     }
 }


### PR DESCRIPTION
fixed [#1484 Strings are not interned on deserialization when the destination property type is object instead of string ](https://github.com/neuecc/MessagePack-CSharp/issues/1484)