### PR TITLE
Use 'Write' instead of 'WriteInt32' for union type keys

### DIFF
--- a/src/MessagePack.SourceGenerator/Transforms/UnionTemplate.cs
+++ b/src/MessagePack.SourceGenerator/Transforms/UnionTemplate.cs
@@ -71,7 +71,7 @@ namespace MessagePack.SourceGenerator.Transforms
 			if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
 			{
 				writer.WriteArrayHeader(2);
-				writer.WriteInt32(keyValuePair.Key);
+				writer.Write(keyValuePair.Key);
 				switch (keyValuePair.Value)
 				{
 ");

--- a/src/MessagePack.SourceGenerator/Transforms/UnionTemplate.tt
+++ b/src/MessagePack.SourceGenerator/Transforms/UnionTemplate.tt
@@ -34,7 +34,7 @@ using MsgPack = global::MessagePack;
 			if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
 			{
 				writer.WriteArrayHeader(2);
-				writer.WriteInt32(keyValuePair.Key);
+				writer.Write(keyValuePair.Key);
 				switch (keyValuePair.Value)
 				{
 <# for(var i = 0; i < Info.SubTypes.Length; i++) { var item = Info.SubTypes[i]; #>

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/UnionFormatter(Namespace)/Formatters.MessagePack.GeneratedMessagePackResolver.MyTestNamespace.IMyTypeFormatter.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/UnionFormatter(Namespace)/Formatters.MessagePack.GeneratedMessagePackResolver.MyTestNamespace.IMyTypeFormatter.g.cs
@@ -32,7 +32,7 @@ internal partial class MyTestNamespace {
 			if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
 			{
 				writer.WriteArrayHeader(2);
-				writer.WriteInt32(keyValuePair.Key);
+				writer.Write(keyValuePair.Key);
 				switch (keyValuePair.Value)
 				{
 					case 0:

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/UnionFormatter(NestingClass)/Formatters.MessagePack.GeneratedMessagePackResolver.ContainingClass.IMyTypeFormatter.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/UnionFormatter(NestingClass)/Formatters.MessagePack.GeneratedMessagePackResolver.ContainingClass.IMyTypeFormatter.g.cs
@@ -32,7 +32,7 @@ internal partial class ContainingClass {
 			if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
 			{
 				writer.WriteArrayHeader(2);
-				writer.WriteInt32(keyValuePair.Key);
+				writer.Write(keyValuePair.Key);
 				switch (keyValuePair.Value)
 				{
 					case 0:

--- a/tests/MessagePack.SourceGenerator.Tests/Resources/UnionFormatter(None)/Formatters.MessagePack.GeneratedMessagePackResolver.IMyTypeFormatter.g.cs
+++ b/tests/MessagePack.SourceGenerator.Tests/Resources/UnionFormatter(None)/Formatters.MessagePack.GeneratedMessagePackResolver.IMyTypeFormatter.g.cs
@@ -31,7 +31,7 @@ internal partial class GeneratedMessagePackResolver {
 			if (value != null && this.typeToKeyAndJumpMap.TryGetValue(value.GetType().TypeHandle, out keyValuePair))
 			{
 				writer.WriteArrayHeader(2);
-				writer.WriteInt32(keyValuePair.Key);
+				writer.Write(keyValuePair.Key);
 				switch (keyValuePair.Value)
 				{
 					case 0:


### PR DESCRIPTION
Union type keys are usually small positive integers, likely to fit in a single byte. As late as version 2.5.198, the library would encode [Union(0, typeof(Foo))] as two bytes 0x92 0x00 (one for "two-element array", and one for the 0 integer key), followed by the serialization of type Foo.

In version 3.1.4, [Union(0, typeof(Foo))] is instead encoded as six bytes 0x92 0xD2 0x00 0x00 0x00 0x00 (one for "two-element array", one for "32-bit integer", and the four bytes of the 0 integer key). Although the two representations are compatible, for code bases that use many small polymorphic objects, the migration from 2.x to 3.x would lead to a significant increase in the size of the serialized data.

This behavior is caused by the generated code for the interface using `WriteInt32` (which always encodes the integer as five bytes), and is fixed by instead using `Write` (which uses the smallest possible number of bytes for its argument).