### PR TITLE
Added sandbox tests for nested generic types

### DIFF
--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -332,10 +332,10 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class CFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.C>
     {
-        // a
-        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
         // b
         private static global::System.ReadOnlySpan<byte> GetSpan_b() => new byte[1 + 1] { 161, 98 };
+        // a
+        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.C value, global::MessagePack.MessagePackSerializerOptions options)
         {
@@ -347,10 +347,10 @@ namespace MessagePack.Formatters.TestData2
 
             var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
-            writer.WriteRaw(GetSpan_a());
-            writer.Write(value.a);
             writer.WriteRaw(GetSpan_b());
             global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.B>(formatterResolver).Serialize(ref writer, value.b, options);
+            writer.WriteRaw(GetSpan_a());
+            writer.Write(value.a);
         }
 
         public global::TestData2.C Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -378,11 +378,11 @@ namespace MessagePack.Formatters.TestData2
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
                         {
                             default: goto FAIL;
-                            case 97UL:
-                                ____result.a = reader.ReadInt32();
-                                continue;
                             case 98UL:
                                 ____result.b = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.B>(formatterResolver).Deserialize(ref reader, options);
+                                continue;
+                            case 97UL:
+                                ____result.a = reader.ReadInt32();
                                 continue;
                         }
 

--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -47,22 +47,26 @@ namespace MessagePack.Resolvers
 
         static GeneratedResolverGetFormatterHelper()
         {
-            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(14)
+            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(18)
             {
                 { typeof(global::System.Collections.Generic.List<global::TestData2.A>), 0 },
                 { typeof(global::System.Collections.Generic.List<global::TestData2.B>), 1 },
-                { typeof(global::TestData2.Nest1.Id), 2 },
-                { typeof(global::TestData2.Nest2.Id), 3 },
-                { typeof(global::TestData2.A), 4 },
-                { typeof(global::TestData2.B), 5 },
-                { typeof(global::TestData2.C), 6 },
-                { typeof(global::TestData2.Nest1), 7 },
-                { typeof(global::TestData2.Nest1.IdType), 8 },
-                { typeof(global::TestData2.Nest2), 9 },
-                { typeof(global::TestData2.Nest2.IdType), 10 },
-                { typeof(global::TestData2.PropNameCheck1), 11 },
-                { typeof(global::TestData2.PropNameCheck2), 12 },
-                { typeof(global::TestData2.Record), 13 },
+                { typeof(global::System.Collections.Generic.List<global::TestData2.NestedGenericTestA<int>>), 2 },
+                { typeof(global::TestData2.NestedGenericTestA<int>), 3 },
+                { typeof(global::TestData2.NestedGenericTestB<int>), 4 },
+                { typeof(global::TestData2.Nest1.Id), 5 },
+                { typeof(global::TestData2.Nest2.Id), 6 },
+                { typeof(global::TestData2.A), 7 },
+                { typeof(global::TestData2.B), 8 },
+                { typeof(global::TestData2.C), 9 },
+                { typeof(global::TestData2.Nest1), 10 },
+                { typeof(global::TestData2.Nest1.IdType), 11 },
+                { typeof(global::TestData2.Nest2), 12 },
+                { typeof(global::TestData2.Nest2.IdType), 13 },
+                { typeof(global::TestData2.NestedGenericTestC), 14 },
+                { typeof(global::TestData2.PropNameCheck1), 15 },
+                { typeof(global::TestData2.PropNameCheck2), 16 },
+                { typeof(global::TestData2.Record), 17 },
             };
         }
 
@@ -78,18 +82,22 @@ namespace MessagePack.Resolvers
             {
                 case 0: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.A>();
                 case 1: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.B>();
-                case 2: return new MessagePack.Formatters.TestData2.Nest1_IdFormatter();
-                case 3: return new MessagePack.Formatters.TestData2.Nest2_IdFormatter();
-                case 4: return new MessagePack.Formatters.TestData2.AFormatter();
-                case 5: return new MessagePack.Formatters.TestData2.BFormatter();
-                case 6: return new MessagePack.Formatters.TestData2.CFormatter();
-                case 7: return new MessagePack.Formatters.TestData2.Nest1Formatter();
-                case 8: return new MessagePack.Formatters.TestData2.Nest1_IdTypeFormatter();
-                case 9: return new MessagePack.Formatters.TestData2.Nest2Formatter();
-                case 10: return new MessagePack.Formatters.TestData2.Nest2_IdTypeFormatter();
-                case 11: return new MessagePack.Formatters.TestData2.PropNameCheck1Formatter();
-                case 12: return new MessagePack.Formatters.TestData2.PropNameCheck2Formatter();
-                case 13: return new MessagePack.Formatters.TestData2.RecordFormatter();
+                case 2: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.NestedGenericTestA<int>>();
+                case 3: return new MessagePack.Formatters.TestData2.NestedGenericTestAFormatter<int>();
+                case 4: return new MessagePack.Formatters.TestData2.NestedGenericTestBFormatter<int>();
+                case 5: return new MessagePack.Formatters.TestData2.Nest1_IdFormatter();
+                case 6: return new MessagePack.Formatters.TestData2.Nest2_IdFormatter();
+                case 7: return new MessagePack.Formatters.TestData2.AFormatter();
+                case 8: return new MessagePack.Formatters.TestData2.BFormatter();
+                case 9: return new MessagePack.Formatters.TestData2.CFormatter();
+                case 10: return new MessagePack.Formatters.TestData2.Nest1Formatter();
+                case 11: return new MessagePack.Formatters.TestData2.Nest1_IdTypeFormatter();
+                case 12: return new MessagePack.Formatters.TestData2.Nest2Formatter();
+                case 13: return new MessagePack.Formatters.TestData2.Nest2_IdTypeFormatter();
+                case 14: return new MessagePack.Formatters.TestData2.NestedGenericTestCFormatter();
+                case 15: return new MessagePack.Formatters.TestData2.PropNameCheck1Formatter();
+                case 16: return new MessagePack.Formatters.TestData2.PropNameCheck2Formatter();
+                case 17: return new MessagePack.Formatters.TestData2.RecordFormatter();
                 default: return null;
             }
         }
@@ -324,10 +332,10 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class CFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.C>
     {
-        // b
-        private static global::System.ReadOnlySpan<byte> GetSpan_b() => new byte[1 + 1] { 161, 98 };
         // a
         private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
+        // b
+        private static global::System.ReadOnlySpan<byte> GetSpan_b() => new byte[1 + 1] { 161, 98 };
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.C value, global::MessagePack.MessagePackSerializerOptions options)
         {
@@ -339,10 +347,10 @@ namespace MessagePack.Formatters.TestData2
 
             var formatterResolver = options.Resolver;
             writer.WriteMapHeader(2);
-            writer.WriteRaw(GetSpan_b());
-            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.B>(formatterResolver).Serialize(ref writer, value.b, options);
             writer.WriteRaw(GetSpan_a());
             writer.Write(value.a);
+            writer.WriteRaw(GetSpan_b());
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.B>(formatterResolver).Serialize(ref writer, value.b, options);
         }
 
         public global::TestData2.C Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -370,11 +378,11 @@ namespace MessagePack.Formatters.TestData2
                         switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
                         {
                             default: goto FAIL;
-                            case 98UL:
-                                ____result.b = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.B>(formatterResolver).Deserialize(ref reader, options);
-                                continue;
                             case 97UL:
                                 ____result.a = reader.ReadInt32();
+                                continue;
+                            case 98UL:
+                                ____result.b = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.B>(formatterResolver).Deserialize(ref reader, options);
                                 continue;
                         }
 
@@ -560,6 +568,168 @@ namespace MessagePack.Formatters.TestData2
 
             reader.Skip();
             var ____result = new global::TestData2.Nest2.IdType();
+            return ____result;
+        }
+    }
+
+    public sealed class NestedGenericTestAFormatter<T> : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.NestedGenericTestA<T>>
+    {
+        // Field
+        private static global::System.ReadOnlySpan<byte> GetSpan_Field() => new byte[1 + 5] { 165, 70, 105, 101, 108, 100 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.NestedGenericTestA<T> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            var formatterResolver = options.Resolver;
+            writer.WriteMapHeader(1);
+            writer.WriteRaw(GetSpan_Field());
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<T>(formatterResolver).Serialize(ref writer, value.Field, options);
+        }
+
+        public global::TestData2.NestedGenericTestA<T> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
+            var length = reader.ReadMapHeader();
+            var ____result = new global::TestData2.NestedGenericTestA<T>();
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 431315315014UL) { goto FAIL; }
+
+                        ____result.Field = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<T>(formatterResolver).Deserialize(ref reader, options);
+                        continue;
+
+                }
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class NestedGenericTestBFormatter<T> : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.NestedGenericTestB<T>>
+    {
+        // Field
+        private static global::System.ReadOnlySpan<byte> GetSpan_Field() => new byte[1 + 5] { 165, 70, 105, 101, 108, 100 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.NestedGenericTestB<T> value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            var formatterResolver = options.Resolver;
+            writer.WriteMapHeader(1);
+            writer.WriteRaw(GetSpan_Field());
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.NestedGenericTestA<T>>>(formatterResolver).Serialize(ref writer, value.Field, options);
+        }
+
+        public global::TestData2.NestedGenericTestB<T> Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
+            var length = reader.ReadMapHeader();
+            var ____result = new global::TestData2.NestedGenericTestB<T>();
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 431315315014UL) { goto FAIL; }
+
+                        ____result.Field = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.NestedGenericTestA<T>>>(formatterResolver).Deserialize(ref reader, options);
+                        continue;
+
+                }
+            }
+
+            reader.Depth--;
+            return ____result;
+        }
+    }
+
+    public sealed class NestedGenericTestCFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.NestedGenericTestC>
+    {
+        // Field
+        private static global::System.ReadOnlySpan<byte> GetSpan_Field() => new byte[1 + 5] { 165, 70, 105, 101, 108, 100 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.NestedGenericTestC value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            var formatterResolver = options.Resolver;
+            writer.WriteMapHeader(1);
+            writer.WriteRaw(GetSpan_Field());
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.NestedGenericTestB<int>>(formatterResolver).Serialize(ref writer, value.Field, options);
+        }
+
+        public global::TestData2.NestedGenericTestC Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
+            var length = reader.ReadMapHeader();
+            var ____result = new global::TestData2.NestedGenericTestC();
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 5:
+                        if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 431315315014UL) { goto FAIL; }
+
+                        ____result.Field = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.NestedGenericTestB<int>>(formatterResolver).Deserialize(ref reader, options);
+                        continue;
+
+                }
+            }
+
+            reader.Depth--;
             return ____result;
         }
     }

--- a/sandbox/TestData2/NestedGenerics.cs
+++ b/sandbox/TestData2/NestedGenerics.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning disable SA1401 // Fields should be private
 #pragma warning disable SA1649 // File name should match first type name

--- a/sandbox/TestData2/NestedGenerics.cs
+++ b/sandbox/TestData2/NestedGenerics.cs
@@ -1,0 +1,25 @@
+﻿
+#pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable SA1401 // Fields should be private
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace TestData2
+{
+    [MessagePackObject(true)]
+    public class NestedGenericTestA<T>
+    {
+        public T Field { get; set; }
+    }
+
+    [MessagePackObject(true)]
+    public class NestedGenericTestB<T>
+    {
+        public List<NestedGenericTestA<T>> Field { get; set; }
+    }
+
+    [MessagePackObject(true)]
+    public class NestedGenericTestC
+    {
+        public NestedGenericTestB<int> Field { get; set; }
+    }
+}


### PR DESCRIPTION
It's worth to add sandbox tests for nested generic types. Related PR - https://github.com/neuecc/MessagePack-CSharp/pull/1534.