### PR TITLE
Fixed nullable embedded types are being added to generated resolver

### DIFF
--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -255,12 +255,12 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class BFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.B>
     {
-        // a
-        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
         // ass
         private static global::System.ReadOnlySpan<byte> GetSpan_ass() => new byte[1 + 3] { 163, 97, 115, 115 };
         // c
         private static global::System.ReadOnlySpan<byte> GetSpan_c() => new byte[1 + 1] { 161, 99 };
+        // a
+        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.B value, global::MessagePack.MessagePackSerializerOptions options)
         {
@@ -272,12 +272,12 @@ namespace MessagePack.Formatters.TestData2
 
             var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
-            writer.WriteRaw(GetSpan_a());
-            writer.Write(value.a);
             writer.WriteRaw(GetSpan_ass());
             global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>(formatterResolver).Serialize(ref writer, value.ass, options);
             writer.WriteRaw(GetSpan_c());
             global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.C>(formatterResolver).Serialize(ref writer, value.c, options);
+            writer.WriteRaw(GetSpan_a());
+            writer.Write(value.a);
         }
 
         public global::TestData2.B Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -301,22 +301,22 @@ namespace MessagePack.Formatters.TestData2
                     FAIL:
                       reader.Skip();
                       continue;
-                    case 1:
-                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
-                        {
-                            default: goto FAIL;
-                            case 97UL:
-                                ____result.a = reader.ReadInt32();
-                                continue;
-                            case 99UL:
-                                ____result.c = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.C>(formatterResolver).Deserialize(ref reader, options);
-                                continue;
-                        }
                     case 3:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 7566177UL) { goto FAIL; }
 
                         ____result.ass = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>(formatterResolver).Deserialize(ref reader, options);
                         continue;
+                    case 1:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 99UL:
+                                ____result.c = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.C>(formatterResolver).Deserialize(ref reader, options);
+                                continue;
+                            case 97UL:
+                                ____result.a = reader.ReadInt32();
+                                continue;
+                        }
 
                 }
             }

--- a/sandbox/TestData2/Generated.cs
+++ b/sandbox/TestData2/Generated.cs
@@ -47,22 +47,24 @@ namespace MessagePack.Resolvers
 
         static GeneratedResolverGetFormatterHelper()
         {
-            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(14)
+            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(16)
             {
-                { typeof(global::System.Collections.Generic.List<global::TestData2.A>), 0 },
-                { typeof(global::System.Collections.Generic.List<global::TestData2.B>), 1 },
-                { typeof(global::TestData2.Nest1.Id), 2 },
-                { typeof(global::TestData2.Nest2.Id), 3 },
-                { typeof(global::TestData2.A), 4 },
-                { typeof(global::TestData2.B), 5 },
-                { typeof(global::TestData2.C), 6 },
-                { typeof(global::TestData2.Nest1), 7 },
-                { typeof(global::TestData2.Nest1.IdType), 8 },
-                { typeof(global::TestData2.Nest2), 9 },
-                { typeof(global::TestData2.Nest2.IdType), 10 },
-                { typeof(global::TestData2.PropNameCheck1), 11 },
-                { typeof(global::TestData2.PropNameCheck2), 12 },
-                { typeof(global::TestData2.Record), 13 },
+                { typeof(global::System.Collections.Generic.List<byte[]>), 0 },
+                { typeof(global::System.Collections.Generic.List<global::TestData2.A>), 1 },
+                { typeof(global::System.Collections.Generic.List<global::TestData2.B>), 2 },
+                { typeof(global::TestData2.Nest1.Id), 3 },
+                { typeof(global::TestData2.Nest2.Id), 4 },
+                { typeof(global::TestData2.A), 5 },
+                { typeof(global::TestData2.B), 6 },
+                { typeof(global::TestData2.C), 7 },
+                { typeof(global::TestData2.Nest1), 8 },
+                { typeof(global::TestData2.Nest1.IdType), 9 },
+                { typeof(global::TestData2.Nest2), 10 },
+                { typeof(global::TestData2.Nest2.IdType), 11 },
+                { typeof(global::TestData2.NullableTest), 12 },
+                { typeof(global::TestData2.PropNameCheck1), 13 },
+                { typeof(global::TestData2.PropNameCheck2), 14 },
+                { typeof(global::TestData2.Record), 15 },
             };
         }
 
@@ -76,20 +78,22 @@ namespace MessagePack.Resolvers
 
             switch (key)
             {
-                case 0: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.A>();
-                case 1: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.B>();
-                case 2: return new MessagePack.Formatters.TestData2.Nest1_IdFormatter();
-                case 3: return new MessagePack.Formatters.TestData2.Nest2_IdFormatter();
-                case 4: return new MessagePack.Formatters.TestData2.AFormatter();
-                case 5: return new MessagePack.Formatters.TestData2.BFormatter();
-                case 6: return new MessagePack.Formatters.TestData2.CFormatter();
-                case 7: return new MessagePack.Formatters.TestData2.Nest1Formatter();
-                case 8: return new MessagePack.Formatters.TestData2.Nest1_IdTypeFormatter();
-                case 9: return new MessagePack.Formatters.TestData2.Nest2Formatter();
-                case 10: return new MessagePack.Formatters.TestData2.Nest2_IdTypeFormatter();
-                case 11: return new MessagePack.Formatters.TestData2.PropNameCheck1Formatter();
-                case 12: return new MessagePack.Formatters.TestData2.PropNameCheck2Formatter();
-                case 13: return new MessagePack.Formatters.TestData2.RecordFormatter();
+                case 0: return new global::MessagePack.Formatters.ListFormatter<byte[]>();
+                case 1: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.A>();
+                case 2: return new global::MessagePack.Formatters.ListFormatter<global::TestData2.B>();
+                case 3: return new MessagePack.Formatters.TestData2.Nest1_IdFormatter();
+                case 4: return new MessagePack.Formatters.TestData2.Nest2_IdFormatter();
+                case 5: return new MessagePack.Formatters.TestData2.AFormatter();
+                case 6: return new MessagePack.Formatters.TestData2.BFormatter();
+                case 7: return new MessagePack.Formatters.TestData2.CFormatter();
+                case 8: return new MessagePack.Formatters.TestData2.Nest1Formatter();
+                case 9: return new MessagePack.Formatters.TestData2.Nest1_IdTypeFormatter();
+                case 10: return new MessagePack.Formatters.TestData2.Nest2Formatter();
+                case 11: return new MessagePack.Formatters.TestData2.Nest2_IdTypeFormatter();
+                case 12: return new MessagePack.Formatters.TestData2.NullableTestFormatter();
+                case 13: return new MessagePack.Formatters.TestData2.PropNameCheck1Formatter();
+                case 14: return new MessagePack.Formatters.TestData2.PropNameCheck2Formatter();
+                case 15: return new MessagePack.Formatters.TestData2.RecordFormatter();
                 default: return null;
             }
         }
@@ -251,12 +255,12 @@ namespace MessagePack.Formatters.TestData2
 
     public sealed class BFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.B>
     {
+        // a
+        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
         // ass
         private static global::System.ReadOnlySpan<byte> GetSpan_ass() => new byte[1 + 3] { 163, 97, 115, 115 };
         // c
         private static global::System.ReadOnlySpan<byte> GetSpan_c() => new byte[1 + 1] { 161, 99 };
-        // a
-        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
 
         public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.B value, global::MessagePack.MessagePackSerializerOptions options)
         {
@@ -268,12 +272,12 @@ namespace MessagePack.Formatters.TestData2
 
             var formatterResolver = options.Resolver;
             writer.WriteMapHeader(3);
+            writer.WriteRaw(GetSpan_a());
+            writer.Write(value.a);
             writer.WriteRaw(GetSpan_ass());
             global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>(formatterResolver).Serialize(ref writer, value.ass, options);
             writer.WriteRaw(GetSpan_c());
             global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.C>(formatterResolver).Serialize(ref writer, value.c, options);
-            writer.WriteRaw(GetSpan_a());
-            writer.Write(value.a);
         }
 
         public global::TestData2.B Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
@@ -297,22 +301,22 @@ namespace MessagePack.Formatters.TestData2
                     FAIL:
                       reader.Skip();
                       continue;
+                    case 1:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 97UL:
+                                ____result.a = reader.ReadInt32();
+                                continue;
+                            case 99UL:
+                                ____result.c = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.C>(formatterResolver).Deserialize(ref reader, options);
+                                continue;
+                        }
                     case 3:
                         if (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey) != 7566177UL) { goto FAIL; }
 
                         ____result.ass = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<global::TestData2.A>>(formatterResolver).Deserialize(ref reader, options);
                         continue;
-                    case 1:
-                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
-                        {
-                            default: goto FAIL;
-                            case 99UL:
-                                ____result.c = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::TestData2.C>(formatterResolver).Deserialize(ref reader, options);
-                                continue;
-                            case 97UL:
-                                ____result.a = reader.ReadInt32();
-                                continue;
-                        }
 
                 }
             }
@@ -560,6 +564,70 @@ namespace MessagePack.Formatters.TestData2
 
             reader.Skip();
             var ____result = new global::TestData2.Nest2.IdType();
+            return ____result;
+        }
+    }
+
+    public sealed class NullableTestFormatter : global::MessagePack.Formatters.IMessagePackFormatter<global::TestData2.NullableTest>
+    {
+        // a
+        private static global::System.ReadOnlySpan<byte> GetSpan_a() => new byte[1 + 1] { 161, 97 };
+        // b
+        private static global::System.ReadOnlySpan<byte> GetSpan_b() => new byte[1 + 1] { 161, 98 };
+
+        public void Serialize(ref global::MessagePack.MessagePackWriter writer, global::TestData2.NullableTest value, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            var formatterResolver = options.Resolver;
+            writer.WriteMapHeader(2);
+            writer.WriteRaw(GetSpan_a());
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<int[]>(formatterResolver).Serialize(ref writer, value.a, options);
+            writer.WriteRaw(GetSpan_b());
+            global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<byte[]>>(formatterResolver).Serialize(ref writer, value.b, options);
+        }
+
+        public global::TestData2.NullableTest Deserialize(ref global::MessagePack.MessagePackReader reader, global::MessagePack.MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            options.Security.DepthStep(ref reader);
+            var formatterResolver = options.Resolver;
+            var length = reader.ReadMapHeader();
+            var ____result = new global::TestData2.NullableTest();
+
+            for (int i = 0; i < length; i++)
+            {
+                var stringKey = global::MessagePack.Internal.CodeGenHelpers.ReadStringSpan(ref reader);
+                switch (stringKey.Length)
+                {
+                    default:
+                    FAIL:
+                      reader.Skip();
+                      continue;
+                    case 1:
+                        switch (global::MessagePack.Internal.AutomataKeyGen.GetKey(ref stringKey))
+                        {
+                            default: goto FAIL;
+                            case 97UL:
+                                ____result.a = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<int[]>(formatterResolver).Deserialize(ref reader, options);
+                                continue;
+                            case 98UL:
+                                ____result.b = global::MessagePack.FormatterResolverExtensions.GetFormatterWithVerify<global::System.Collections.Generic.List<byte[]>>(formatterResolver).Deserialize(ref reader, options);
+                                continue;
+                        }
+
+                }
+            }
+
+            reader.Depth--;
             return ____result;
         }
     }

--- a/sandbox/TestData2/NullableTest.cs
+++ b/sandbox/TestData2/NullableTest.cs
@@ -1,5 +1,5 @@
-﻿
-using System;
+﻿// Copyright (c) All contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
 #pragma warning disable SA1401 // Fields should be private
@@ -13,5 +13,5 @@ namespace TestData2;
 public class NullableTest
 {
     public int[]? a;
-    public List<byte[]?> b;
+    public List<byte[]?> b = null!;
 }

--- a/sandbox/TestData2/NullableTest.cs
+++ b/sandbox/TestData2/NullableTest.cs
@@ -1,0 +1,17 @@
+﻿
+using System;
+
+#pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning disable SA1401 // Fields should be private
+#pragma warning disable SA1649 // File name should match first type name
+
+#nullable enable
+
+namespace TestData2;
+
+[MessagePackObject(true)]
+public class NullableTest
+{
+    public int[]? a;
+    public List<byte[]?> b;
+}

--- a/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
+++ b/src/MessagePack.GeneratorCore/CodeAnalysis/TypeCollector.cs
@@ -319,7 +319,7 @@ namespace MessagePackCompiler.CodeAnalysis
                 return;
             }
 
-            var typeSymbolString = typeSymbol.ToString() ?? throw new InvalidOperationException();
+            var typeSymbolString = typeSymbol.WithNullableAnnotation(NullableAnnotation.NotAnnotated).ToString() ?? throw new InvalidOperationException();
             if (this.embeddedTypes.Contains(typeSymbolString))
             {
                 return;


### PR DESCRIPTION
If some embedded reference type, such as byte[] is defined as nullable in MessagePackObject, it starts to appear in generated resolver. But, generated formatter for byte[] (ArrayFormatter<byte>) is not binary compatible with embedded formatter (ByteArrayFormatter).
This is what is generated from NullableTest before the fix:
```
        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(18)
            {
                { typeof(byte[]), 0 },
                { typeof(global::System.Collections.Generic.List<byte[]>), 1 },
                { typeof(global::System.Collections.Generic.List<global::TestData2.A>), 2 },
                { typeof(global::System.Collections.Generic.List<global::TestData2.B>), 3 },
                { typeof(int[]), 4 },
                { typeof(global::TestData2.Nest1.Id), 5 },
                { typeof(global::TestData2.Nest2.Id), 6 },
                { typeof(global::TestData2.A), 7 },
                { typeof(global::TestData2.B), 8 },
                { typeof(global::TestData2.C), 9 },
                { typeof(global::TestData2.Nest1), 10 },
                { typeof(global::TestData2.Nest1.IdType), 11 },
                { typeof(global::TestData2.Nest2), 12 },
                { typeof(global::TestData2.Nest2.IdType), 13 },
                { typeof(global::TestData2.NullableTest), 14 },
                { typeof(global::TestData2.PropNameCheck1), 15 },
                { typeof(global::TestData2.PropNameCheck2), 16 },
                { typeof(global::TestData2.Record), 17 },
            };
        }
```

After the fix it looks like this:
```
        static GeneratedResolverGetFormatterHelper()
        {
            lookup = new global::System.Collections.Generic.Dictionary<global::System.Type, int>(16)
            {
                { typeof(global::System.Collections.Generic.List<byte[]>), 0 },
                { typeof(global::System.Collections.Generic.List<global::TestData2.A>), 1 },
                { typeof(global::System.Collections.Generic.List<global::TestData2.B>), 2 },
                { typeof(global::TestData2.Nest1.Id), 3 },
                { typeof(global::TestData2.Nest2.Id), 4 },
                { typeof(global::TestData2.A), 5 },
                { typeof(global::TestData2.B), 6 },
                { typeof(global::TestData2.C), 7 },
                { typeof(global::TestData2.Nest1), 8 },
                { typeof(global::TestData2.Nest1.IdType), 9 },
                { typeof(global::TestData2.Nest2), 10 },
                { typeof(global::TestData2.Nest2.IdType), 11 },
                { typeof(global::TestData2.NullableTest), 12 },
                { typeof(global::TestData2.PropNameCheck1), 13 },
                { typeof(global::TestData2.PropNameCheck2), 14 },
                { typeof(global::TestData2.Record), 15 },
            };
        }
```
