### PR TITLE
Use Mono.RuntimeStructs rather than Mono.Runtime to test if app is running on Mono runtime

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MonoProtection.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MonoProtection.cs
@@ -14,7 +14,7 @@ namespace MessagePack
         /// <summary>
         /// Gets a value indicating whether the mono runtime is executing this code.
         /// </summary>
-        internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+        internal static bool IsRunningOnMono => Type.GetType("Mono.RuntimeStructs") != null;
 
         /// <summary>
         /// A lock that we enter on mono when generating dynamic types.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -19,7 +19,7 @@ namespace MessagePack
 #if UNITY_2018_3_OR_NEWER
         internal const bool IsMono = true; // hard code since we haven't tested whether mono is detected on all unity platforms.
 #else
-        internal static readonly bool IsMono = Type.GetType("Mono.Runtime") is Type;
+        internal static readonly bool IsMono = Type.GetType("Mono.RuntimeStructs") is Type;
 #endif
 
         internal delegate void GetWriterBytesAction<TArg>(ref MessagePackWriter writer, TArg argument);

--- a/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/Tests/ShareTests/TestUtilities.cs
@@ -14,7 +14,7 @@ namespace MessagePack.Tests
         /// <summary>
         /// Gets a value indicating whether the mono runtime is executing this code.
         /// </summary>
-        internal static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+        internal static bool IsRunningOnMono => Type.GetType("Mono.RuntimeStructs") != null;
 
         internal static string ToHex(byte[] buffer) => BitConverter.ToString(buffer).Replace("-", string.Empty).ToLowerInvariant();
     }


### PR DESCRIPTION
In newer versions of .NET (6 or later), Mono runtime is still used for some targets like mobile OSes, rather than CoreCLR.
However, currently, `Mono.Runtime` class does not exist in latest Mono-flavored `System.Private.CoreLib` library.

This causes the problem of `MonoProtection` (introduced by #1035) not being enabled unintentionally.
The bug in Mono that is the cause of introducing `MonoProtection` is not fixed yet so `MonoProtection` is still needed.

`Mono.RuntimeStructs` is one of the types which exist in both the older Mono and newer Mono.
So this pullreq modifies to use this type to determine the current runtime rather than `Mono.Runtime`.

Other projects like [BenchmarkDotnet](https://github.com/dotnet/BenchmarkDotNet/blob/fb7f1be069e5516c71e4fff86d30788fe8083840/src/BenchmarkDotNet/Portability/RuntimeInformation.cs#L28-L31) also uses `Mono.RuntimeStructs` to make decisions.