### PR TITLE
Add Option For MessagePack.Generator to generate formatters for types from metadata.

### DIFF
--- a/src/MessagePack.Generator/MessagepackCompiler.cs
+++ b/src/MessagePack.Generator/MessagepackCompiler.cs
@@ -46,7 +46,8 @@ namespace MessagePack.Generator
             [Option("n", "Set namespace root name.")] string @namespace = "MessagePack",
             [Option("m", "Force use map mode serialization.")] bool useMapMode = false,
             [Option("ms", "Generate #if-- files by symbols, split with ','.")] string? multipleIfDirectiveOutputSymbols = null,
-            [Option("ei", "Ignore type names.")] string[]? externalIgnoreTypeNames = null)
+            [Option("ei", "Ignore type names.")] string[]? externalIgnoreTypeNames = null,
+            [Option("me", "Generate formatters for types from metadata (e.g. used dlls)")] bool includeTypesFromMetadata = false)
         {
             Workspace? workspace = null;
             try
@@ -70,7 +71,8 @@ namespace MessagePack.Generator
                         @namespace,
                         useMapMode,
                         multipleIfDirectiveOutputSymbols,
-                        externalIgnoreTypeNames).ConfigureAwait(false);
+                        externalIgnoreTypeNames,
+                        includeTypesFromMetadata).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -243,6 +243,8 @@ namespace MessagePackCompiler.CodeAnalysis
 
         private readonly HashSet<string> externalIgnoreTypeNames;
 
+        private readonly bool includeTypesFromMetadata;
+
         // visitor workspace:
 #pragma warning disable RS1024 // Compare symbols correctly (https://github.com/dotnet/roslyn-analyzers/issues/5246)
         private readonly HashSet<ITypeSymbol> alreadyCollected = new(SymbolEqualityComparer.Default);
@@ -252,12 +254,13 @@ namespace MessagePackCompiler.CodeAnalysis
         private readonly List<GenericSerializationInfo> collectedGenericInfo = new();
         private readonly List<UnionSerializationInfo> collectedUnionInfo = new();
 
-        public TypeCollector(Compilation compilation, bool disallowInternal, bool isForceUseMap, string[]? ignoreTypeNames, Action<string> logger)
+        public TypeCollector(Compilation compilation, bool disallowInternal, bool isForceUseMap, string[]? ignoreTypeNames, bool includeTypesFromMetadata, Action<string> logger)
         {
             this.typeReferences = new ReferenceSymbols(compilation, logger);
             this.disallowInternal = disallowInternal;
             this.isForceUseMap = isForceUseMap;
             this.externalIgnoreTypeNames = new HashSet<string>(ignoreTypeNames ?? Array.Empty<string>());
+            this.includeTypesFromMetadata = includeTypesFromMetadata;
 
             targetTypes = compilation.GetNamedTypeSymbols()
                 .Where(x =>
@@ -367,7 +370,7 @@ namespace MessagePackCompiler.CodeAnalysis
                 return;
             }
 
-            if (type.Locations[0].IsInMetadata)
+            if (type.Locations[0].IsInMetadata && !includeTypesFromMetadata)
             {
                 return;
             }

--- a/src/MessagePack.GeneratorCore/CodeGenerator.cs
+++ b/src/MessagePack.GeneratorCore/CodeGenerator.cs
@@ -38,6 +38,7 @@ namespace MessagePackCompiler
         /// <param name="useMapMode">A boolean value that indicates whether all formatters should use property maps instead of more compact arrays.</param>
         /// <param name="multipleIfDirectiveOutputSymbols">A comma-delimited list of symbols that should surround redundant generated files. May be null.</param>
         /// <param name="externalIgnoreTypeNames"> May be null.</param>
+        /// <param name="includeTypesFromMetadata">A bulean balue that indicates wheather formatters for types from metadata should be generated.</param>
         /// <returns>A task that indicates when generation has completed.</returns>
         public async Task GenerateFileAsync(
            Compilation compilation,
@@ -46,7 +47,8 @@ namespace MessagePackCompiler
            string? @namespace,
            bool useMapMode,
            string? multipleIfDirectiveOutputSymbols,
-           string[]? externalIgnoreTypeNames)
+           string[]? externalIgnoreTypeNames,
+           bool includeTypesFromMetadata)
         {
             var namespaceDot = string.IsNullOrWhiteSpace(@namespace) ? string.Empty : @namespace + ".";
             var multipleOutputSymbols = multipleIfDirectiveOutputSymbols?.Split(',') ?? Array.Empty<string>();
@@ -57,7 +59,7 @@ namespace MessagePackCompiler
             {
                 logger("Project Compilation Start:" + compilation.AssemblyName);
 
-                var collector = new TypeCollector(compilation, true, useMapMode, externalIgnoreTypeNames, Console.WriteLine);
+                var collector = new TypeCollector(compilation, true, useMapMode, externalIgnoreTypeNames, includeTypesFromMetadata, Console.WriteLine);
 
                 logger("Project Compilation Complete:" + sw.Elapsed.ToString());
 

--- a/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
+++ b/src/MessagePack.MSBuild.Tasks/MessagePackGenerator.cs
@@ -44,6 +44,8 @@ namespace MessagePack.MSBuild.Tasks
 
         public string[]? ExternalIgnoreTypeNames { get; set; }
 
+        public bool IncludeTypesFromMetadata { get; set; }
+
         [Output]
         public string? GeneratedOutputPath { get; set; }
 
@@ -73,7 +75,8 @@ namespace MessagePack.MSBuild.Tasks
                     Namespace,
                     UseMapMode,
                     null,
-                    ExternalIgnoreTypeNames).GetAwaiter().GetResult();
+                    ExternalIgnoreTypeNames,
+                    IncludeTypesFromMetadata).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {

--- a/tests/MessagePack.Generator.Tests/GenerateEnumFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateEnumFormatterTest.cs
@@ -53,7 +53,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             var symbols = compilation.GetNamedTypeSymbolsFromGenerated();

--- a/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateGenericsFormatterTest.cs
@@ -63,7 +63,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -110,7 +111,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -158,7 +160,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -223,7 +226,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -307,7 +311,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -375,7 +380,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -444,7 +450,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -513,7 +520,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -568,7 +576,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -617,7 +626,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -674,7 +684,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -732,7 +743,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -791,7 +803,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -865,7 +878,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();
@@ -939,7 +953,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Where(x => x.WarningLevel == 0).Should().BeEmpty();

--- a/tests/MessagePack.Generator.Tests/GenerateKeyedFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateKeyedFormatterTest.cs
@@ -54,7 +54,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -128,7 +129,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);

--- a/tests/MessagePack.Generator.Tests/GenerateMessagePackFormatterAttrTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateMessagePackFormatterAttrTest.cs
@@ -68,7 +68,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
         }
     }
 }

--- a/tests/MessagePack.Generator.Tests/GenerateStringKeyedFormatterTest.cs
+++ b/tests/MessagePack.Generator.Tests/GenerateStringKeyedFormatterTest.cs
@@ -55,7 +55,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -120,7 +121,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -180,7 +182,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -240,7 +243,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -297,7 +301,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -363,7 +368,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -437,7 +443,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -506,7 +513,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -571,7 +579,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -637,7 +646,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -706,7 +716,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -773,7 +784,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);
@@ -835,7 +847,8 @@ namespace TempProject
                 "TempProject.Generated",
                 false,
                 string.Empty,
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                false);
 
             var compilation = tempWorkarea.GetOutputCompilation();
             compilation.Compilation.GetDiagnostics().Should().NotContain(x => x.Severity == DiagnosticSeverity.Error);


### PR DESCRIPTION
Added option to generate formatters for types from metadata. Useful when serialized classes in project are using types from dlls.