### PR TITLE
fix ThreadsafeTypeKeyHashTable.GetOrAdd stampede issue

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -180,7 +180,7 @@ namespace MessagePack.Internal
                 return v;
             }
 
-            if (!this.TryAddInternal(key, valueFactory, out v))
+            if (!this.TryAddInternal(key, valueFactory, out v) && !this.TryGetValue(key, out v))
             {
                 throw new InvalidOperationException("Failed to get or add.");
             }


### PR DESCRIPTION
`GetOrAdd` is not running inside a lock, so if multiple threads try to serialize the same type, it could result in the `throw new InvalidOperationException("Failed to get or add.");`.
 
for example : 
1. 2 threads enter the function at the same time
2. both threads fail to Get value and are now in Add attempt
3. one succeeds (in locked context so the other waits)
4. second thread fails to add item and throws exception 

fix : 
after failing to Add() item try to Get it again before raising exception
