### PR TITLE
Revert change that introduced thread-safety bug

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -43,7 +43,7 @@ namespace MessagePack.Internal
             return this.TryAddInternal(key, valueFactory, out TValue? _);
         }
 
-        private bool TryAddInternal(Type key, Func<Type, TValue> valueFactory, [MaybeNullWhen(false)] out TValue resultingValue)
+        private bool TryAddInternal(Type key, Func<Type, TValue> valueFactory, out TValue resultingValue)
         {
             lock (this.writerLock)
             {
@@ -91,7 +91,7 @@ namespace MessagePack.Internal
             }
         }
 
-        private bool AddToBuckets(Entry[] buckets, Type newKey, Entry? newEntryOrNull, Func<Type, TValue>? valueFactory, out TValue? resultingValue)
+        private bool AddToBuckets(Entry[] buckets, Type newKey, Entry? newEntryOrNull, Func<Type, TValue>? valueFactory, out TValue resultingValue)
         {
             var h = (newEntryOrNull != null) ? newEntryOrNull.Hash : newKey.GetHashCode();
             if (buckets[h & (buckets.Length - 1)] == null)
@@ -180,11 +180,7 @@ namespace MessagePack.Internal
                 return v;
             }
 
-            if (!this.TryAddInternal(key, valueFactory, out v) && !this.TryGetValue(key, out v))
-            {
-                throw new InvalidOperationException("Failed to get or add.");
-            }
-
+            this.TryAddInternal(key, valueFactory, out v);
             return v;
         }
 

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -40,7 +40,7 @@ namespace MessagePack.Internal
 
         public bool TryAdd(Type key, Func<Type, TValue> valueFactory)
         {
-            return this.TryAddInternal(key, valueFactory, out TValue _);
+            return this.TryAddInternal(key, valueFactory, out TValue? _);
         }
 
         private bool TryAddInternal(Type key, Func<Type, TValue> valueFactory, [MaybeNullWhen(false)] out TValue resultingValue)


### PR DESCRIPTION
- Fix compiler warning that appears with VS 2022 Update 6 preview
- Remove code to throw an exception
    This fixes a regression introduced in a398f715739950b4a8f291a840039b78d30f442f.
    I misunderstood that the `TryAddInternal` method *always* sets the out value even when returning false.