### PR TITLE
Hide Microsoft.NET.StringTools from compilation of downstream projects

### DIFF
--- a/src/MessagePack/MessagePack.csproj
+++ b/src/MessagePack/MessagePack.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.StringTools" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.4.0" PrivateAssets="compile" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />


### PR DESCRIPTION
Fixes #1509