### PR TITLE
Fixed issue with generics formatters generation

### DIFF
--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -483,7 +483,7 @@ namespace MessagePackCompiler.CodeAnalysis
             INamedTypeSymbol genericType = type.ConstructUnboundGenericType();
             var genericTypeString = genericType.ToDisplayString();
             var fullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            var isOpenGenericType = type.TypeArguments.Any(x => x is ITypeParameterSymbol);
+            var isOpenGenericType = IsOpenGenericTypeRecursively(type);
 
             // special case
             if (fullName == "global::System.ArraySegment<byte>" || fullName == "global::System.ArraySegment<byte>?")
@@ -1044,6 +1044,11 @@ namespace MessagePackCompiler.CodeAnalysis
             while (symbol != null);
 
             return true;
+        }
+
+        private bool IsOpenGenericTypeRecursively(INamedTypeSymbol type)
+        {
+            return type.IsGenericType && type.TypeArguments.Any(x => x is ITypeParameterSymbol || (x is INamedTypeSymbol symbol && IsOpenGenericTypeRecursively(symbol)));
         }
     }
 }


### PR DESCRIPTION
There is an issue with resolver generation for a nested generic classes.
For example, this set of classes:

    [MessagePackObject]
    public class ClassA<T>
    {
        [Key(0)]
        public readonly T Field { get; set; }
    }

    [MessagePackObject]
    public class ClassB<T>
    {
        [Key(0)]
        public List<ClassA<T>> Field { get; set; }
    }

    [MessagePackObject]
    public class ClassC
    {
        [Key(0)]
        public ClassB<float> Field {get;set;}
    }

Resolver for this set will contain such generated code:

    internal static class GeneratedResolverGetFormatterHelper
    {
        private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> lookup;

        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(5)
            {
                { typeof(global::System.Collections.Generic.List<global::Ti.ClassA<float>>), 0 },
                { typeof(global::System.Collections.Generic.List<global::Ti.ClassA<T>>), 1 },
                { typeof(global::Ti.ClassA<float>), 2 },
                { typeof(global::Ti.ClassB<float>), 3 },
                { typeof(global::Ti.ClassC), 4 },
            };
        }

        internal static object GetFormatter(global::System.Type t)
        {
            int key;
            if (!lookup.TryGetValue(t, out key))
            {
                return null;
            }

            switch (key)
            {
                case 0: return new global::MessagePack.Formatters.ListFormatter<global::Ti.ClassA<float>>();
                case 1: return new global::MessagePack.Formatters.ListFormatter<global::Ti.ClassA<T>>();
                case 2: return new MessagePack.Formatters.Ti.ClassAFormatter<float>();
                case 3: return new MessagePack.Formatters.Ti.ClassBFormatter<float>();
                case 4: return new MessagePack.Formatters.Ti.ClassCFormatter();
                default: return null;
            }
        }
    }

Obviously, this code won't compile. I've added a recursive check for open generic type to take such situations into accout. Now resolver generates correctly:

    internal static class GeneratedResolverGetFormatterHelper
    {
        private static readonly global::System.Collections.Generic.Dictionary<global::System.Type, int> lookup;

        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(4)
            {
                { typeof(global::System.Collections.Generic.List<global::Ti.ClassA<float>>), 0 },
                { typeof(global::Ti.ClassA<float>), 1 },
                { typeof(global::Ti.ClassB<float>), 2 },
                { typeof(global::Ti.ClassC), 3 },
            };
        }

        internal static object GetFormatter(global::System.Type t)
        {
            int key;
            if (!lookup.TryGetValue(t, out key))
            {
                return null;
            }

            switch (key)
            {
                case 0: return new global::MessagePack.Formatters.ListFormatter<global::Ti.ClassA<float>>();
                case 1: return new MessagePack.Formatters.Ti.ClassAFormatter<float>();
                case 2: return new MessagePack.Formatters.Ti.ClassBFormatter<float>();
                case 3: return new MessagePack.Formatters.Ti.ClassCFormatter();
                default: return null;
            }
        }
    }