### PR TITLE
MessagePack.Generator.csproj target to net7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1696,17 +1696,3 @@ The StreamJsonRpc library is based on [JSON-RPC](https://www.jsonrpc.org/) and i
 ## How to build
 
 See our [contributor's guide](CONTRIBUTING.md).
-
-## Author Info
-
-Yoshifumi Kawai (a.k.a. neuecc) is a software developer in Japan.
-He is the Director/CTO at Grani, Inc.
-Grani is a mobile game developer company in Japan and well known for using C#.
-He is awarding Microsoft MVP for Visual C# since 2011.
-He is known as the creator of [UniRx](https://github.com/neuecc/UniRx/) (Reactive Extensions for Unity)
-
-* Blog: [https://medium.com/@neuecc](https://medium.com/@neuecc) (English)
-* Blog: [http://neue.cc/](http://neue.cc/) (Japanese)
-* Twitter: [https://twitter.com/neuecc](https://twitter.com/neuecc) (Japanese)
-
-[Releases]: https://github.com/neuecc/MessagePack-CSharp/releases

--- a/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>mpc</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
If only install dotnet sdk 7,0(does not install sdk 6.0)

![image](https://user-images.githubusercontent.com/46207/205536803-188a9f06-e3e1-4105-b8ea-e603e0cb31d4.png)

mpc fail to get metadata so can't execute it.

![image](https://user-images.githubusercontent.com/46207/205536895-907fce0c-7eae-40a9-ad84-1fa05e52d917.png)

using net7.0 success.

![image](https://user-images.githubusercontent.com/46207/205536935-5638874d-e28a-4032-866f-b818c05d03c9.png)

@AArnott require to change global.json and CI?