### PR TITLE
Fix the errant package dependency in source generator package

### DIFF
--- a/src/MessagePack.Analyzers.CodeFixes/MessagePack.Analyzers.CodeFixes.csproj
+++ b/src/MessagePack.Analyzers.CodeFixes/MessagePack.Analyzers.CodeFixes.csproj
@@ -19,6 +19,14 @@
     <Content Include="tools\*.ps1" Pack="true" PackagePath="tools\" />
     <None Remove="tools\*.ps1" />
   </ItemGroup>
+  <ItemDefinitionGroup>
+    <PackageReference>
+      <!-- We need this, even with SuppressDependenciesWhenPacking=true because the
+           dependencies will otherwise show up as dependencies in packages built by projects
+           that reference this one. Probably due to transitive pinning. -->
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>

--- a/src/SourceGenerator.props
+++ b/src/SourceGenerator.props
@@ -16,6 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MessagePack.Analyzers\MessagePack.Analyzers.csproj" PrivateAssets="none" IncludeAssets="analyzers" />
+    <!-- Source generators need the analyzers assembly at compile-time and runtime.
+         At runtime we need it added as an analyzer, so we must also depend on the project that produces the nuget package. -->
+    <ProjectReference Include="..\MessagePack.Analyzers\MessagePack.Analyzers.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\MessagePack.Analyzers.CodeFixes\MessagePack.Analyzers.CodeFixes.csproj" PrivateAssets="none" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The source generator package was depending on the non-existant MessagePack.Analyzers.Only package.