### PR TITLE
Expose written bytes from MessagePackWriter.

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/BufferWriter.cs
@@ -34,6 +34,7 @@ namespace MessagePack
 
         /// <summary>
         /// The number of uncommitted bytes (all the calls to <see cref="Advance(int)"/> since the last call to <see cref="Commit"/>).
+        /// Backing field for the <see cref="BytesBuffered"/> property.
         /// </summary>
         private int _buffered;
 
@@ -93,6 +94,11 @@ namespace MessagePack
         /// Gets the total number of bytes written with this writer.
         /// </summary>
         public long BytesCommitted => _bytesCommitted;
+
+        /// <summary>
+        /// The number of uncommitted bytes (all the calls to <see cref="Advance(int)"/> since the last call to <see cref="Commit"/>).
+        /// </summary>
+        public int BytesBuffered => _buffered;
 
         /// <summary>
         /// Gets the <see cref="IBufferWriter{T}"/> underlying this instance.

--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/MessagePackWriter.cs
@@ -32,6 +32,11 @@ namespace MessagePack
         private BufferWriter writer;
 
         /// <summary>
+        /// Gets the total number of bytes written with this writer.
+        /// </summary>
+        public long WrittenBytes => writer.BytesCommitted + writer.BytesBuffered;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="MessagePackWriter"/> struct.
         /// </summary>
         /// <param name="writer">The writer to use.</param>


### PR DESCRIPTION
This is related to #1608. This exposes a long property WrittenBytes on MessagePackWriter with the total number of bytes written (i.e. BytesCommitted + bytes buffered). There's some boilerplate around exposing a new public API which I don't fully understand, so advice there would be great.