### PR TITLE
Remove a few dependencies from unity package

### DIFF
--- a/src/MessagePack.UnityClient/build.bat
+++ b/src/MessagePack.UnityClient/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-IF NOT EXIST "%~dp0Assets/Microsoft.VisualStudio.Threading.dll" CALL "%~dp0copy_assets.bat"
+IF NOT EXIST "%~dp0Assets/Plugins/System.Runtime.CompilerServices.Unsafe.dll" CALL "%~dp0copy_assets.bat"
 
 IF "%Build_ArtifactStagingDirectory%"=="" (
     SET LogDirectory=%~dp0..\..\bin\build_logs

--- a/src/MessagePack.UnityClient/build.sh
+++ b/src/MessagePack.UnityClient/build.sh
@@ -8,7 +8,7 @@ done
 
 SCRIPT_DIR=$(dirname "$(realpath $0)")
 
-if ! [[ -e "${SCRIPT_DIR}/Assets/Plugins/System.Memory.dll" ]] ; then
+if ! [[ -e "${SCRIPT_DIR}/Assets/Plugins/System.Runtime.CompilerServices.Unsafe.dll" ]] ; then
    ${SCRIPT_DIR}/copy_assets.sh
 fi
 

--- a/src/MessagePack.UnityClient/copy_assets.bat
+++ b/src/MessagePack.UnityClient/copy_assets.bat
@@ -8,10 +8,7 @@
 
 @pushd %~dp0
 
-echo F | xcopy "..\..\bin\MessagePack\release\netstandard2.0\publish\System.Buffers.dll" ".\Assets\Plugins\System.Buffers.dll" /Y /I
-echo F | xcopy "..\..\bin\MessagePack\release\netstandard2.0\publish\System.Memory.dll" ".\Assets\Plugins\System.Memory.dll" /Y /I
 echo F | xcopy "..\..\bin\MessagePack\release\netstandard2.0\publish\System.Runtime.CompilerServices.Unsafe.dll" ".\Assets\Plugins\System.Runtime.CompilerServices.Unsafe.dll" /Y /I
 echo F | xcopy "..\..\bin\MessagePack\release\netstandard2.0\publish\Microsoft.NET.StringTools.dll" ".\Assets\Plugins\Microsoft.NET.StringTools.dll" /Y /I
-echo F | xcopy "..\..\bin\MessagePack\release\netstandard2.0\publish\System.Threading.Tasks.Extensions.dll" ".\Assets\Plugins\System.Threading.Tasks.Extensions.dll" /Y /I
 
 @popd

--- a/src/MessagePack.UnityClient/copy_assets.sh
+++ b/src/MessagePack.UnityClient/copy_assets.sh
@@ -18,8 +18,5 @@ if ! [[ -d "${SCRIPT_DIR}/Assets/Plugins" ]] ; then
   mkdir -p ${SCRIPT_DIR}/Assets/Plugins
 fi
 
-cp ${SCRIPT_DIR}/../../bin/MessagePack/${BUILDCONFIGURATION}/netstandard2.0/publish/System.Buffers.dll ${SCRIPT_DIR}/Assets/Plugins/System.Buffers.dll
-cp ${SCRIPT_DIR}/../../bin/MessagePack/${BUILDCONFIGURATION}/netstandard2.0/publish/System.Memory.dll ${SCRIPT_DIR}/Assets/Plugins/System.Memory.dll
 cp ${SCRIPT_DIR}/../../bin/MessagePack/${BUILDCONFIGURATION}/netstandard2.0/publish/System.Runtime.CompilerServices.Unsafe.dll ${SCRIPT_DIR}/Assets/Plugins/System.Runtime.CompilerServices.Unsafe.dll
 cp ${SCRIPT_DIR}/../../bin/MessagePack/${BUILDCONFIGURATION}/netstandard2.0/publish/Microsoft.NET.StringTools.dll ${SCRIPT_DIR}/Assets/Plugins/Microsoft.NET.StringTools.dll
-cp ${SCRIPT_DIR}/../../bin/MessagePack/${BUILDCONFIGURATION}/netstandard2.0/publish/System.Threading.Tasks.Extensions.dll ${SCRIPT_DIR}/Assets/Plugins/System.Threading.Tasks.Extensions.dll


### PR DESCRIPTION
Unity 2021.2 and later already include these assemblies, and our inclusion of them causes failures because unity will prefer the 'app-local' copy over its own.

Fixes #1475