### PR TITLE
Avoid copying data twice in MessagePackWriter.MemoryCopy when running…

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1335,6 +1335,14 @@ namespace MessagePack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy)
         {
+#if UNITY_2018_3_OR_NEWER
+            if (sourceBytesToCopy > destinationSizeInBytes)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceBytesToCopy));
+            }
+
+            global::Unity.Collections.LowLevel.Unsafe.UnsafeUtility.MemMove(destination, source, sourceBytesToCopy);
+#else
 #pragma warning disable 0162
 
             if (Utilities.IsMono)
@@ -1361,6 +1369,7 @@ namespace MessagePack
             }
 
 #pragma warning restore 0162
+#endif
         }
     }
 }

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -1338,7 +1338,9 @@ namespace MessagePack
 #if UNITY_2018_3_OR_NEWER
             if (sourceBytesToCopy > destinationSizeInBytes)
             {
-                throw new ArgumentOutOfRangeException(nameof(sourceBytesToCopy));
+                static void Throw(string paramName) => throw new ArgumentOutOfRangeException(paramName);
+
+                Throw(nameof(sourceBytesToCopy));
             }
 
             global::Unity.Collections.LowLevel.Unsafe.UnsafeUtility.MemMove(destination, source, sourceBytesToCopy);

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Utilities.cs
@@ -16,11 +16,7 @@ namespace MessagePack
         /// <summary>
         /// A value indicating whether we're running on mono.
         /// </summary>
-#if UNITY_2018_3_OR_NEWER
-        internal const bool IsMono = true; // hard code since we haven't tested whether mono is detected on all unity platforms.
-#else
         internal static readonly bool IsMono = Type.GetType("Mono.RuntimeStructs") is Type;
-#endif
 
         internal delegate void GetWriterBytesAction<TArg>(ref MessagePackWriter writer, TArg argument);
 


### PR DESCRIPTION
… in Unity

This PR uses UnsafeUtility.MemMove to implement MessagePackWriter.MemoryCopy in Unity. The [API](https://docs.unity3d.com/2018.1/Documentation/ScriptReference/Unity.Collections.LowLevel.Unsafe.UnsafeUtility.MemMove.html) exists since Unity 2018.1, so all Unity versions supported by MessagePack have it.