### PR TITLE
Remove Analyzers.Only PackageId

### DIFF
--- a/src/MessagePack.Analyzers/MessagePack.Analyzers.csproj
+++ b/src/MessagePack.Analyzers/MessagePack.Analyzers.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <PackageId>MessagePack.Analyzers.Only</PackageId>
 
     <MicrosoftCodeAnalysisVersion>$(CodeAnalysisVersionForUnity)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>


### PR DESCRIPTION
If you set IsPackage to false and also set PakcageId, it seems that a reference to a non-existent package occurs

https://www.nuget.org/packages/MessagePack.SourceGenerator/2.6.95-alpha#dependencies-body-tab
<img width="676" alt="image" src="https://github.com/neuecc/MessagePack-CSharp/assets/11359025/4fe5f341-fe09-4053-b401-0f59b3c455cc">
