### PR TITLE
Fix `ILookup<TKey, TElement>` deserialized behavior

### DIFF
--- a/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
+++ b/src/MessagePack.UnityClient/Assets/Scripts/MessagePack/Formatters/CollectionFormatter.cs
@@ -813,7 +813,7 @@ namespace MessagePack.Formatters
         {
             get
             {
-                return this.groupings[key];
+                return this.groupings.TryGetValue(key, out var value) ? value : Enumerable.Empty<TElement>();
             }
         }
 


### PR DESCRIPTION
The indexer was throwing when it should instead return an empty sequence.

Fixes #1431
