### PR TITLE
DynamicObjectResolver with type builder configuration hook

### DIFF
--- a/tests/MessagePack.Tests/DataContractTest.cs
+++ b/tests/MessagePack.Tests/DataContractTest.cs
@@ -345,7 +345,8 @@ namespace MessagePack.Tests
         {
             var model = MixAttrDataContractUser.GetModelWithTestData();
 
-            DynamicObjectResolver.BuildFormatterHelperHook += DynamicObjectResolver_BuildFormatterHelperHook;
+            DynamicObjectResolver.Instance.BuildFormatterHelperHook -= DynamicObjectResolver_BuildFormatterHelperHook;
+            DynamicObjectResolver.Instance.BuildFormatterHelperHook += DynamicObjectResolver_BuildFormatterHelperHook;
 
             var opts = MessagePackSerializerOptions.Standard.WithResolver(CompositeResolver.Create(
                 DynamicObjectResolver.Instance,
@@ -359,11 +360,11 @@ namespace MessagePack.Tests
 
         private void DynamicObjectResolver_BuildFormatterHelperHook(object sender, DynamicObjectResolver.BuildFormatterHelperHookEventArgs e)
         {
-            if (!e.FormatterHeplerConfiguration.ForceStringKey
+            if (!e.DynamicObjectTypeBuilderConfiguration.ForceStringKey
                 && e.Ti.GetCustomAttribute<DataContractAttribute>() is not null
                 && e.Ti.GetCustomAttribute<MessagePackObjectAttribute>() is null)
             {
-                e.FormatterHeplerConfiguration.ForceStringKey = true;
+                e.DynamicObjectTypeBuilderConfiguration.ForceStringKey = true;
             }
         }
 


### PR DESCRIPTION
I have modified the DynamicObjectResolver to have a Hook providing info and modifiable configuration settings to a consumer of the library.

This makes it possible to control/configure DynamicObject serialization from outside.

I have made this to solve an issue im having [Using MessagePack with DataContract Annotation](https://github.com/MessagePack-CSharp/MessagePack-CSharp/issues/2217)
Making the library compatible with thousands of projects by the flick of a switch (... yes its just a bool that already exists and just has to be set to true)

I have added an event to the build formatter function as the hook and we give the user the current configuration and infos we have. This could serve as a nice extension point and I already can see other usecases with the DynamicObjectTypeBuilderConfig

Let me know what you think