### PR TITLE
Show details of errors occurred when the generator opens a project

### DIFF
--- a/src/MessagePack.Generator/MessagepackCompiler.cs
+++ b/src/MessagePack.Generator/MessagepackCompiler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
@@ -90,6 +91,12 @@ namespace MessagePack.Generator
             {
                 var logger = new ConsoleLogger(Microsoft.Build.Framework.LoggerVerbosity.Quiet);
                 var project = await workspace.OpenProjectAsync(projectPath, logger, null, cancellationToken);
+                if (workspace.Diagnostics.Any(x => x.Kind is WorkspaceDiagnosticKind.Failure))
+                {
+                    throw new InvalidOperationException("One or more errors occured while opening the project:" + Environment.NewLine +
+                        string.Join(Environment.NewLine, workspace.Diagnostics.Select(x => $"========================================{Environment.NewLine}{x.Message}{Environment.NewLine}========================================")));
+                }
+
                 var compilation = await project.GetCompilationAsync(cancellationToken);
                 if (compilation is null)
                 {


### PR DESCRIPTION
This PR changes to show details of errors that occur when the generator opens a project.

Currently, when an error occurs in the SDK resolver, the generator continues to proceed.
The error then occurs elsewhere, making it difficult to determine the cause.

### Before
```
Project Compilation Start:MyProject
failed to get metadata of System.Threading.Tasks.Task`1
failed to get metadata of System.Threading.Tasks.Task
Fail in console app running on MessagepackCompiler.RunAsync
System.InvalidOperationException: failed to get metadata of MessagePack.MessagePackObjectAttribute
   at MessagePackCompiler.CodeAnalysis.ReferenceSymbols..ctor(Compilation compilation, Action`1 logger) in C:\Users\path\to\MessagePack-CSharp\src\MessagePack.GeneratorCore\CodeAnalysis\TypeCollector.cs:line 53
   at MessagePackCompiler.CodeAnalysis.TypeCollector..ctor(Compilation compilation, Boolean disallowInternal, Boolean isForceUseMap, String[] ignoreTypeNames, Action`1 logger) in C:\Users\path\to\MessagePack-CSharp\src\MessagePack.GeneratorCore\CodeAnalysis\TypeCollector.cs:line 259
```

### After
```
Fail in console app running on MessagepackCompiler.RunAsync
System.InvalidOperationException: One or more errors occured while opening the project:
========================================
Msbuild failed when processing the file 'C:\Users\path\to\MyProject.csproj' with message: SDK Resolver Failure: "The SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" failed while attempting to resolve the SDK "Microsoft.NET.Sdk". Exception: "Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadManifestCompositionException: Workload manifest dependency 'Microsoft.NET.Workload.Emscripten' version '6.0.4' is lower than version '6.0.9' required by manifest 'microsoft.net.workload.mono.toolchain' [C:\Program Files\dotnet\sdk-manifests\6.0.300\microsoft.net.workload.mono.toolchain\WorkloadManifest.json]
   at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.ComposeWorkloadManifests()
   at Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver.Create(IWorkloadManifestProvider manifestProvider, String dotnetRootPath, String sdkVersion, String userProfileDir)
   at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.CachingWorkloadResolver.Resolve(String sdkReferenceName, String dotnetRootPath, String sdkVersion, String userProfileDir)
   at Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver.WorkloadSdkResolver.Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
   at Microsoft.Build.BackEnd.SdkResolution.SdkResolverService.TryResolveSdkUsingSpecifiedResolvers(IList`1 resolvers, Int32 submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, String solutionPath, String projectPath, Boolean interactive, Boolean isRunningInVisualStudio, SdkResult& sdkResult)""  C:\Users\path\to\MyProject.csproj
========================================
   at MessagePack.Generator.MessagepackCompiler.OpenMSBuildProjectAsync(String projectPath, CancellationToken cancellationToken) in C:\Users\path\to\MessagePack-CSharp\src\MessagePack.Generator\MessagepackCompiler.cs:line 96
```